### PR TITLE
Retain more detailed course information in `RequirementFulfillment`

### DIFF
--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -22,7 +22,7 @@ function createRequirementJSON(
   requirement: BaseRequirement,
   totalRequirementCredits: number,
   totalRequirementCount: number,
-  coursesThatFulilledRequirement: readonly string[]
+  coursesThatFulilledRequirement: readonly CourseTaken[][]
 ): RequirementFulfillment {
   let fulfilled: number | undefined;
   switch (requirement.fulfilledBy) {
@@ -133,7 +133,7 @@ function iterateThroughUniversityRequirements(
       academicCreditsRequirements,
       coursesThatCountTowardsAcademicCredits.reduce((accumulator, course) => accumulator + course.credits, 0),
       0,
-      coursesThatCountTowardsAcademicCredits.map(course => course.code)
+      [coursesThatCountTowardsAcademicCredits]
     )
   );
 
@@ -144,7 +144,7 @@ function iterateThroughUniversityRequirements(
       PERequirement,
       0,
       coursesThatCountTowardsPE.length,
-      coursesThatCountTowardsPE.map(course => course.code)
+      [coursesThatCountTowardsPE]
     )
   );
 
@@ -184,7 +184,6 @@ function iterateThroughCollegeOrMajorRequirements(
     let totalRequirementCredits = 0;
     let totalRequirementCount = 0;
     const coursesThatFulfilledRequirement: CourseTaken[][] = requirementCourses.map(() => []);
-    const courseCodesThatFulfilledRequirement = new Set<string>();
 
     // eslint-disable-next-line no-loop-func
     coursesTaken.forEach(courseTaken => {
@@ -221,7 +220,6 @@ function iterateThroughCollegeOrMajorRequirements(
         // Add course to dictionary with name
         if (code in satisfiedRequirementMap) satisfiedRequirementMap[code].push(requirementName);
         else satisfiedRequirementMap[code] = [requirementName];
-        courseCodesThatFulfilledRequirement.add(code);
       });
     });
 
@@ -229,7 +227,7 @@ function iterateThroughCollegeOrMajorRequirements(
       requirement,
       totalRequirementCredits,
       totalRequirementCount,
-      Array.from(courseCodesThatFulfilledRequirement.values())
+      coursesThatFulfilledRequirement
     );
     requirementJSONs.push(generatedResults);
   }

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -83,8 +83,8 @@ export type DecoratedRequirementsJson = {
 export type RequirementFulfillment = {
   /** The original requirement object. */
   readonly requirement: BaseRequirement;
-  /** A list of course codes that satisfy this requirement. */
-  readonly courses: readonly string[];
+  /** A list of courses that satisfy this requirement. */
+  readonly courses: readonly CourseTaken[][];
   /**
    * Current fulfillment progress.
    * When it's a number, it's either number of courses or number of credits.


### PR DESCRIPTION
### Summary

Here begins the interesting refactoring part: in order to separate the phase of requirement computation into a requirement classification phase and a requirement postprocessing phase, the classification phase needs to output more information for the postprocessing phase to consume.

Currently, a lot of information is lost. For example, `coursesThatFulilledRequirement` field only stores the course code of the courses, not their full information. As a result, we have the computation of requirementMap and course fulfillment array entangled with each other.

This diff only changes the type of `courses` from code array (`string[]`) to nested array of full `CourseTaken` object (`CourseTaken[][]`). Now it can retain the structure of subrequirements, which can aid later computation.

### Test Plan

Everything still works.