### PR TITLE
Set up prod and dev environments

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,7 @@
 {
   "projects": {
-    "default": "cornell-courseplan"
+    "default": "cornell-courseplan",
+    "staging": "cornelldti-courseplan-dev",
+    "production": "cornell-courseplan"
   }
 }

--- a/src/firebaseConfig.js
+++ b/src/firebaseConfig.js
@@ -15,7 +15,7 @@ require('firebase/firestore');
 // };
 // firebase.initializeApp(config);
 
-// Deployment config
+// Development config
 const developmentConfig = {
   apiKey: 'AIzaSyAfePy1Tbrqm55bYR7BHHl50r-9NTVj0Rs',
   authDomain: 'cornelldti-courseplan-dev.firebaseapp.com',

--- a/src/firebaseConfig.js
+++ b/src/firebaseConfig.js
@@ -1,18 +1,31 @@
 const firebase = require('firebase/app');
+
 require('firebase/auth');
 require('firebase/firestore');
 
-// firebase init goes here
-const config = {
-  apiKey: 'AIzaSyDkKOpImjbjS2O0RhIQNJLQXx2SuYbxsfU',
-  authDomain: 'cornell-courseplan.firebaseapp.com',
-  databaseURL: 'https://cornell-courseplan.firebaseio.com',
-  projectId: 'cornell-courseplan',
+// Production config
+// const config = {
+//   apiKey: 'AIzaSyDkKOpImjbjS2O0RhIQNJLQXx2SuYbxsfU',
+//   authDomain: 'cornell-courseplan.firebaseapp.com',
+//   databaseURL: 'https://cornell-courseplan.firebaseio.com',
+//   projectId: 'cornell-courseplan',
+//   storageBucket: '',
+//   messagingSenderId: '1031551180906',
+//   appId: '1:1031551180906:web:bdcea6ec074e673ea72a13'
+// };
+// firebase.initializeApp(config);
+
+// Deployment config
+const developmentConfig = {
+  apiKey: 'AIzaSyAfePy1Tbrqm55bYR7BHHl50r-9NTVj0Rs',
+  authDomain: 'cornelldti-courseplan-dev.firebaseapp.com',
+  databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
+  projectId: 'cornelldti-courseplan-dev',
   storageBucket: '',
-  messagingSenderId: '1031551180906',
-  appId: '1:1031551180906:web:bdcea6ec074e673ea72a13'
+  messagingSenderId: '321304703190',
+  appId: '1:321304703190:web:2f2fefb4a0284465b99977',
 };
-firebase.initializeApp(config);
+firebase.initializeApp(developmentConfig);
 
 // firebase utils
 const db = firebase.firestore();


### PR DESCRIPTION
### Summary <!-- Required -->

Set up different configs and projects for the new dev and prod environments. Currently need to uncomment whichever config is being used (dev if deploying to the development environment, prod otherwise).

Run `firebase deploy -P staging` when deploying to the dev environment, and `firebase deploy -P production` to deploy to prod.

- [x] set up multiple firebase projects for staging and production
- [x] added multiple configs to the code

### Test Plan

Confirm changes made get deployed to the dev environment when the dev config is not commented out.