### PR TITLE
Strictify Requirements.vue

### DIFF
--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -79,3 +79,36 @@ export type DecoratedRequirementsJson = {
   readonly college: CollegeRequirements<DecoratedCollegeOrMajorRequirement>;
   readonly major: MajorRequirements<DecoratedCollegeOrMajorRequirement>;
 };
+
+export type MutableRequirementFulfillment = {
+  name: string;
+  type: string;
+  courses: readonly string[];
+  required?: number;
+  description: string;
+  source: string;
+  fulfilled?: number;
+  progressBar: boolean;
+  displayDescription: boolean;
+};
+export type RequirementFulfillment = Readonly<MutableRequirementFulfillment>;
+
+export type GroupedRequirementFulfillmentReport = {
+  readonly groupName: 'University' | 'College' | 'Major';
+  readonly specific: string | null;
+  readonly reqs: readonly MutableRequirementFulfillment[];
+};
+
+export type SingleMenuRequirement = {
+  readonly ongoing: MutableRequirementFulfillment[];
+  readonly completed: MutableRequirementFulfillment[];
+  readonly name: string;
+  readonly group: string;
+  readonly specific: string | null;
+  readonly color: string;
+  displayDetails: boolean;
+  displayCompleted: boolean;
+  type?: string;
+  fulfilled?: number;
+  required?: number;
+};


### PR DESCRIPTION
### Summary

To make further progress on making complex requirement map post-processing, it's important to strictify things a little bit so that we know the static types of those giant maps being passing around and manipulated. Therefore, I decide to convert `Requirements.vue` to be in TypeScript.

The conversion is mostly straightforward. If you read the diff, you will see that all I have added is type annotation. The only exception is that I changed `req.required` to `req.required || 0` to make TS happy, unless it will yell at us that `req.required` can be undefined.

### Test Plan

Played with the app. No behavior change.

### Notes

Waiting on #83 to be merged before merging this.