### PR TITLE
Decouple requirement filfillment map and group computation

### DIFF
--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -152,7 +152,7 @@ import Course from '@/components/Course.vue';
 import Modal from '@/components/Modals/Modal.vue';
 import { BaseRequirement as Requirement, CourseTaken, SingleMenuRequirement } from '@/requirements/types';
 
-import computeRequirements from '@/requirements/reqs-functions';
+import { computeRequirements, computeRequirementMap } from '@/requirements/reqs-functions';
 
 Vue.component('course', Course);
 Vue.component('modal', Modal);
@@ -173,14 +173,10 @@ export default Vue.extend({
     isBottomBar: Boolean
   },
   mounted() {
-    const [builtRequirementMap, groups] = computeRequirements(
-      this.getCourseCodesArray(),
-      this.user.college,
-      this.user.major
-    );
+    const groups = computeRequirements(this.getCourseCodesArray(), this.user.college, this.user.major);
 
     // Send satisfied credits data back to dashboard to build alerts
-    this.$emit('requirementsMap', builtRequirementMap);
+    this.$emit('requirementsMap', computeRequirementMap(groups));
 
     // Turn result into data readable by requirements menu
     const singleMenuRequirements = groups.map(group => {


### PR DESCRIPTION
### Summary

With the infra setup in #90, we can clearly see how easy it is to decouple requirement fulfillment computation and `requirementMap` computation. Now instead of letting them entangle each other in `reqs-functions.ts`, we should make map computation depends on fulfillment list computation.

I moved all map computation code into `computeRequirementMap`, which takes in an already computed grouped requirement fulfillment. A lot of code is simplified:

- It turns out that `mergeRequirementsMap` is completely unnecessary when we build the map globally, so it's purged.
- `iterateThroughXxxRequirements` now become pure functions, so I renamed it to be `computeXxxRequirementFulfillments` to reflect this fact.

The biggest achievement of this diff is that now all functions in `reqs-functions.ts` are pure.

### Test Plan

Everything still works.