### PR TITLE
Refactor types of requirement fulfillment

### DIFF
--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -73,14 +73,14 @@
               </button>
             </div>
             <div class="col-7" @click="toggleDescription(index, 'ongoing', id)">
-              <p class="sup-req pointer">{{subReq.name}}</p>
+              <p class="sup-req pointer">{{subReq.requirement.name}}</p>
             </div>
             <div class="col">
-              <p class="sup-req-progress text-right">( {{ (subReq.fulfilled !== null && subReq.fulfilled !== undefined) ? `${subReq.fulfilled}/${subReq.required} ${subReq.type}` : 'Self-Check' }}  )</p>
+              <p class="sup-req-progress text-right">( {{ (subReq.fulfilled !== null && subReq.fulfilled !== undefined) ? `${subReq.fulfilled}/${subReq.requirement.minCount} ${subReq.requirement.fulfilledBy}` : 'Self-Check' }}  )</p>
             </div>
           </div>
           <div v-if="subReq.displayDescription" class="description">
-            {{ subReq.description }} <a class="more" :style="{ 'color': `#${req.color}` }" :href="subReq.source" target="_blank"><strong>Learn More</strong></a>
+            {{ subReq.requirement.description }} <a class="more" :style="{ 'color': `#${req.color}` }" :href="subReq.requirement.source" target="_blank"><strong>Learn More</strong></a>
           </div>
           <div class="separator"></div>
         </div>
@@ -121,14 +121,14 @@
                 </button>
               </div>
               <div class="col-7" @click="toggleDescription(index, 'completed', id)">
-                <p class="sup-req pointer">{{subReq.name}}</p>
+                <p class="sup-req pointer">{{subReq.requirement.name}}</p>
               </div>
               <div class="col">
-                <p class="sup-req-progress text-right">( {{subReq.fulfilled}}/{{subReq.required}} {{ subReq.type }} )</p>
+                <p class="sup-req-progress text-right">( {{subReq.fulfilled}}/{{subReq.requirement.minCount}} {{ subReq.requirement.fulfilledBy }} )</p>
               </div>
             </div>
             <div v-if="subReq.displayDescription" class="description">
-              {{ subReq.description }} <a class="more" :style="{ 'color': `#${req.color}` }" :href="subReq.source" target="_blank"><strong>Learn More</strong></a>
+              {{ subReq.requirement.description }} <a class="more" :style="{ 'color': `#${req.color}` }" :href="subReq.requirement.source" target="_blank"><strong>Learn More</strong></a>
             </div>
           </div>
         </div>
