### PR TITLE
Make requirement-functions.ts contains only pure functions

### DIFF
--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -5,7 +5,8 @@ import {
   DecoratedCollegeOrMajorRequirement,
   MutableRequirementFulfillment,
   RequirementFulfillment,
-  GroupedRequirementFulfillmentReport
+  GroupedRequirementFulfillmentReport,
+  SingleMenuRequirement
 } from './types';
 
 type RequirementMap = { readonly [code: string]: readonly string[] };
@@ -257,13 +258,23 @@ function iterateThroughCollegeOrMajorRequirements(
   return requirementJSONs;
 }
 
-export default function getReqs(
+/**
+ * @param coursesTaken a list of classes taken by the user, with some metadata (e.g. no. of credits)
+ * helping to compute requirement progress.
+ * @param college user's college.
+ * @param major user's major.
+ * @returns a tuple with the format:
+ * [
+ *   a requirement map that maps course code to a list of satisfying courses,
+ * ]
+ */
+export default function computeRequirements(
   coursesTaken: readonly CourseTaken[],
   college: string,
-  major: string,
-  requirementsMap: MutableRequirementMap
-): readonly GroupedRequirementFulfillmentReport[] {
-  // prepare final output JSONs
+  major: string
+): [RequirementMap, readonly GroupedRequirementFulfillmentReport[]] {
+  const requirementsMap: MutableRequirementMap = {};
+  // prepare grouped fulfillment summary
   const groups: GroupedRequirementFulfillmentReport[] = [];
 
   // PART 1: check university requirements
@@ -305,5 +316,5 @@ export default function getReqs(
     });
   }
 
-  return groups;
+  return [requirementsMap, groups];
 }


### PR DESCRIPTION
### Summary

To help understanding the codebase, we don't want side effects that is related to UI rendering to entangle together with pure computation code. This diff unbreaks the entanglement and make everything in requirement-functions.ts pure functions.

This diff completes the effort necessary to cleanup the requirement codebase. After this, we can move on to implement support for filtering away illegally double-counted classes during post-process phase.

### Test Plan

Played with the app. No behavior change.

### Notes

Waiting on #84 to be merged before merging this.