### PR TITLE
Adding course fixes

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -152,8 +152,9 @@ export default {
       const credits = course.credits || course.enrollGroups[0].unitsMaximum;
 
       // Semesters: remove periods and split on ', '
-      // alternateSemesters option in case catalogWhenOffered for the course is null
-      const alternateSemesters = (course.catalogWhenOffered != null) ? course.catalogWhenOffered.replace(/\./g, '').split(', ') : [];
+      // alternateSemesters option in case catalogWhenOffered for the course is null, undef, or ''
+      const catalogWhenOfferedDoesNotExist = course.catalogWhenOffered === undefined || course.catalogWhenOffered === null || course.catalogWhenOffered === '';
+      const alternateSemesters = (catalogWhenOfferedDoesNotExist) ? [] : course.catalogWhenOffered.replace(/\./g, '').split(', ');
       const semesters = course.semesters || alternateSemesters;
 
       // Get prereqs of course as string (). '' if neither available because '' is interpreted as false
@@ -194,8 +195,9 @@ export default {
       }
 
       // Distribution of course (e.g. MQR-AS)
-      // alternateDistributions option in case catalogDistr for the course is null
-      const alternateDistributions = (course.catalogDistr != null) ? /\(([^)]+)\)/.exec(course.catalogDistr)[1].split(', ') : [""];
+      // alternateDistributions option in case catalogDistr for the course is null, undef, ''
+      const catalogDistrDoesNotExist = course.catalogDistr === undefined || course.catalogDistr === null || course.catalogDistr === '';
+      const alternateDistributions = (catalogDistrDoesNotExist) ? [''] : /\(([^)]+)\)/.exec(course.catalogDistr)[1].split(', ');
       const distributions = course.distributions || alternateDistributions;
 
       // Get last semester of available course. TODO: Remove when no longer firebase data dependant

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -153,7 +153,7 @@ export default {
 
       // Semesters: remove periods and split on ', '
       // alternateSemesters option in case catalogWhenOffered for the course is null, undef, or ''
-      const catalogWhenOfferedDoesNotExist = course.catalogWhenOffered === undefined || course.catalogWhenOffered === null || course.catalogWhenOffered === '';
+      const catalogWhenOfferedDoesNotExist = (!course.catalogWhenOffered) || course.catalogWhenOffered === '';
       const alternateSemesters = (catalogWhenOfferedDoesNotExist) ? [] : course.catalogWhenOffered.replace(/\./g, '').split(', ');
       const semesters = course.semesters || alternateSemesters;
 
@@ -196,7 +196,7 @@ export default {
 
       // Distribution of course (e.g. MQR-AS)
       // alternateDistributions option in case catalogDistr for the course is null, undef, ''
-      const catalogDistrDoesNotExist = course.catalogDistr === undefined || course.catalogDistr === null || course.catalogDistr === '';
+      const catalogDistrDoesNotExist = (!course.catalogDistr) || course.catalogDistr === '';
       const alternateDistributions = (catalogDistrDoesNotExist) ? [''] : /\(([^)]+)\)/.exec(course.catalogDistr)[1].split(', ');
       const distributions = course.distributions || alternateDistributions;
 

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -195,7 +195,7 @@ export default {
 
       // Distribution of course (e.g. MQR-AS)
       // alternateDistributions option in case catalogDistr for the course is null
-      const alternateDistributions = (course.catalogDistr != null) ? course.catalogDistr.split(', ') : [""];
+      const alternateDistributions = (course.catalogDistr != null) ? /\(([^)]+)\)/.exec(course.catalogDistr)[1].split(', ') : [""];
       const distributions = course.distributions || alternateDistributions;
 
       // Get last semester of available course. TODO: Remove when no longer firebase data dependant

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -152,7 +152,9 @@ export default {
       const credits = course.credits || course.enrollGroups[0].unitsMaximum;
 
       // Semesters: remove periods and split on ', '
-      const semesters = course.semesters || course.catalogWhenOffered.replace(/\./g, '').split(', ');
+      // alternateSemesters option in case catalogWhenOffered for the course is null
+      const alternateSemesters = (course.catalogWhenOffered != null) ? course.catalogWhenOffered.replace(/\./g, '').split(', ') : [];
+      const semesters = course.semesters || alternateSemesters;
 
       // Get prereqs of course as string (). '' if neither available because '' is interpreted as false
       const prereqs = course.prereqs || course.catalogPrereqCoreq || '';
@@ -192,7 +194,9 @@ export default {
       }
 
       // Distribution of course (e.g. MQR-AS)
-      const distributions = course.distributions || course.catalogDistr.split(',');
+      // alternateDistributions option in case catalogDistr for the course is null
+      const alternateDistributions = (course.catalogDistr != null) ? course.catalogDistr.split(', ') : [""];
+      const distributions = course.distributions || alternateDistributions;
 
       // Get last semester of available course. TODO: Remove when no longer firebase data dependant
       const lastRoster = course.lastRoster || course.roster;

--- a/src/components/Modals/Modal.vue
+++ b/src/components/Modals/Modal.vue
@@ -111,6 +111,7 @@ export default {
       // TODO: can I make the valid assumption that the course code is up to the colon in the title?
       const courseCode = title.substring(0, title.indexOf(':'));
       const subject = courseCode.split(' ')[0];
+      const number = courseCode.split(' ')[1];
 
       const parent = this.$parent;
 
@@ -131,12 +132,16 @@ export default {
       fetch(`https://classes.cornell.edu/api/2.0/search/classes.json?roster=${roster}&subject=${subject}&q=${courseCode}`)
         .then(res => res.json())
         .then(resultJSON => {
-          const course = resultJSON.data.classes[0];
-          course.roster = roster;
-
-          if (this.courseIsAddable) {
-            parent.addCourse(course);
-          }
+          // check catalogNbr of resultJSON class matches number of course to add
+          resultJSON.data.classes.forEach(resultJSONclass => {
+            if (resultJSONclass.catalogNbr === number) {
+              const course = resultJSONclass;
+              course.roster = roster;
+              if (this.courseIsAddable) {
+                parent.addCourse(course);
+              }
+            }
+          });
         });
 
       // clear input and close modal when complete

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -520,7 +520,8 @@ export default {
               if (ifCodeMatch(`${courseInfo.subject} ${courseInfo.catalogNbr}`, option)) {
                 return true;
               }
-            } else if (courseInfo[search].includes(option)) return true;
+            // Make sure courseInfo[search] is not null
+            } else if (courseInfo[search] && courseInfo[search].includes(option)) return true;
           }
         }
 


### PR DESCRIPTION
### Summary 

This pull request resolves a couple bug fixes found for adding courses from the alpha launch. 

- [x] Debugged adding supplementary course when trying to add main course (i.e. CHEM 1007 added when trying to add CHEM 2070)
- [x] Fixed adding courses for edge cases where null data props exist for fetched data from course roster API (i.e. unable to add MEDVL 1101)

### Notes
Read through requirements functions and referred to Cornell course roster API to diagnose the bugs. Implemented a secondary check when selecting fetched course to avoid accidentally adding supplementary courses and handled cases where fetched course data had null props that needed to be parsed.

