### PR TITLE
Setup strict release workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,24 @@
+name: CD
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Node
+        uses: actions/setup-node@v1
+      - name: NPM Install
+        run: npm install
+      - name: Build
+        run: npm run build:staging
+      - name: Deploy
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          npm install --save-dev firebase-tools
+          ./node_modules/.bin/firebase use staging
+          ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,13 +2,6 @@ name: CI Build
 on: pull_request
 
 jobs:
-  warn-big-diff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - uses: cornell-dti/big-diff-warning@master
-        env:
-          BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-policies.yml
+++ b/.github/workflows/ci-policies.yml
@@ -1,0 +1,24 @@
+name: CI Policies
+on: pull_request
+
+jobs:
+  enforce-release-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Print base ref and head ref
+        run: |
+          echo "Your head ref is ${{ github.head_ref }}."
+          echo "Your base ref is ${{ github.base_ref }}."
+      - name: Fail if try to push release from non-master branch
+        if: github.base_ref != 'beta-release' && github.head_ref == 'master'
+        run: |
+          echo "Head ref must be master for release. Everything should go through staging first!"
+          exit 1
+  warn-big-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: cornell-dti/big-diff-warning@master
+        env:
+          BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  push:
+    branches:
+      - beta-release
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Node
+        uses: actions/setup-node@v1
+      - name: NPM Install
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Deploy
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          npm install --save-dev firebase-tools
+          ./node_modules/.bin/firebase use production
+          ./node_modules/.bin/firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting


### PR DESCRIPTION
### Summary

Setup a release workflow: such that commit pushed to `beta-release` branch will be deployed to prod directly.

This is a sensitive operation, so the `beta-release` branch is strictly branch-protected:

- Requires 3 reviews
- All CI checks must pass
- PR should be from `master -> beta-release`

### Test Plan

Code is adapted from samwise. See https://github.com/cornell-dti/samwise/pull/301
Something can only tested when we are doing deployment.

### Notes

We want to eventually change the branch name to `release` when the beta is over.