### PR TITLE
Automatically purge closed PR resources

### DIFF
--- a/.github/workflows/cleanup-workflow.yml
+++ b/.github/workflows/cleanup-workflow.yml
@@ -1,0 +1,23 @@
+name: Cleanup
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  clean-up:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages Branch
+        uses: actions/checkout@master
+        with:
+          ref: gh-pages
+      - name: Purge Static Assets
+        env:
+          ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+        run: |
+          git rm -rf ${{ github.event.number }} || echo "Nothing to remove"
+          git config user.name "deployment-bot"
+          git config user.email "hello@cornelldti.org"
+          git add .
+          git commit -m "Remove assets in ${{ github.event.number }}" || echo "Nothing to commit."
+          git push "https://${ACCESS_TOKEN}@github.com/cornell-dti/course-plan.git" || echo "Nothing to push."


### PR DESCRIPTION
### Summary

Adapted from https://github.com/cornell-dti/samwise/blob/master/.github/workflows/cleanup-workflow.yml

I created a workflow that automatically deploy built resources to github pages a while ago. Over the time, a lot of unused garbage has accumulated and I have to manually purge them https://github.com/cornell-dti/course-plan/commit/7c2e5c1a380c01bf0c7a01b6438b9a0e0f293707 to avoid github pages deployment failure. This workflow will automatically purge them once a PR is closed.

### Test Plan

The samwise one runs fine, so I guess it will run fine. We can only truly test it once this PR is closed.