### PR TITLE
Dupe Bottom Bar Tab Bug Fix for Beta Release v0.9.1

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -440,7 +440,8 @@ export default {
         difficulty: 0,
         workload: 0,
         prerequisites: this.noneIfEmpty(course.prereqs),
-        description: course.description
+        description: course.description,
+        uniqueID: course.uniqueID
       };
 
       // expand bottombar if first course added


### PR DESCRIPTION
### Summary 
This pull request is the duplicate bottom bar tab bug fix for Beta Release v0.9.1. 

- [x] If user clicks on the same course card multiple times, only one bottom bar tab appears, or if it is already in the tab list, it is brought to the front.

- [x] If user clicks on multiple different course cards that represent the same course (i.e. multiple INFO 1998 course cards in the user's plan), at most one bottom bar tab appears for each course card (i.e. each INFO 1998 course card in the plan) clicked.

### Test Plan 
Trying the above items to see if dupe bottom bar tab bug still exists.
