### PR TITLE
Break requirement computation into small phases

### DIFF
--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -80,11 +80,14 @@ export type DecoratedRequirementsJson = {
   readonly major: MajorRequirements<DecoratedCollegeOrMajorRequirement>;
 };
 
-export type RequirementFulfillment = {
+export type RequirementFulfillment<M extends {}> = {
   /** The original requirement object. */
   readonly requirement: BaseRequirement;
   /** A list of courses that satisfy this requirement. */
   readonly courses: readonly CourseTaken[][];
+} & M;
+
+export type RequirementFulfillmentStatistics = {
   /**
    * Current fulfillment progress.
    * When it's a number, it's either number of courses or number of credits.
@@ -96,12 +99,12 @@ export type RequirementFulfillment = {
 export type GroupedRequirementFulfillmentReport = {
   readonly groupName: 'University' | 'College' | 'Major';
   readonly specific: string | null;
-  readonly reqs: readonly RequirementFulfillment[];
+  readonly reqs: readonly RequirementFulfillment<RequirementFulfillmentStatistics>[];
 };
 
-export type DisplayableRequirementFulfillment = RequirementFulfillment & {
-  displayDescription: boolean;
-}
+export type DisplayableRequirementFulfillment = RequirementFulfillment<
+  RequirementFulfillmentStatistics & { displayDescription: boolean }
+>;
 
 export type SingleMenuRequirement = {
   readonly ongoing: DisplayableRequirementFulfillment[];


### PR DESCRIPTION
### Summary

Now we can finally make our first concrete push towards requirement computation post-processing. This diff setups the infra for post-processing via monads (:octocat::bangbang:).

I first refactor the type of `RequirementFulfillment` to be parametric over metadata M. In other words, each requirement fulfillment can have base data `{ requirement, courses }` and potentially other metadata `M`. The other metadata `M` can be:

- nothing: `{ }`
- fulfillment statistics: `{ fulfillment: 42 }`
- some alert information like `{ alert: ['satisfies by two courses', 'has requirement that might be double counted', ...] }`
- any combo of above

Then I created `postProcessRequirementsFulfillments` that computes over metadata. You can see the JSDoc about it's usage. (This pattern is known as monad in functional programming languages.)

The above you setup finally allows us to break `iterateThroughCollegeOrMajorRequirements` into three clearly defined phases:

1. Compute all requirement fulfillment locally for each requirement.
2. Compute fulfillment statistics for each requirement.
3. Build requirement map

This clear separation of phases makes some problems very easy to spot. Namely, the code of building the requirement map doesn't really need to be inside `iterateThroughCollegeOrMajorRequirements`. However, refactoring it elsewhere will be the focus of future diff to keep this one small.

The rest of the diff is mostly moving code around.

### Test Plan

Everything still works.