@@ -196,23 +196,20 @@ export default Vue.extend({
       };
 
       group.reqs.forEach(req => {
-        // Account for progress type
-        if (req.type) req.type = req.type.charAt(0).toUpperCase() + req.type.substring(1);
-
         // Create progress bar with requirement with progressBar = true
-        if (req.progressBar) {
-          singleMenuRequirement.type = req.type;
+        if (req.requirement.progressBar) {
+          singleMenuRequirement.type = this.getRequirementTypeDisplayName(req.requirement.fulfilledBy);
           singleMenuRequirement.fulfilled = req.fulfilled;
-          singleMenuRequirement.required = req.required;
+          singleMenuRequirement.required = req.requirement.minCount;
         }
 
         // Default display value of false for all requirement lists
-        req.displayDescription = false;
+        const displayableRequirementFulfillment = { ...req, displayDescription: false };
 
-        if (!req.fulfilled || req.fulfilled < (req.required || 0)) {
-          singleMenuRequirement.ongoing.push(req);
+        if (!req.fulfilled || req.fulfilled < (req.requirement.minCount || 0)) {
+          singleMenuRequirement.ongoing.push(displayableRequirementFulfillment);
         } else {
-          singleMenuRequirement.completed.push(req);
+          singleMenuRequirement.completed.push(displayableRequirementFulfillment);
         }
       });
 
@@ -278,6 +275,10 @@ export default Vue.extend({
   },
 
   methods: {
+    getRequirementTypeDisplayName(type: string): string {
+      return type.charAt(0).toUpperCase() + type.substring(1);
+    },
+
     toggleDetails(index: number): void {
       this.reqs[index].displayDetails = !this.reqs[index].displayDetails;
     },

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -3,10 +3,8 @@ import {
   CourseTaken,
   BaseRequirement,
   DecoratedCollegeOrMajorRequirement,
-  MutableRequirementFulfillment,
   RequirementFulfillment,
-  GroupedRequirementFulfillmentReport,
-  SingleMenuRequirement
+  GroupedRequirementFulfillmentReport
 } from './types';
 
 type RequirementMap = { readonly [code: string]: readonly string[] };
@@ -26,17 +24,6 @@ function createRequirementJSON(
   totalRequirementCount: number,
   coursesThatFulilledRequirement: readonly string[]
 ): RequirementFulfillment {
-  const requirementFulfillmentData: MutableRequirementFulfillment = {
-    name: requirement.name,
-    type: requirement.fulfilledBy,
-    courses: coursesThatFulilledRequirement,
-    required: requirement.minCount,
-    description: requirement.description,
-    source: requirement.source,
-    fulfilled: undefined,
-    progressBar: false,
-    displayDescription: false
-  };
   let fulfilled: number | undefined;
   switch (requirement.fulfilledBy) {
     case 'courses':
@@ -51,12 +38,7 @@ function createRequirementJSON(
     default:
       throw new Error('Fulfillment type unknown.');
   }
-
-  requirementFulfillmentData.fulfilled = fulfilled;
-
-  // Make requirement use for progressbar if progressbar attr is true
-  if (requirement.progressBar) requirementFulfillmentData.progressBar = true;
-  return requirementFulfillmentData;
+  return { requirement, courses: coursesThatFulilledRequirement, fulfilled };
 }
 
 function mergeRequirementsMap(

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -80,28 +80,32 @@ export type DecoratedRequirementsJson = {
   readonly major: MajorRequirements<DecoratedCollegeOrMajorRequirement>;
 };
 
-export type MutableRequirementFulfillment = {
-  name: string;
-  type: string;
-  courses: readonly string[];
-  required?: number;
-  description: string;
-  source: string;
-  fulfilled?: number;
-  progressBar: boolean;
-  displayDescription: boolean;
+export type RequirementFulfillment = {
+  /** The original requirement object. */
+  readonly requirement: BaseRequirement;
+  /** A list of course codes that satisfy this requirement. */
+  readonly courses: readonly string[];
+  /**
+   * Current fulfillment progress.
+   * When it's a number, it's either number of courses or number of credits.
+   * When it's undefined, it means that the requirement is self-check.
+   */
+  readonly fulfilled?: number;
 };
-export type RequirementFulfillment = Readonly<MutableRequirementFulfillment>;
 
 export type GroupedRequirementFulfillmentReport = {
   readonly groupName: 'University' | 'College' | 'Major';
   readonly specific: string | null;
-  readonly reqs: readonly MutableRequirementFulfillment[];
+  readonly reqs: readonly RequirementFulfillment[];
 };
 
+export type DisplayableRequirementFulfillment = RequirementFulfillment & {
+  displayDescription: boolean;
+}
+
 export type SingleMenuRequirement = {
-  readonly ongoing: MutableRequirementFulfillment[];
-  readonly completed: MutableRequirementFulfillment[];
+  readonly ongoing: DisplayableRequirementFulfillment[];
+  readonly completed: DisplayableRequirementFulfillment[];
   readonly name: string;
   readonly group: string;
   readonly specific: string | null;


### PR DESCRIPTION
### Summary

It turns out that the previous few refactors are still not enough to implement double-counting detections and other potential post-processing functionality in a clean way.

This diff intends to address one of a few remaining problems. Currently, `RequirementFulfillment` object still has a bunch of field that's frontend related. The computation of these fields should not be entangled together with requirement satisfiability code.

This diff purges all uses of these bad practices for `MutableRequirementFulfillment`. Notable changes include:

- Doing capitalization of the first letter on the `SingleMenuRequirement` side instead of `RequirementFulfillment` side
- Refactor the `displayDescription` field into another object type, so that `RequirementFulfillment` no longer contains any UI-only fields
- After that `RequirementFulfillment` can be made immutable! Thus, it's now immutable

### Test Plan

Everything still works.