### PR TITLE
Bump github-pages deployment action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,13 +29,11 @@ jobs:
           name: built-assets
           path: ${{ github.event.number }}
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v2.5.0
-        env:
-          PUBLISH_DIR: '.'
-          PUBLISH_BRANCH: gh-pages
-          PERSONAL_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          keepFiles: true
+          keep_files: true
+          publish_dir: '.'
+          github_token: '${{ secrets.BOT_TOKEN }}'
       - name: Comment on pull request
         uses: cornell-dti/dti-repo-tools@master
         env:


### PR DESCRIPTION
### Summary

The new action is built with TS instead of Docker container, so we can reduce some CI runtime by avoiding building a docker container

### Test Plan

See how it deploys in a CI run.