### PR TITLE
Compact fixes

### DIFF
--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -161,7 +161,7 @@ export default {
       }
     },
     deleteCourse() {
-      this.$emit('delete-course', this.uniqueID);
+      this.$emit('delete-course', this.subject, this.number, this.uniqueID);
       this.closeMenuIfOpen();
     },
     colorCourse(color) {

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -284,14 +284,14 @@ export default {
       this.openConfirmationModal(`Added ${courseCode} to ${this.type} ${this.year}`);
       this.buildCautions();
     },
-    deleteCourse(uniqueID) {
+    deleteCourse(subject, number, uniqueID) {
       for (let i = 0; i < this.courses.length; i += 1) {
         if (this.courses[i].uniqueID === uniqueID) {
           this.courses.splice(i, 1);
           break;
         }
       }
-      const courseCode = `${this.subject} ${this.number}`;
+      const courseCode = `${subject} ${number}`;
       this.openConfirmationModal(`Removed ${courseCode} from ${this.type} ${this.year}`);
       // Update requirements menu
       this.$emit('update-requirements-menu');

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -410,7 +410,6 @@ export default {
     width: 23.75rem;
     height: 9.38rem;
     color: #d8d8d8;
-
     &:hover,
     &:active,
     &:focus {
@@ -422,6 +421,8 @@ export default {
       width: 13rem;
       height: 3.5rem;
       margin-top: .875rem;
+      margin-left: 1.125rem;
+      margin-right: 1.125rem;
     }
   }
 

--- a/src/components/SemesterView.vue
+++ b/src/components/SemesterView.vue
@@ -56,7 +56,7 @@
         v-for="sem in semesters"
         :key="sem.id"
         class="semesterView-wrapper semesterView-wrapper--compact">
-        <semester v-bind="sem" :isNotSemesterButton="true" :compact="compact" @updateBar="updateBar"
+        <semester v-bind="sem" :isNotSemesterButton="true" :compact="compact" @updateBar="updateBar" :semesters="semesters"
         :activatedCourse="activatedCourse" @delete-semester="deleteSemester" @edit-semester="editSemester" />
       </div>
       <div class="semesterView-wrapper" :class="{ 'semesterView-wrapper--compact': compact }">


### PR DESCRIPTION
### Summary <!-- Required -->

Fix a couple of bugs that only occur on the compact view

- [x] Disallow editing semesters to a duplicate sem in compact
- [x] Fix +SEMESTER button on some breakpoints of compact
- [x] Fix undefined subject/number in delete course confirmation

### Test Plan <!-- Required -->

Ensure that the above functions work on compact now. Also verify adding new sems still does not allow duplicates. And ensure that deleting courses pops up the expected modal with correct text.