### PR TITLE
Add color scheme with user data on new course

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -160,8 +160,9 @@ export default {
       const credits = course.credits || course.enrollGroups[0].unitsMaximum;
 
       // Semesters: remove periods and split on ', '
-      // alternateSemesters option in case catalogWhenOffered for the course is null
-      const alternateSemesters = (course.catalogWhenOffered != null) ? course.catalogWhenOffered.replace(/\./g, '').split(', ') : [];
+      // alternateSemesters option in case catalogWhenOffered for the course is null, undef, or ''
+      const catalogWhenOfferedDoesNotExist = (!course.catalogWhenOffered) || course.catalogWhenOffered === '';
+      const alternateSemesters = (catalogWhenOfferedDoesNotExist) ? [] : course.catalogWhenOffered.replace(/\./g, '').split(', ');
       const semesters = course.semesters || alternateSemesters;
 
       // Get prereqs of course as string (). '' if neither available because '' is interpreted as false
@@ -202,8 +203,9 @@ export default {
       }
 
       // Distribution of course (e.g. MQR-AS)
-      // alternateDistributions option in case catalogDistr for the course is null
-      const alternateDistributions = (course.catalogDistr) ? /\(([^)]+)\)/.exec(course.catalogDistr)[1].split(', ') : [''];
+      // alternateDistributions option in case catalogDistr for the course is null, undef, ''
+      const catalogDistrDoesNotExist = (!course.catalogDistr) || course.catalogDistr === '';
+      const alternateDistributions = (catalogDistrDoesNotExist) ? [''] : /\(([^)]+)\)/.exec(course.catalogDistr)[1].split(', ');
       const distributions = course.distributions || alternateDistributions;
 
       // Get last semester of available course. TODO: Remove when no longer firebase data dependant

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -99,10 +99,15 @@ export default {
     this.getInformationFromUser();
   },
   methods: {
-    getInformationFromUser() {
+    getDocRef() {
       const user = auth.currentUser;
       const userEmail = user.email;
       const docRef = userDataCollection.doc(userEmail);
+      return docRef;
+    },
+
+    getInformationFromUser() {
+      const docRef = this.getDocRef();
 
       // TODO: error handling for firebase errors
       docRef.get()
@@ -294,10 +299,7 @@ export default {
       }
 
       // Update subjectColors on Firebase with new subject color group
-      const user = auth.currentUser;
-      const userEmail = user.email;
-      const docRef = userDataCollection.doc(userEmail);
-
+      const docRef = this.getDocRef();
       this.subjectColors[subject] = randomColor;
       docRef.update({ subjectColors: this.subjectColors });
 
@@ -402,8 +404,7 @@ export default {
       this.user = user;
       this.loaded = true;
 
-      const userEmail = auth.currentUser.email;
-      const docRef = userDataCollection.doc(userEmail);
+      const docRef = this.getDocRef();
 
       const data = {
         name: onboardingData.name,

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -239,10 +239,6 @@ export default {
 
       const colors = [
         {
-          text: 'Gray',
-          hex: 'C4C4C4'
-        },
-        {
           text: 'Red',
           hex: 'DA4A4A'
         },
@@ -283,10 +279,19 @@ export default {
       }
 
       // Filter out used colors
-      let unusedColors = colors.filter(color => !colorsUsedMap[color.hex]);
-      if (unusedColors.length === 0) unusedColors = colors;
+      const unusedColors = colors.filter(color => !colorsUsedMap[color.hex]);
 
-      const randomColor = unusedColors[Math.floor(Math.random() * unusedColors.length)].hex;
+      let randomColor;
+
+      // pick a color from unusedColors if there are any
+      if (unusedColors.length !== 0) {
+        randomColor = unusedColors[Math.floor(Math.random() * unusedColors.length)].hex;
+      // otherwise pick a color following the random order set by the first 7 subjects
+      } else {
+        const colorIndex = Object.keys(this.subjectColors).length;
+        const key = Object.keys(this.subjectColors)[colorIndex % colors.length];
+        randomColor = this.subjectColors[key];
+      }
 
       // Update subjectColors on Firebase with new subject color group
       const user = auth.currentUser;

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -235,7 +235,6 @@ export default {
     },
 
     addColor(subject) {
-
       if (this.subjectColors && this.subjectColors[subject]) return this.subjectColors[subject];
 
       const colors = [
@@ -277,30 +276,30 @@ export default {
       if (this.subjectColors === undefined) this.subjectColors = {};
 
       // Create list of used colors
-      let colorsUsedMap = {};
-      for (let subjectKey of Object.keys(this.subjectColors)) {
+      const colorsUsedMap = {};
+      for (const subjectKey of Object.keys(this.subjectColors)) {
         const subjectColor = this.subjectColors[subjectKey];
         colorsUsedMap[subjectColor] = true;
       }
 
       // Filter out used colors
-      let unusedColors = colors.filter((color) => !colorsUsedMap[color.hex]);
+      let unusedColors = colors.filter(color => !colorsUsedMap[color.hex]);
       if (unusedColors.length === 0) unusedColors = colors;
 
-      let randomColor = unusedColors[Math.floor(Math.random() * unusedColors.length)].hex;
-      
+      const randomColor = unusedColors[Math.floor(Math.random() * unusedColors.length)].hex;
+
       // Update subjectColors on Firebase with new subject color group
       const user = auth.currentUser;
       const userEmail = user.email;
       const docRef = userDataCollection.doc(userEmail);
 
       this.subjectColors[subject] = randomColor;
-      docRef.update({subjectColors: this.subjectColors});
+      docRef.update({ subjectColors: this.subjectColors });
 
       // Return randomly generated color
       return randomColor;
     },
-    
+
     createSemester(courses, type, year) {
       const semester = {
         courses,


### PR DESCRIPTION
### Summary <!-- Required -->

When a user adds a course from a new subject, a color scheme is randomly generated for the subject and saved in user data on firebase. Colors are cycled through until all color groups are used. Then, new subject colors and completely randomized.

This pull request is the first step towards shipping the Beta

- [x] add generated color scheme

### Test Plan <!-- Required -->

<img width="919" alt="Screen Shot 2020-02-26 at 7 37 00 PM" src="https://user-images.githubusercontent.com/44352119/75401199-62f63a80-58cf-11ea-923c-46ad30d5f170.png">

### Breaking Changes  <!-- Optional -->

`subjectColors` is created in Firebase user data. Users who don't have subjectColors will have one generated upon adding a new course.
