### PR TITLE
Strictify type annotation for requirement function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,20 @@ module.exports = {
           }
         ]
       }
+    },
+    {
+      files: ['*.js'],
+      rules: {
+        'import/extensions': [
+          'error',
+          'always',
+          {
+            js: 'never',
+            ts: 'never',
+            vue: 'never'
+          }
+        ]
+      }
     }
   ]
 };

--- a/src/requirements/reqs-functions.js
+++ b/src/requirements/reqs-functions.js
@@ -1,4 +1,9 @@
-import reqsData from '@/requirements/reqs.json';
+// @ts-check
+
+/** @typedef { import('../requirements/types').StrictFulfilledByType } StrictFulfilledByType */
+/** @typedef { import('../requirements/types').BaseRequirement<StrictFulfilledByType> } Requirement */
+/** @type {Requirement} */
+import reqsData from '@/requirements/typed-requirement-json';
 
 /**
  * Check if a code matches the course name (CS 2110 and CS 2*** returns true, AEM 3110 and AEM 32** returns false)
@@ -87,6 +92,7 @@ function checkIfCourseFulfilled(courseInfo, search, includes, excludes) {
  * @returns {RequirementFulfillment}
  */
 function createRequirementJSON(requirement, totalRequirementCredits, totalRequirementCount, coursesThatFulilledRequirement) {
+  /** @type {RequirementFulfillment} */
   const requirementFulfillmentData = {
     name: requirement.name,
     type: requirement.fulfilledBy,
@@ -120,8 +126,10 @@ function createRequirementJSON(requirement, totalRequirementCredits, totalRequir
   return requirementFulfillmentData;
 }
 
-/** @param {Object.<string, string[]>} requirementsMap */
-/** @param {Object.<string, string[]>} satisfiedMap */
+/**
+ * @param {Object.<string, string[]>} requirementsMap
+ * @param {Object.<string, string[]>} satisfiedMap
+ */
 function mergeRequirementsMap(requirementsMap, satisfiedMap) {
   Object.keys(satisfiedMap).forEach(course => {
     if (course in requirementsMap) requirementsMap[course] = requirementsMap[course].concat(satisfiedMap[course]);
@@ -134,7 +142,7 @@ function mergeRequirementsMap(requirementsMap, satisfiedMap) {
  * @property {string} name
  * @property {string} type
  * @property {string[]} courses
- * @property {number} required
+ * @property {number | undefined} required
  * @property {string} description
  * @property {string} source
  * @property {number | null | undefined} fulfilled
@@ -144,8 +152,8 @@ function mergeRequirementsMap(requirementsMap, satisfiedMap) {
 
 /**
  * Loops through requirement data and compare all courses on (to identify whether they satisfy the requirement)
- * @param {Object.<string, Object>} allCoursesTakenWithInfo : object of courses taken with API information (CS 2110: {info})
- * @param {Requirement[]} allRequirements : requirements in requirements format from reqs.json (college, major, or university requirements)
+ * @param {Object.<string, any>} allCoursesTakenWithInfo : object of courses taken with API information (CS 2110: {info})
+ * @param {readonly Requirement[]} allRequirements : requirements in requirements format from reqs.json (college, major, or university requirements)
  * @param {Object.<string, string[]>} requirementsMap : object of courses taken with requirements they fulfill
  * @returns {Promise<RequirementFulfillment[]>}
  */
@@ -258,6 +266,7 @@ function getCourseInfo(code, roster) {
  */
 async function getReqs(coursesTaken, college, major, requirementsMap) {
   // TODO: make it so that it takes in classes corresponding with years/semesters for most accurate information
+  /** @type {Object.<string, any>} */
   const coursesTakenWithInfo = {};
   const courseData = await Promise.all(
     coursesTaken.map(courseTaken => getCourseInfo(courseTaken.code, courseTaken.roster))

--- a/src/requirements/typed-requirement-json.ts
+++ b/src/requirements/typed-requirement-json.ts
@@ -1,0 +1,5 @@
+import reqsData from '@/requirements/reqs.json';
+import { StrictFulfilledByType, RequirementsJson } from './types';
+
+// Cast the json to a stricter type of requirement with an enum `fulfilled` field for all requirements.
+export default (reqsData as RequirementsJson<StrictFulfilledByType>);


### PR DESCRIPTION
### Summary

Thanks to Will's effort in #71, we are only a few steps away from making the requirement function in TypeScript. The first step is to enable type checking based on JSDoc annotation, which is implemented in this diff. Previously this is impossible due to other non-strict functions in `Requirements.vue` file.

Now with a stronger type definition of requirements established in #68, TypeScript is able to find more type errors due to incorrect type definition setup in #44. I fixed these errors.

I have to create a separate `typed-requirement-json.ts` that basically just re-exported the json with a type assersion, and make `reqs-functions.js` import this file instead. This hack is necessary because TypeScript widens the `fulfillBy` enum to string when it's inferring the type of json (more background in #68).

### Test Plan

`yarn tsc` still type checks, but now we have more type coverage!

### Notes

In the future, we can

- Convert `reqs-functions.js` to TypeScript simply by changing the file extension and moving jsdoc type annotations to function parameters
- Strictify the types of these functions even more. e.g. Replace all `any`s with actual type definitions.
- Make `iterateThroughRequirements` non-async. It's probably async due to some legacy code.