### PR TITLE
Setup CI job to warn against big diff

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,6 +2,13 @@ name: CI Build
 on: pull_request
 
 jobs:
+  warn-big-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: cornell-dti/big-diff-warning@master
+        env:
+          BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Summary

Setup a CI job to warn against big diff, powered by [big-diff-warning](https://github.com/cornell-dti/big-diff-warning)

### Test Plan

See the PR comment. Bot comment should be there.