### PR TITLE
[WIP] Adds English major.

### DIFF
--- a/src/requirements/reqs.json
+++ b/src/requirements/reqs.json
@@ -1378,6 +1378,76 @@
                 }
             ]
         },
+        "ENGL": {
+            "name": "English",
+            "schools": [
+                "AS"
+            ],
+            "requirements": [
+                {
+                    "name": "Pre-1800",
+                    "description": "12 credits (normally 3 courses) must be from courses in which 50% or more of the material consists of literature originally written in English before 1800 (such courses are indicated in the English course listings)",
+                    "source": "https://english.cornell.edu/majoring-and-minoring-english-cornell#requirements-for-the-major",
+                    "search": "catalogCommeents",
+                    "includes": [
+                        [
+                            "This course will satisfy the pre-1800 requirement for English majors.",
+                            "This course may be used as one of the three pre-1800 courses required of English majors.",
+                            "May be used as one of the three pre-1800 courses required of English majors."
+                        ]
+                    ],
+                    "fulfilledBy": "credits",
+                    "minCount": 12
+                },
+                {
+                    "name": "4000 or Above",
+                    "description": "8 credits (2 courses) must be at the 4000 level or above",
+                    "source": "https://www.engineering.cornell.edu/students/undergraduate-students/curriculum/undergraduate-requirements",
+                    "search": "code",
+                    "includes": [
+                        [
+                            "ENGL 4***"
+                        ]
+                    ],
+                    "fulfilledBy": "credits",
+                    "minCount": 8
+                },
+                {
+                    "name": "Concentration",
+                    "description": "12 credits (3 courses) must form an intellectually coherent concentration (see below).",
+                    "source": "https://www.engineering.cornell.edu/students/undergraduate-students/curriculum/undergraduate-requirements",
+                    "search": "catalogSatisfiesReq",
+                    "includes": [],
+                    "fulfilledBy": "self-check",
+                    "minCount": 12
+                },
+                {
+                    "name": "Total Credits",
+                    "description": "To graduate with a major in English, a student must complete with a grade of C or better 40 credit hours approved for the English major. All 2000-level ENGL courses (with the exception of 2800-2810 and 2880-2890) count for the major, as do all 3000-and 4000-level courses.",
+                    "source": "https://english.cornell.edu/majoring-and-minoring-english-cornell#requirements-for-the-major",
+                    "search": "code",
+                    "includes": [
+                        [
+                            "ENGL 2***",
+                            "ENGL 3***",
+                            "ENGL 4***",
+                            "ENGL 5***",
+                            "ENGL 6***"
+                        ]
+                    ],
+                    "excludes": [
+                        [
+                            "ENGL 2800",
+                            "ENGL 2810",
+                            "ENGL 2880",
+                            "ENGL 2890"
+                        ]
+                    ],
+                    "fulfilledBy": "credits",
+                    "minCount": 40
+                }
+            ]
+        },
         "HIST": {
             "name": "History",
             "schools": [

--- a/src/requirements/reqs.json
+++ b/src/requirements/reqs.json
@@ -1388,7 +1388,7 @@
                     "name": "Pre-1800",
                     "description": "12 credits (normally 3 courses) must be from courses in which 50% or more of the material consists of literature originally written in English before 1800 (such courses are indicated in the English course listings)",
                     "source": "https://english.cornell.edu/majoring-and-minoring-english-cornell#requirements-for-the-major",
-                    "search": "catalogCommeents",
+                    "search": "catalogComments",
                     "includes": [
                         [
                             "This course will satisfy the pre-1800 requirement for English majors.",


### PR DESCRIPTION
Edited reqs.json to include the English ("ENGL") major in Arts & Sciences.

### Summary <!-- Required -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds the Arts & Sciences English major requirements.

- [x] 40 total credits ENGL 2000 level or above (excluding ENGL 2800, 2810, 2880, 2890)
- [ ] 12 credits of courses fulfilling the pre-1800 requirement
- [x] 8 credits of courses above the ENGL 4000 level
- [x] 12 credits within a recognizable academic concentration


### Test Plan <!-- Required -->

Screen shots:
<img width="1440" alt="Screen Shot 2020-02-01 at 4 41 20 PM 1" src="https://user-images.githubusercontent.com/33047156/73599480-fe370280-4511-11ea-8bed-1f9d2e49951d.png">
<img width="596" alt="Screen Shot 2020-02-01 at 4 42 18 PM" src="https://user-images.githubusercontent.com/33047156/73599482-fecf9900-4511-11ea-93bc-e5ee120e439b.png">

### Notes <!-- Optional -->

Pre-1800 is not done yet because in the class roster, the pre-1800 indication inconsistently uses both "Comments:" and "Satisfies Requirement:".

To describe the major, the JSON format needs to be able to search both `catalogSatisfiesReq` and `catalogComments` for a single requirement.

Something like: `"search": ["catalogComments", "catalogSatisfiesReq"]`
