### PR TITLE
Automatic dev/staging/prod mode based on environment variables

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+NODE_ENV=development
+VUE_APP_FIREBASE_MODE=dev

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+NODE_ENV=production
+VUE_APP_FIREBASE_MODE=prod

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,2 @@
+NODE_ENV=production
+VUE_APP_FIREBASE_MODE=dev

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: NPM Install
         run: npm install
       - name: Build
-        run: PUBLIC_URL="/course-plan/${{ github.event.number }}" npm run build
+        run: PUBLIC_URL="/course-plan/${{ github.event.number }}" npm run build:staging
       - name: Upload Built Static Assets
         uses: actions/upload-artifact@master
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2844,7 +2844,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "coa": {
       "version": "2.0.2",
@@ -5616,7 +5617,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5637,12 +5639,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5657,17 +5661,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5784,7 +5791,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5796,6 +5804,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5810,6 +5819,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5817,12 +5827,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5841,6 +5853,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5921,7 +5934,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5933,6 +5947,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6018,7 +6033,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6054,6 +6070,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6073,6 +6090,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6116,12 +6134,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10679,7 +10699,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build:staging": "vue-cli-service build --mode staging",
+    "build": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint",
     "format": "prettier --write '**/*.{js,vue,scss,css,html}'",
     "format:check": "prettier --check '**/*.{js,vue,scss,css,html}'"

--- a/src/firebaseConfig.js
+++ b/src/firebaseConfig.js
@@ -3,30 +3,33 @@ const firebase = require('firebase/app');
 require('firebase/auth');
 require('firebase/firestore');
 
-// Production config
-const config = {
-  apiKey: 'AIzaSyDkKOpImjbjS2O0RhIQNJLQXx2SuYbxsfU',
-  authDomain: 'cornell-courseplan.firebaseapp.com',
-  databaseURL: 'https://cornell-courseplan.firebaseio.com',
-  projectId: 'cornell-courseplan',
-  storageBucket: '',
-  messagingSenderId: '1031551180906',
-  appId: '1:1031551180906:web:bdcea6ec074e673ea72a13',
-  measurementId: 'G-8B1JVCBX0Z'
-};
-firebase.initializeApp(config);
+let config;
 
-// Development config
-// const developmentConfig = {
-//   apiKey: 'AIzaSyAfePy1Tbrqm55bYR7BHHl50r-9NTVj0Rs',
-//   authDomain: 'cornelldti-courseplan-dev.firebaseapp.com',
-//   databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
-//   projectId: 'cornelldti-courseplan-dev',
-//   storageBucket: '',
-//   messagingSenderId: '321304703190',
-//   appId: '1:321304703190:web:2f2fefb4a0284465b99977',
-// };
-// firebase.initializeApp(developmentConfig);
+if (process.env.VUE_APP_FIREBASE_MODE === 'prod') {
+  // Production config
+  config = {
+    apiKey: 'AIzaSyDkKOpImjbjS2O0RhIQNJLQXx2SuYbxsfU',
+    authDomain: 'cornell-courseplan.firebaseapp.com',
+    databaseURL: 'https://cornell-courseplan.firebaseio.com',
+    projectId: 'cornell-courseplan',
+    storageBucket: '',
+    messagingSenderId: '1031551180906',
+    appId: '1:1031551180906:web:bdcea6ec074e673ea72a13',
+    measurementId: 'G-8B1JVCBX0Z'
+  };
+} else {
+  config = {
+    apiKey: 'AIzaSyAfePy1Tbrqm55bYR7BHHl50r-9NTVj0Rs',
+    authDomain: 'cornelldti-courseplan-dev.firebaseapp.com',
+    databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
+    projectId: 'cornelldti-courseplan-dev',
+    storageBucket: '',
+    messagingSenderId: '321304703190',
+    appId: '1:321304703190:web:2f2fefb4a0284465b99977'
+  };
+}
+
+firebase.initializeApp(config);
 
 // firebase utils
 const db = firebase.firestore();


### PR DESCRIPTION
### Summary

This diff setups up the infrastructure to automatically build different variants of course plan suitable for dev/staging/production. The CI build job is changed to use staging build, so we want accidently break stuff in prod database while play-testing.

Behaviors for three different variants are listed below:
- dev: non-mimized code, dev database
- staging: minimized code, dev database
- prod: minimized code, prod database

### Test Plan

I tested all three modes locally. To facilitate testing, I globally installed `serve` that can directly statically serve a directory locally.
In the new dev environment, I have not been granted alpha whitelist yet. Indeed both dev version (`by npm run serve`) and the staging version (`npm run build:staging && serve dist`) alerted that I do not have access. The prod version (`npm run build && serve dist`) directly autoloads into the page for me, since I'm previously granted alph  access to the prod version.

### Notes

Relevant docs: https://cli.vuejs.org/guide/mode-and-env.html#environment-variables