### PR TITLE
Start taking advantage of typescript setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,7 @@ module.exports = {
           'always',
           {
             js: 'never',
+            ts: 'never',
             vue: 'always'
           }
         ]

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -14,5 +14,7 @@ jobs:
         run: npm install
       - name: Run Linter
         run: npm run lint
+      - name: Type Check
+        run: npm run tsc
       - name: Run requirement schema check
         run: node src/requirements/validate.js

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint",
+    "tsc": "tsc",
     "build:staging": "vue-cli-service build --mode staging",
     "format": "prettier --write '**/*.{js,vue,scss,css,html}'",
     "format:check": "prettier --check '**/*.{js,vue,scss,css,html}'"

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -146,6 +146,8 @@ import { Vue } from 'vue-property-decorator';
 import VueCollapse from 'vue2-collapse';
 import Course from '@/components/Course';
 import Modal from '@/components/Modals/Modal';
+/** @typedef { import('../requirements/types').StrictFulfilledByType } StrictFulfilledByType */
+/** @typedef { import('../requirements/types').BaseRequirement<StrictFulfilledByType> } Requirement */
 
 import reqsData from '../requirements/reqs.json';
 
@@ -363,19 +365,6 @@ export default {
       this.emitRequirementsMap();
 
       return finalRequirementJSONs;
-
-      /**
-       * @typedef {Object} Requirement
-       * @property {string} name
-       * @property {string} description
-       * @property {string} source
-       * @property {string} search
-       * @property {string[][]} includes
-       * @property {string} fulfilledBy
-       * @property {number} minCount
-       * @property {string} applies
-       * @property {boolean} progressBar
-       */
 
       /**
        * @typedef {Object} RequirementFulfillment

--- a/src/requirements/types.test.ts
+++ b/src/requirements/types.test.ts
@@ -1,0 +1,4 @@
+import requirementsJson from './reqs.json';
+import { RequirementsJson } from './types';
+
+const _: RequirementsJson = requirementsJson;

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -1,0 +1,70 @@
+export type StrictFulfilledByType = 'credits' | 'courses' | 'self-check';
+
+// Q: Why do we need to paramerize `fulfilledBy` field and default the type argument to string?
+// A:
+//    This is a hack.
+//    Unfortunately, typescript gives json a more general type when typechecking it.
+//    In our example, instead of recognizing that `fulfilledBy` can be all enums above, it generalizes
+//    it to string.
+//    Without using string as a parameter, type checking the json file against the type definition
+//    will fail. Therefore, the hack is added to ensure we get some type safety when type checking
+//    json.
+
+// Q: Still, why do we need to paramerize `fulfilledBy` field?
+// A: While we need `fulfilledBy` to be `string` when type checking json alone, we can have some
+//    stricter guarantee elsewhere. Therefore, we parameterize it, so it can strict if we want.
+
+export interface BaseRequirement<F = string> {
+  readonly name: string;
+  readonly description: string;
+  readonly source: string;
+  readonly search?: readonly string[];
+  readonly includes?: readonly string[][];
+  readonly excludes?: readonly string[][];
+  readonly fulfilledBy: F;
+  readonly applies?: string;
+  readonly minCount?: number;
+  readonly progressBar?: boolean;
+}
+
+export interface UniversityRequirement<F = string> extends BaseRequirement<F> {
+  readonly includes: readonly string[][];
+  readonly minCount: number;
+}
+
+export type UniversityRequirements<F = string> = {
+  readonly value: string;
+  readonly name: string;
+  readonly requirements: readonly UniversityRequirement<F>[];
+};
+
+export interface CollegeRequirement<F = string> extends BaseRequirement<F> {
+  readonly includes: readonly string[][];
+}
+
+export type CollegeRequirements<F = string> = {
+  readonly [collegeCode: string]: {
+    readonly name: string;
+    readonly requirements: readonly CollegeRequirement<F>[];
+  };
+};
+
+export interface MajorRequirement<F = string> extends BaseRequirement<F> {
+  readonly includes: readonly string[][];
+}
+
+export type MajorRequirements<F = string> = {
+  readonly [collegeCode: string]: {
+    readonly name: string;
+    readonly schools: readonly string[];
+    readonly requirements: readonly MajorRequirement<F>[];
+  };
+};
+
+export type RequirementsJson<F = string> = {
+  readonly university: UniversityRequirements<F>;
+  readonly college: CollegeRequirements<F>;
+  readonly major: MajorRequirements<F>;
+};
+
+export type StrictRequirementsJson = RequirementsJson<StrictFulfilledByType>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
+    "resolveJsonModule": true,
     "baseUrl": ".",
     "types": [
       "webpack-env"


### PR DESCRIPTION
### Summary

#56 setups up typescript for this project. This diff starts the non-invasive refactoring effort to take advantage of the new setup.

I added type definitions for all requirements json in `src/requirements/types.ts`. Using this definition, we can also test the validity of the json schema via a typescript type checking run.

The type definition is not only useful for checking the json itself. It can also be used to the code that computes on the json. In `src/components/Requirements.vue`, I added a type import for requirements. Now autocompletion on requirement object will work perfectly with type shown. (You still need to annotate params as `Requirement` in jsdoc to enable the autocompletion.) To avoid too much disruption, I did not plan to migrate more code to TS in this diff.

Finally, I tweaked some ts and linter config so the correct setup can pass all the CI checks.

### Test Plan

- Run `npm run tsc`. It will succeed.
- Now break the requirement json. (e.g. change name to a int). Run `npm run tsc`. It will fail and produce a type error.

### Notes

Here is the autocompletion enabled by this diff:
<img width="1147" alt="autocompletion" src="https://user-images.githubusercontent.com/4290500/75639919-f649ab80-5c00-11ea-9c68-e257478272fd.png">
