### PR TITLE
Remove duplicated eslint config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,21 +49,6 @@
     "typescript": "~3.7.5",
     "vue-template-compiler": "^2.6.11"
   },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true
-    },
-    "extends": [
-      "plugin:vue/essential",
-      "eslint:recommended",
-      "@vue/typescript"
-    ],
-    "rules": {},
-    "parserOptions": {
-      "parser": "@typescript-eslint/parser"
-    }
-  },
   "postcss": {
     "plugins": {
       "autoprefixer": {}


### PR DESCRIPTION
### Summary

We already have one: `.eslintrc.js`

### Test Plan

`npm run lint` still works.