### PR TITLE
Reqs course cards

### DIFF
--- a/firebase-debug.log
+++ b/firebase-debug.log
@@ -1,0 +1,42 @@
+[debug] [2020-05-08T01:54:28.403Z] ----------------------------------------------------------------------
+[debug] [2020-05-08T01:54:28.407Z] Command:       /usr/local/bin/node /usr/local/bin/firebase emulators:start --only functions
+[debug] [2020-05-08T01:54:28.407Z] CLI Version:   7.6.1
+[debug] [2020-05-08T01:54:28.407Z] Platform:      darwin
+[debug] [2020-05-08T01:54:28.407Z] Node Version:  v10.16.3
+[debug] [2020-05-08T01:54:28.408Z] Time:          Thu May 07 2020 21:54:28 GMT-0400 (Eastern Daylight Time)
+[debug] [2020-05-08T01:54:28.409Z] ----------------------------------------------------------------------
+[debug] [2020-05-08T01:54:28.409Z] 
+[info] i  Starting emulators: ["functions"]
+[warn] ⚠  Your requested "node" version "8" doesn't match your global version "10"
+[info] ✔  functions: Emulator started at http://localhost:5001
+[info] i  functions: Watching "/Users/theresacho/Desktop/course-plan/functions" for Cloud Functions...
+[debug] [2020-05-08T01:54:29.307Z] [runtime-status] Functions runtime initialized. {"cwd":"/Users/theresacho/Desktop/course-plan/functions","node_version":"10.16.3"}
+[debug] [2020-05-08T01:54:29.309Z] [runtime-status] Disabled runtime features: undefined {}
+[debug] [2020-05-08T01:54:29.316Z] [runtime-status] Resolved module firebase-admin {"declared":true,"installed":true,"version":"8.9.2","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-admin/lib/index.js"}
+[debug] [2020-05-08T01:54:29.319Z] [runtime-status] Resolved module firebase-functions {"declared":true,"installed":true,"version":"3.3.0","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-functions/lib/index.js"}
+[debug] [2020-05-08T01:54:29.914Z] [runtime-status] Found google-gax at /Users/theresacho/Desktop/course-plan/functions/node_modules/google-gax/build/src/index.js {}
+[debug] [2020-05-08T01:54:29.915Z] [runtime-status] Outgoing network have been stubbed. [{"name":"http","status":"mocked"},{"name":"http","status":"mocked"},{"name":"https","status":"mocked"},{"name":"https","status":"mocked"},{"name":"net","status":"mocked"},{"name":"google-gax","status":"mocked"}]
+[debug] [2020-05-08T01:54:30.010Z] [runtime-status] Checked functions.config() {"config":{}}
+[debug] [2020-05-08T01:54:30.012Z] [runtime-status] Resolved module firebase-functions {"declared":true,"installed":true,"version":"3.3.0","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-functions/lib/index.js"}
+[debug] [2020-05-08T01:54:30.013Z] [runtime-status] Resolved module firebase-admin {"declared":true,"installed":true,"version":"8.9.2","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-admin/lib/index.js"}
+[debug] [2020-05-08T01:54:30.013Z] [runtime-status] Resolved module firebase-functions {"declared":true,"installed":true,"version":"3.3.0","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-functions/lib/index.js"}
+[debug] [2020-05-08T01:54:30.136Z] [runtime-status] firebase-admin has been stubbed. {"adminResolution":{"declared":true,"installed":true,"version":"8.9.2","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-admin/lib/index.js"}}
+[debug] [2020-05-08T01:54:30.141Z] [runtime-status] initializeApp(DEFAULT) {"databaseURL":"https://cornelldti-courseplan-dev.firebaseio.com","storageBucket":"cornelldti-courseplan-dev.appspot.com","projectId":"cornelldti-courseplan-dev"}
+[warn] ⚠  functions: The Cloud Firestore emulator is not running, so calls to Firestore will affect production.
+[info] ✔  functions[TrackUsers]: http function initialized (http://localhost:5001/cornelldti-courseplan-dev/us-central1/TrackUsers).
+[info] ✔  functions[fetchCourses]: http function initialized (http://localhost:5001/cornelldti-courseplan-dev/us-central1/fetchCourses).
+[info] ✔  All emulators started, it is now safe to connect.
+[debug] [2020-05-08T02:02:50.993Z] File /Users/theresacho/Desktop/course-plan/functions/index.js changed, reloading triggers
+[debug] [2020-05-08T02:02:53.848Z] [runtime-status] Functions runtime initialized. {"cwd":"/Users/theresacho/Desktop/course-plan/functions","node_version":"10.16.3"}
+[debug] [2020-05-08T02:02:53.849Z] [runtime-status] Disabled runtime features: undefined {}
+[debug] [2020-05-08T02:02:53.861Z] [runtime-status] Resolved module firebase-admin {"declared":true,"installed":true,"version":"8.9.2","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-admin/lib/index.js"}
+[debug] [2020-05-08T02:02:53.868Z] [runtime-status] Resolved module firebase-functions {"declared":true,"installed":true,"version":"3.3.0","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-functions/lib/index.js"}
+[debug] [2020-05-08T02:02:55.704Z] [runtime-status] Found google-gax at /Users/theresacho/Desktop/course-plan/functions/node_modules/google-gax/build/src/index.js {}
+[debug] [2020-05-08T02:02:55.712Z] [runtime-status] Outgoing network have been stubbed. [{"name":"http","status":"mocked"},{"name":"http","status":"mocked"},{"name":"https","status":"mocked"},{"name":"https","status":"mocked"},{"name":"net","status":"mocked"},{"name":"google-gax","status":"mocked"}]
+[debug] [2020-05-08T02:02:56.029Z] [runtime-status] Checked functions.config() {"config":{}}
+[debug] [2020-05-08T02:02:56.031Z] [runtime-status] Resolved module firebase-functions {"declared":true,"installed":true,"version":"3.3.0","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-functions/lib/index.js"}
+[debug] [2020-05-08T02:02:56.033Z] [runtime-status] Resolved module firebase-admin {"declared":true,"installed":true,"version":"8.9.2","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-admin/lib/index.js"}
+[debug] [2020-05-08T02:02:56.034Z] [runtime-status] Resolved module firebase-functions {"declared":true,"installed":true,"version":"3.3.0","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-functions/lib/index.js"}
+[debug] [2020-05-08T02:02:56.682Z] [runtime-status] firebase-admin has been stubbed. {"adminResolution":{"declared":true,"installed":true,"version":"8.9.2","resolution":"/Users/theresacho/Desktop/course-plan/functions/node_modules/firebase-admin/lib/index.js"}}
+[debug] [2020-05-08T02:02:56.688Z] [runtime-status] initializeApp(DEFAULT) {"databaseURL":"https://cornelldti-courseplan-dev.firebaseio.com","storageBucket":"cornelldti-courseplan-dev.appspot.com","projectId":"cornelldti-courseplan-dev"}
+[warn] ⚠  functions: The Cloud Firestore emulator is not running, so calls to Firestore will affect production.

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,6 +6,8 @@ admin.initializeApp();
 const db = admin.firestore();
 const userDataCollection = db.collection('userData');
 
+const cors = require('cors')({origin: true});
+
 let average = (array) => array.reduce((a, b) => a + b) / array.length;
 function typeToMonth(type){
   switch(type) {
@@ -90,4 +92,24 @@ exports.TrackUsers = functions.https.onRequest(async (req, res) => {
       });
       
 });
+// TODO: Re-deploy fetchCourses firebase function
+// // fetch by list of course codes (codes="CS1110,CS2110,...")
+// exports.fetchCourses = functions.https.onRequest(async (req, res) => {
+//   res.set('Access-Control-Allow-Origin', '*');
+//   // assuming this is a list for now
+//   console.log("hello from will & theresa");
+//   let codes = req.query.codes;
+//   console.log(codes);
+  
+//   // let arr = codes.split(',');
 
+//   // access the filtered-all-courses.json
+  
+//   // loop thru rosters (starting from most recent) until finding the course
+  
+//   // append data to something
+
+//   // return the something after looping through all courses
+//   // want an array of courses
+//   res.send(codes);
+// });

--- a/src/assets/images/dropleft-blue.svg
+++ b/src/assets/images/dropleft-blue.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="17" viewBox="0 0 18 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.90827 16.9705L0.422992 8.48523L8.90827 -5.17368e-05V16.9705Z" fill="#1AA9A5"/>
+</svg>

--- a/src/assets/images/dropleft-grayblue.svg
+++ b/src/assets/images/dropleft-grayblue.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="17" viewBox="0 0 18 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.90827 16.9705L0.422992 8.48523L8.90827 -5.17368e-05V16.9705Z" fill="#508197"/>
+</svg>

--- a/src/assets/images/dropleft-green.svg
+++ b/src/assets/images/dropleft-green.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="17" viewBox="0 0 18 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.90827 16.9705L0.422992 8.48523L8.90827 -5.17368e-05V16.9705Z" fill="#105351"/>
+</svg>

--- a/src/assets/images/dropleft-lightblue.svg
+++ b/src/assets/images/dropleft-lightblue.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="17" viewBox="0 0 18 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.90827 16.9705L0.422992 8.48523L8.90827 -5.17368e-05V16.9705Z" fill="#92C3E6"/>
+</svg>

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -18,7 +18,7 @@
           <div :class="{ 'course-code--min': compact }" class="course-code">
             {{ subject }} {{ number }}
           </div>
-          <div class="course-dotRow" @click="openMenu">
+          <div v-if="!isReqCourse" class="course-dotRow" @click="openMenu">
             <span class="course-dot course-dot--menu"></span>
             <span class="course-dot course-dot--menu"></span>
             <span class="course-dot course-dot--menu"></span>
@@ -101,7 +101,8 @@ export default {
     id: String,
     uniqueID: Number,
     active: Boolean,
-    semId: Number
+    semId: Number,
+    isReqCourse: Boolean
   },
   data() {
     return {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -269,6 +269,8 @@ export default {
 
       const alerts = { requirement: null, caution: null };
 
+      const isReqCourse = isRequirementsCourse;
+
       const newCourse = {
         subject,
         number,
@@ -286,7 +288,8 @@ export default {
         color,
         alerts,
         check: true,
-        uniqueID
+        uniqueID,
+        isReqCourse
       };
 
       if (!isRequirementsCourse) {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -197,7 +197,7 @@ export default {
     /**
      * Creates a course on frontend with either user or API data
      */
-    createCourse(course) {
+    createCourse(course, isRequirementsCourse) {
       const uniqueID = course.uniqueID || this.incrementID();
 
       const subject = (course.code && course.code.split(' ')[0]) || course.subject;
@@ -288,8 +288,11 @@ export default {
         check: true,
         uniqueID
       };
-      // Update requirements menu
-      this.updateRequirementsMenu();
+
+      if (!isRequirementsCourse) {
+        // Update requirements menu
+        this.updateRequirementsMenu();
+      }
 
       return newCourse;
     },

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -18,9 +18,11 @@
           :user="user"
           :key="requirementsKey"
           @requirementsMap="loadRequirementsMap"
+          @reqCourseDropHandler="reqCourseDropHandler"
          />
       </div>
       <semesterview v-if="loaded && ((!isOpeningRequirements && isTablet) || !isTablet)"
+        ref="semesterView"
         :semesters="semesters"
         :compact="compactVal"
         :isBottomBarExpanded="bottomBar.isExpanded"
@@ -528,6 +530,12 @@ export default {
 
     closeBar() {
       this.bottomBar.isExpanded = false;
+    },
+
+    reqCourseDropHandler() {
+      // Prevents dupe with dragged and dropped req course and the new Course
+      // component that appears in semesterView
+      this.$refs.semesterView.$data.key += 1;
     },
 
     startOnboarding() {

--- a/src/components/Modals/Modal.vue
+++ b/src/components/Modals/Modal.vue
@@ -107,8 +107,10 @@ export default {
     addCourse() {
       const dropdown = document.getElementById(`dropdown-${this.semesterID}`);
       const title = dropdown.value;
+      console.log(title);
       // name used to transmit roster information
       const roster = dropdown.name;
+      console.log(roster);
 
       // TODO: can I make the valid assumption that the course code is up to the colon in the title?
       const courseCode = title.substring(0, title.indexOf(':'));
@@ -116,7 +118,8 @@ export default {
       const number = courseCode.split(' ')[1];
 
       const parent = this.$parent;
-
+      console.log('roster for add modal in modal.vue');
+      console.log(roster);
       // To use for retrieve course data from Firebase
       // // TODO: error handling if course not found or some firebase error
       // docRef

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -125,16 +125,16 @@
                 <div class="draggable-requirements-wrapper" v-if="subReq.displayDescription">
                   <div
                     class="draggable-requirements-seeAll-wrapper"
-                    v-if="subReqsCourseMapList[req.group] !== undefined && subReqsCourseMapList[req.group][subReq.requirement.name] !== undefined"
+                    v-if="subReqsCoursesMap[req.group] !== undefined && subReqsCoursesMap[req.group][subReq.requirement.name] !== undefined"
                   >
                     <div class="draggable-requirements-seeAll-button" v-on:click="showSeeAll(req.group, req.specific, subReq.requirement.name)">{{ seeAll }}</div>
                   </div>
                     <div
-                      v-if="subReqsCourseMapList[req.group] !== undefined && subReqsCourseMapList[req.group][subReq.requirement.name] !== undefined"
+                      v-if="subReqsCoursesMap[req.group] !== undefined && subReqsCoursesMap[req.group][subReq.requirement.name] !== undefined"
                       class="draggable-requirements-courses"
-                      v-dragula="subReqsCourseMapList[req.group][subReq.requirement.name]"
+                      v-dragula="subReqsCoursesMap[req.group][subReq.requirement.name]"
                       bag="first-bag">
-                      <div v-for="course in subReqsCourseMapList[req.group][subReq.requirement.name]" :key="course.uniqueID" class="requirements-courseWrapper">
+                      <div v-for="course in subReqsCoursesMap[req.group][subReq.requirement.name]" :key="course.uniqueID" class="requirements-courseWrapper">
                         <course
                           v-bind="course"
                           :courseObj="course"
@@ -210,11 +210,11 @@
         <!-- loop through reqs array of req objects -->
         <div
           class="req"
-          v-for="reqGroup in Object.keys(subReqsCourseMapList)"
+          v-for="reqGroup in Object.keys(subReqsCoursesMap)"
           :key="reqGroup.id"
         >
           <div
-            v-for="subReqName in Object.keys(subReqsCourseMapList[reqGroup])"
+            v-for="subReqName in Object.keys(subReqsCoursesMap[reqGroup])"
             :key="subReqName.id"
           >
             <div class="row top">
@@ -239,11 +239,11 @@
             <h1 class="title">All {{subReqName}} Courses</h1>
             <div class="draggable-requirements-wrapper">
                 <div
-                  v-if="subReqsCourseMapList[reqGroup] !== undefined && subReqsCourseMapList[reqGroup][subReqName] !== undefined"
+                  v-if="subReqsCoursesMap[reqGroup] !== undefined && subReqsCoursesMap[reqGroup][subReqName] !== undefined"
                   class="draggable-requirements-courses"
-                  v-dragula="subReqsCourseMapList[reqGroup][subReqName]"
+                  v-dragula="subReqsCoursesMap[reqGroup][subReqName]"
                   bag="first-bag">
-                  <div v-for="course in subReqsCourseMapList[reqGroup][subReqName]" :key="course.uniqueID" class="requirements-courseWrapper">
+                  <div v-for="course in subReqsCoursesMap[reqGroup][subReqName]" :key="course.uniqueID" class="requirements-courseWrapper">
                     <course
                       v-bind="course"
                       :courseObj="course"
@@ -297,7 +297,7 @@ type Data = {
   minors: minor[];
   requirementsMap: {};
   reqGroupColorMap: {};
-  subReqsCourseMapList: {};
+  subReqsCoursesMap: {};
   scrollable: boolean;
   isSeeAll: boolean;
 
@@ -355,7 +355,7 @@ export default Vue.extend({
       }
       console.log('in singleMenuReq');
       if (singleMenuRequirement.group !== 'UNIVERSITY') {
-        this.subReqsCourseMapList[singleMenuRequirement.group] = {};
+        this.subReqsCoursesMap[singleMenuRequirement.group] = {};
 
         // isSeeAll param is false because only show first 4
         this.addRequirementsCourse(singleMenuRequirement.group, singleMenuRequirement.specific, this.isSeeAll);
@@ -429,7 +429,7 @@ export default Vue.extend({
       },
       // subReqCourseMap maps from the group name to the subreq to a Course[]
       // Each item has key <group name>: <subreq name>: list of courses that fulfill the subreq
-      subReqsCourseMapList: {},
+      subReqsCoursesMap: {},
       scrollable: false,
       isSeeAll: false
     };
@@ -532,8 +532,8 @@ export default Vue.extend({
       }
       this.minors = minors;
     },
-    // Fetches course data and updates the subReqsCourseMapList with the course
-    updateSubReqsCourseMapList(roster, subject, number, courseCode, group, subReqName, isSeeAll) {
+    // Fetches course data and updates the subReqsCoursesMap with the course
+    updatesubReqsCoursesMap(roster, subject, number, courseCode, group, subReqName, isSeeAll) {
       fetch(`https://classes.cornell.edu/api/2.0/search/classes.json?roster=${roster}&subject=${subject}&q=${courseCode}`)
         .then(res => res.json())
         .then(resultJSON => {
@@ -547,10 +547,10 @@ export default Vue.extend({
                 const newCourse = this.$parent.createCourse(course, true);
                 newCourse.compact = !isSeeAll;
                 // console.log(newCourse);
-                if (this.subReqsCourseMapList[group] && this.subReqsCourseMapList[group][subReqName]) {
-                  this.subReqsCourseMapList[group][subReqName].push(newCourse);
+                if (this.subReqsCoursesMap[group] && this.subReqsCoursesMap[group][subReqName]) {
+                  this.subReqsCoursesMap[group][subReqName].push(newCourse);
                 } else {
-                  this.subReqsCourseMapList[group][subReqName] = [newCourse];
+                  this.subReqsCoursesMap[group][subReqName] = [newCourse];
                 }
               }
             });
@@ -602,7 +602,7 @@ export default Vue.extend({
                   const courseSubjectToAdd = courseCodeToAdd.split(' ')[0];
                   const courseNumberToAdd = courseCodeToAdd.split(' ')[1];
                   console.log(courseCodeToAdd);
-                  this.updateSubReqsCourseMapList(roster, courseSubjectToAdd, courseNumberToAdd, courseCodeToAdd, group, subReqName, isSeeAll);
+                  this.updatesubReqsCoursesMap(roster, courseSubjectToAdd, courseNumberToAdd, courseCodeToAdd, group, subReqName, isSeeAll);
                 });
               }
             }
@@ -624,26 +624,26 @@ export default Vue.extend({
                   const courseNumberList = entry[1];
                   courseNumberList.forEach(number => {
                     const courseCode = `${subject} ${number}`;
-                    this.updateSubReqsCourseMapList(roster, subject, number, courseCode, group, subReqName, isSeeAll);
+                    this.updatesubReqsCoursesMap(roster, subject, number, courseCode, group, subReqName, isSeeAll);
                   });
                 });
               }
             }
           }
-          console.log('subReqsCourseMapList');
-          console.log(this.subReqsCourseMapList);
+          console.log('subReqsCoursesMap');
+          console.log(this.subReqsCoursesMap);
         }
       });
     },
     showSeeAll(group, specific, subReqName) {
-      this.subReqsCourseMapList = {};
-      this.subReqsCourseMapList[group] = {};
+      this.subReqsCoursesMap = {};
+      this.subReqsCoursesMap[group] = {};
       this.addRequirementsCourse(group, specific, subReqName, true);
       this.isSeeAll = !this.isSeeAll;
     },
     backtoRequirements() {
       this.isSeeAll = !this.isSeeAll;
-      this.subReqsCourseMapList = {};
+      this.subReqsCoursesMap = {};
     }
   }
 });

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -1,119 +1,249 @@
 <template v-if="semesters">
   <div class="requirements">
     <div class="fixed">
-    <h1 class="title">School Requirements</h1>
-    <!-- loop through reqs array of req objects -->
-    <div class="req" v-for="(req, index) in reqs" :key="req.id">
+    <div class="requirements-regularView" v-if="!this.isSeeAll">
+      <h1 class="title">School Requirements</h1>
+      <!-- loop through reqs array of req objects -->
+      <div class="req" v-for="(req, index) in reqs" :key="req.id">
 
-      <!-- TODO change for multiple colleges -->
-      <div v-if="index<=2 || index == 2 + majors.length" class="row top">
-        <p class="name col p-0">{{ req.name }}</p>
-      </div>
         <!-- TODO change for multiple colleges -->
-        <div v-if="index==2" class="major">
-          <div :style="{'border-bottom': major.display ? `2px solid #${reqGroupColorMap[req.group][0]}` : ''}"  @click="activate(id)" class="major-title" v-for="(major, id) in majors" :key="major.id">
-            <p :style="{'font-weight': major.display ? '500' : '', 'color' : major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}"  class="major-title-top">{{major.majorFN}}</p>
-            <p :style="{'color': major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}" class="major-title-bottom">({{user.collegeFN}})</p>
-          </div>
+        <div v-if="index<=2 || index == 2 + majors.length" class="row top">
+          <p class="name col p-0">{{ req.name }}</p>
         </div>
-        <div v-if="index==2+majors.length" class="minor">
-          <div :style="{'border-bottom': major.display ? `2px solid #${reqGroupColorMap[req.group][0]}` : ''}"  @click="activate(id)" class="major-title" v-for="(minor, id) in minors" :key="minor.id">
-            <p :style="{'font-weight': major.display ? '500' : '', 'color' : major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}"  class="minor-title-top">{{minor.minorFN}}</p>
-            <p :style="{'color': major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}" class="minor-title-bottom">({{user.collegeFN}})</p> <!-- Change for multiple colleges -->
-          </div>
-        </div>
-
-        <!-- progress bar settings -->
-        <div v-if="showMajorOrMinorRequirements(index, req.group)" >
-          <div class="progress">
+          <!-- TODO change for multiple colleges -->
+          <div v-if="index==2" class="major">
             <div
-              class="progress-bar"
-              :style="{ 'background-color': `#${reqGroupColorMap[req.group][0]}`, width: `${(req.fulfilled/req.required)*100}%`}"
-              role="progressbar"
-            ></div>
+              :style="{'border-bottom': major.display ? `2px solid #${reqGroupColorMap[req.group][0]}` : ''}"
+              @click="activate(id)"
+              class="major-title"
+              v-for="(major, id) in majors"
+              :key="major.id"
+            >
+              <p :style="{'font-weight': major.display ? '500' : '', 'color' : major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}"  class="major-title-top">{{major.majorFN}}</p>
+              <p :style="{'color': major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}" class="major-title-bottom">({{user.collegeFN}})</p>
+            </div>
+          </div>
+          <div v-if="index==2+majors.length" class="minor">
+            <div
+              :style="{'border-bottom': major.display ? `2px solid #${reqGroupColorMap[req.group][0]}` : ''}"
+              @click="activate(id)" class="major-title"
+              v-for="(minor, id) in minors"
+              :key="minor.id"
+            >
+              <p :style="{'font-weight': major.display ? '500' : '', 'color' : major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}"  class="minor-title-top">{{minor.minorFN}}</p>
+              <p :style="{'color': major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}" class="minor-title-bottom">({{user.collegeFN}})</p> <!-- Change for multiple colleges -->
+            </div>
           </div>
 
-          <p class="progress-text">
-            <span class="progress-text-credits">{{ req.fulfilled }}/{{ req.required }}</span>
-            <span class="progress-text-text"> Total {{ req.type }} Inputted on Schedule</span>
-          </p>
-
-          <!--View more college requirements -->
-          <div class="row top">
-            <div class="col-1 p-0" >
-              <button :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }" class="btn" @click="toggleDetails(index)">
-                <!-- svg for dropdown icon -->
-                <img
-                  v-if="req.displayDetails"
-                  class="arrow arrow-up"
-                  :src="require(`@/assets/images/dropup-${reqGroupColorMap[req.group][1]}.svg`)"
-                  alt="dropup"
-                />
-                <img
-                  v-else
-                  class="arrow arrow-down"
-                  :src="require(`@/assets/images/dropdown-${reqGroupColorMap[req.group][1]}.svg`)"
-                  alt="dropdown"
-                />
-              </button>
+          <!-- progress bar settings -->
+          <div v-if="showMajorOrMinorRequirements(index, req.group)" >
+            <div class="progress">
+              <div
+                class="progress-bar"
+                :style="{ 'background-color': `#${reqGroupColorMap[req.group][0]}`, width: `${(req.fulfilled/req.required)*100}%`}"
+                role="progressbar"
+              ></div>
             </div>
-            <div class="col p-0 ">
-                <button
-                    class="btn req-name"
-                    :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }"
-                    @click="toggleDetails(index)">
-                    {{ (req.displayDetails) ? "Hide" : "View" }} All {{ req.group.charAt(0) + req.group.substring(1).toLowerCase() }} Requirements
+
+            <p class="progress-text">
+              <span class="progress-text-credits">{{ req.fulfilled }}/{{ req.required }}</span>
+              <span class="progress-text-text"> Total {{ req.type }} Inputted on Schedule</span>
+            </p>
+
+            <!--View more college requirements -->
+            <div class="row top">
+              <div class="col-1 p-0" >
+                <button :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }" class="btn" @click="toggleDetails(index)">
+                  <!-- svg for dropdown icon -->
+                  <img
+                    v-if="req.displayDetails"
+                    class="arrow arrow-up"
+                    :src="require(`@/assets/images/dropup-${reqGroupColorMap[req.group][1]}.svg`)"
+                    alt="dropup"
+                  />
+                  <img
+                    v-else
+                    class="arrow arrow-down"
+                    :src="require(`@/assets/images/dropdown-${reqGroupColorMap[req.group][1]}.svg`)"
+                    alt="dropdown"
+                  />
                 </button>
-            </div>
-          </div>
-
-          <!--Show more of completed requirements -->
-          <div v-if="req.displayDetails">
-            <p class="sub-title">In-Depth College Requirements</p>
-            <div class="separator"></div>
-            <div
-              v-for="(subReq, id) in req.ongoing"
-              :key="subReq.id">
-              <div class="row depth-req">
-                <div class="col-1" @click="toggleDescription(index, 'ongoing', id)">
-                  <button class="btn">
-                    <!-- svg for dropdown icon -->
-                    <img
-                      v-if="subReq.displayDescription"
-                  class="arrow arrow-up"
-                   src="@/assets/images/dropup.svg"
-                   alt="dropup"
-                    />
-                    <img
-                      v-else
-                      class="arrow arrow-down"
-                      src="@/assets/images/dropdown.svg"
-                      alt="dropdown"
-                    />
+              </div>
+              <div class="col p-0 ">
+                  <button
+                      class="btn req-name"
+                      :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }"
+                      @click="toggleDetails(index)">
+                      {{ (req.displayDetails) ? "Hide" : "View" }} All {{ req.group.charAt(0) + req.group.substring(1).toLowerCase() }} Requirements
                   </button>
+              </div>
+            </div>
+
+            <!--Show more of completed requirements -->
+            <div v-if="req.displayDetails">
+              <p class="sub-title">In-Depth College Requirements</p>
+              <div class="separator"></div>
+              <div
+                v-for="(subReq, id) in req.ongoing"
+                :key="subReq.id">
+                <div class="row depth-req">
+                  <div class="col-1" @click="toggleDescription(index, 'ongoing', id)">
+                    <button class="btn">
+                      <!-- svg for dropdown icon -->
+                      <img
+                        v-if="subReq.displayDescription"
+                    class="arrow arrow-up"
+                    src="@/assets/images/dropup.svg"
+                    alt="dropup"
+                      />
+                      <img
+                        v-else
+                        class="arrow arrow-down"
+                        src="@/assets/images/dropdown.svg"
+                        alt="dropdown"
+                      />
+                    </button>
+                  </div>
+                  <div class="col-7" @click="toggleDescription(index, 'ongoing', id)">
+                    <p class="sup-req pointer incomplete-ptext">{{subReq.requirement.name}}</p>
+                  </div>
+                  <div class="col">
+                    <p class="sup-req-progress text-right incomplete-ptext">{{
+                    (subReq.requirement.fulfilledBy !== 'self-check')
+                    ? `${subReq.totalCountFulfilled || subReq.minCountFulfilled}/${subReq.requirement.totalCount
+                      || subReq.requirement.minCount} ${subReq.requirement.fulfilledBy}`
+                    : 'self check' }}</p>
+                  </div>
                 </div>
-                <div class="col-7" @click="toggleDescription(index, 'ongoing', id)">
-                  <p class="sup-req pointer incomplete-ptext">{{subReq.requirement.name}}</p>
+                <div v-if="subReq.displayDescription" class="description">
+                  {{ subReq.requirement.description }} <a class="more"
+                  :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }"
+                  :href="subReq.requirement.source" target="_blank">
+                  <strong>Learn More</strong></a>
                 </div>
-                <div class="col">
-                  <p class="sup-req-progress text-right incomplete-ptext">{{
-                   (subReq.requirement.fulfilledBy !== 'self-check')
-                   ? `${subReq.totalCountFulfilled || subReq.minCountFulfilled}/${subReq.requirement.totalCount
-                    || subReq.requirement.minCount} ${subReq.requirement.fulfilledBy}`
-                   : 'self check' }}</p>
+                <div class="separator"></div>
+                <div class="draggable-requirements-wrapper" v-if="subReq.displayDescription">
+                  <div
+                    class="draggable-requirements-seeAll-wrapper"
+                    v-if="subReqsCourseMapList[req.group] !== undefined && subReqsCourseMapList[req.group][subReq.requirement.name] !== undefined"
+                  >
+                    <div class="draggable-requirements-seeAll-button" v-on:click="showSeeAll(req.group, req.specific, subReq.requirement.name)">{{ seeAll }}</div>
+                  </div>
+                    <div
+                      v-if="subReqsCourseMapList[req.group] !== undefined && subReqsCourseMapList[req.group][subReq.requirement.name] !== undefined"
+                      class="draggable-requirements-courses"
+                      v-dragula="subReqsCourseMapList[req.group][subReq.requirement.name]"
+                      bag="first-bag">
+                      <div v-for="course in subReqsCourseMapList[req.group][subReq.requirement.name]" :key="course.uniqueID" class="requirements-courseWrapper">
+                        <course
+                          v-bind="course"
+                          :courseObj="course"
+                          :id="course.subject + course.number"
+                          :uniqueID="course.uniqueID"
+                          :compact="course.compact"
+                          :active="false"
+                          class="requirements-course"
+                        />
+                      </div>
+                    </div>
+                  <div class="separator"></div>
                 </div>
               </div>
-              <div v-if="subReq.displayDescription" class="description">
-                {{ subReq.requirement.description }} <a class="more"
-                :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }"
-                :href="subReq.requirement.source" target="_blank">
-                <strong>Learn More</strong></a>
+
+              <div v-if="req.completed.length > 0" class="row completed">
+                <p class="col sub-title specific">Filled Requirements</p>
+                <div class="col-1 text-right">
+                  <button class="btn float-right" :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }">
+                    <!-- Toggle to display completed reqs -->
+                    <p
+                      class="toggle"
+                      v-if="req.displayCompleted"
+                      v-on:click="turnCompleted(index, false)">HIDE</p>
+                    <p class="toggle" v-else v-on:click="turnCompleted(index, true)">SHOW</p>
+                  </button>
+                </div>
+              </div>
+
+            <!-- Completed requirements -->
+              <div v-if="req.displayCompleted">
+                <div v-for="(subReq, id) in req.completed" :key="subReq.id">
+                  <div class="separator" v-if="index < reqs.length - 1 || req.displayDetails"></div>
+                  <div class="row depth-req">
+                    <div class="col-1" @click="toggleDescription(index, 'completed', id)">
+                      <button class="btn">
+                        <!-- svg for dropdown icon -->
+                      <img
+                        v-if="subReq.displayDescription"
+                    class="arrow arrow-up completed-arrow"
+                    src="@/assets/images/dropup-lightgray.svg"
+                    alt="dropup"
+                      />
+                      <img
+                        v-else
+                    class="arrow arrow-down completed-arrow"
+                    src="@/assets/images/dropdown-lightgray.svg"
+                    alt="dropdown"
+                      />
+                      </button>
+                    </div>
+                    <div class="col-7" @click="toggleDescription(index, 'completed', id)">
+                      <p class="pointer completed-ptext">{{subReq.requirement.name}}</p>
+                    </div>
+                    <div class="col">
+                      <p class="text-right completed-ptext">{{subReq.minCountFulfilled}}/{{subReq.requirement.minCount}} {{ subReq.requirement.fulfilledBy }}</p>
+                    </div>
+                  </div>
+                  <div v-if="subReq.displayDescription" class="description completed-ptext">
+                    {{ subReq.requirement.description }}
+                    <a class="more" :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }" :href="subReq.requirement.source" target="_blank"><strong>Learn More</strong></a>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          <!-- Add separator if additional completed requirements -->
+          <div class="separator" v-if="req.completed.length > 0"></div>
+          </div>
+        </div>
+      </div>
+      <div class="requirements-seeAllView" v-if="this.isSeeAll">
+        <!-- loop through reqs array of req objects -->
+        <div
+          class="req"
+          v-for="reqGroup in Object.keys(subReqsCourseMapList)"
+          :key="reqGroup.id"
+        >
+          <div
+            v-for="subReqName in Object.keys(subReqsCourseMapList[reqGroup])"
+            :key="subReqName.id"
+          >
+            <div class="row top">
+              <div class="col-1 p-0" >
+                <button :style="{ 'color': `#${reqGroupColorMap[reqGroup][0]}` }" class="btn" v-on:click="backToRequirements()">
+                  <img
+                    class="arrow arrow-left"
+                    :src="require(`@/assets/images/dropleft-${reqGroupColorMap[reqGroup][1]}.svg`)"
+                    alt="dropleft"
+                  />
+                </button>
+              </div>
+              <div class="col p-0 ">
+                  <button
+                      class="btn requirements-seeAllView-backButton"
+                      :style="{ 'color': `#${reqGroupColorMap[reqGroup][0]}` }"
+                      v-on:click="backToRequirements()">
+                      Back to All Requirements
+                  </button>
+              </div>
+            </div>
+            <h1 class="title">All {{subReqName}} Courses</h1>
+            <div class="draggable-requirements-wrapper">
                 <div
-                  v-if="subReqsCourseMapList[req.group] !== undefined && subReqsCourseMapList[req.group][subReq.requirement.name] !== undefined"
+                  v-if="subReqsCourseMapList[reqGroup] !== undefined && subReqsCourseMapList[reqGroup][subReqName] !== undefined"
                   class="draggable-requirements-courses"
-                  v-dragula="subReqsCourseMapList[req.group][subReq.requirement.name]"
+                  v-dragula="subReqsCourseMapList[reqGroup][subReqName]"
                   bag="first-bag">
-                  <div v-for="course in subReqsCourseMapList[req.group][subReq.requirement.name]" :key="course.uniqueID" class="requirements-courseWrapper">
+                  <div v-for="course in subReqsCourseMapList[reqGroup][subReqName]" :key="course.uniqueID" class="requirements-courseWrapper">
                     <course
                       v-bind="course"
                       :courseObj="course"
@@ -125,63 +255,8 @@
                     />
                   </div>
                 </div>
-              </div>
-              <div class="separator"></div>
-            </div>
-
-            <div v-if="req.completed.length > 0" class="row completed">
-              <p class="col sub-title specific">Filled Requirements</p>
-              <div class="col-1 text-right">
-                <button class="btn float-right" :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }">
-                  <!-- Toggle to display completed reqs -->
-                  <p
-                    class="toggle"
-                    v-if="req.displayCompleted"
-                    v-on:click="turnCompleted(index, false)">HIDE</p>
-                  <p class="toggle" v-else v-on:click="turnCompleted(index, true)">SHOW</p>
-                </button>
-              </div>
-            </div>
-
-          <!-- Completed requirements -->
-            <div v-if="req.displayCompleted">
-              <div v-for="(subReq, id) in req.completed" :key="subReq.id">
-                <div class="separator" v-if="index < reqs.length - 1 || req.displayDetails"></div>
-                <div class="row depth-req">
-                  <div class="col-1" @click="toggleDescription(index, 'completed', id)">
-                    <button class="btn">
-                      <!-- svg for dropdown icon -->
-                    <img
-                      v-if="subReq.displayDescription"
-                  class="arrow arrow-up completed-arrow"
-                   src="@/assets/images/dropup-lightgray.svg"
-                   alt="dropup"
-                    />
-                    <img
-                      v-else
-                  class="arrow arrow-down completed-arrow"
-                   src="@/assets/images/dropdown-lightgray.svg"
-                   alt="dropdown"
-                    />
-                    </button>
-                  </div>
-                  <div class="col-7" @click="toggleDescription(index, 'completed', id)">
-                    <p class="pointer completed-ptext">{{subReq.requirement.name}}</p>
-                  </div>
-                  <div class="col">
-                    <p class="text-right completed-ptext">{{subReq.minCountFulfilled}}/{{subReq.requirement.minCount}} {{ subReq.requirement.fulfilledBy }}</p>
-                  </div>
-                </div>
-                <div v-if="subReq.displayDescription" class="description completed-ptext">
-                  {{ subReq.requirement.description }}
-                  <a class="more" :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }" :href="subReq.requirement.source" target="_blank"><strong>Learn More</strong></a>
-                </div>
-              </div>
             </div>
           </div>
-
-        <!-- Add separator if additional completed requirements -->
-        <div class="separator" v-if="req.completed.length > 0"></div>
         </div>
       </div>
     </div>
@@ -224,6 +299,7 @@ type Data = {
   reqGroupColorMap: {};
   subReqsCourseMapList: {};
   scrollable: boolean;
+  isSeeAll: boolean;
 
 }
 export default Vue.extend({
@@ -231,6 +307,11 @@ export default Vue.extend({
     semesters: Array,
     user: Object,
     compact: Boolean
+  },
+  computed: {
+    seeAll() {
+      return 'See all >';
+    }
   },
   mounted() {
     this.$el.addEventListener('touchmove', this.dragListener, { passive: false });
@@ -272,16 +353,12 @@ export default Vue.extend({
         singleMenuRequirement.fulfilled = singleMenuRequirement.completed.length;
         singleMenuRequirement.required = singleMenuRequirement.ongoing.length + singleMenuRequirement.completed.length;
       }
+      console.log('in singleMenuReq');
       if (singleMenuRequirement.group !== 'UNIVERSITY') {
         this.subReqsCourseMapList[singleMenuRequirement.group] = {};
 
-        // isPreview param is true because only show first 4
-        this.addRequirementsCourse(singleMenuRequirement.group, singleMenuRequirement.specific, true);
-
-        // TODO: Remove once adding req courses works
-        // singleMenuRequirement.ongoing.forEach(ongoingReq => {
-        //   this.addRequirementsCourse(ongoingReq.requirement, singleMenuRequirement.group);
-        // });
+        // isSeeAll param is false because only show first 4
+        this.addRequirementsCourse(singleMenuRequirement.group, singleMenuRequirement.specific, this.isSeeAll);
       }
 
       return singleMenuRequirement;
@@ -353,7 +430,8 @@ export default Vue.extend({
       // subReqCourseMap maps from the group name to the subreq to a Course[]
       // Each item has key <group name>: <subreq name>: list of courses that fulfill the subreq
       subReqsCourseMapList: {},
-      scrollable: false
+      scrollable: false,
+      isSeeAll: false
     };
   },
   beforeDestroy() {
@@ -454,56 +532,32 @@ export default Vue.extend({
       }
       this.minors = minors;
     },
-    // TODO: Remove eventually once adding req courses works
-    // OLD VERSION OF ADDING REQ COURSES
-    // addRequirementsCourse(ongoingSubReq, reqGroup) {
-    //   console.log(reqGroup);
-    //   const ongoingSubReqName = ongoingSubReq.name;
-    //   if (ongoingSubReq.fulfilledBy !== 'self-check') {
-    //     ongoingSubReq.courses.forEach(subReqCourseObject => {
-    //       const subReqCourseObjectRosters = Object.keys(subReqCourseObject);
-    //       const roster = subReqCourseObjectRosters[subReqCourseObjectRosters.length - 1];
-    //       const courseRosterObject = subReqCourseObject[roster];
-    //       const courseRosterObjectSubjects = Object.keys(courseRosterObject);
+    // Fetches course data and updates the subReqsCourseMapList with the course
+    updateSubReqsCourseMapList(roster, subject, number, courseCode, group, subReqName, isSeeAll) {
+      fetch(`https://classes.cornell.edu/api/2.0/search/classes.json?roster=${roster}&subject=${subject}&q=${courseCode}`)
+        .then(res => res.json())
+        .then(resultJSON => {
+          if (resultJSON.data !== null) {
+            // check catalogNbr of resultJSON class matches number of course to add
+            resultJSON.data.classes.forEach(resultJSONclass => {
+              if (resultJSONclass.catalogNbr === number) {
+                const course = resultJSONclass;
+                course.roster = roster;
 
-    //       courseRosterObjectSubjects.forEach(subjectKey => {
-    //         const subject = subjectKey;
-    //         const courseRosterObjectSubjectCourses = courseRosterObject[subjectKey];
-
-    //         courseRosterObjectSubjectCourses.forEach(subjectNumber => {
-    //           const number = subjectNumber;
-    //           const courseCode = `${subject} ${number}`;
-    //           console.log(courseCode);
-    //           console.log(roster);
-
-    //           fetch(`https://classes.cornell.edu/api/2.0/search/classes.json?roster=${roster}&subject=${subject}&q=${courseCode}`)
-    //             .then(res => res.json())
-    //             .then(resultJSON => {
-    //               // check catalogNbr of resultJSON class matches number of course to add
-    //               resultJSON.data.classes.forEach(resultJSONclass => {
-    //                 if (resultJSONclass.catalogNbr === number) {
-    //                   const course = resultJSONclass;
-    //                   course.roster = roster;
-
-    //                   const newCourse = this.$parent.createCourse(course, true);
-    //                   newCourse.compact = true;
-    //                   console.log(newCourse);
-    //                   if (this.subReqsCourseMapList[reqGroup] && this.subReqsCourseMapList[reqGroup][ongoingSubReqName]) {
-    //                     this.subReqsCourseMapList[reqGroup][ongoingSubReqName].push(newCourse);
-    //                   } else {
-    //                     this.subReqsCourseMapList[reqGroup][ongoingSubReqName] = [newCourse];
-    //                   }
-    //                 }
-    //               });
-    //             });
-    //         });
-    //       });
-    //     });
-    //   }
-    //   console.log('subReqsCourseMapList');
-    //   console.log(this.subReqsCourseMapList);
-    // }
-    addRequirementsCourse(group, specific, isPreview) {
+                const newCourse = this.$parent.createCourse(course, true);
+                newCourse.compact = !isSeeAll;
+                // console.log(newCourse);
+                if (this.subReqsCourseMapList[group] && this.subReqsCourseMapList[group][subReqName]) {
+                  this.subReqsCourseMapList[group][subReqName].push(newCourse);
+                } else {
+                  this.subReqsCourseMapList[group][subReqName] = [newCourse];
+                }
+              }
+            });
+          }
+        });
+    },
+    addRequirementsCourse(group, specific, seeAllSubReqName = null, isSeeAll) {
       // "university", "college", "major", or "minor"
       const groupName = group.toLowerCase();
 
@@ -513,13 +567,13 @@ export default Vue.extend({
       const requirementsList = decoratedRequirementsJSON[groupName][specific].requirements;
 
       requirementsList.forEach(requirement => {
-        const reqName = requirement.name;
+        const subReqName = requirement.name;
 
         if (requirement.fulfilledBy !== 'self-check') {
           // console.log(requirement);
           // Only list first four courses that fulfill the requirement
-          if (isPreview) {
-            for (let i = 0; i < requirement.courses.length; i += 1) {
+          if (!isSeeAll) {
+            for (let i = 0; i < 4 && i < requirement.courses.length; i += 1) {
               // console.log(requirement.courses);
               const reqCourseObj = requirement.courses[i];
               // get roster keys for reqCourseObj, that is all rosters for a specific course
@@ -530,6 +584,7 @@ export default Vue.extend({
                 const roster = reqCourseObjRosters[reqCourseObjRosters.length - 1];
                 // console.log(roster);
 
+                // Get a list of the course codes for the 4 courses to add
                 const courseCodesToAdd = [];
                 const reqCourseRosterObjEntriesList = Object.entries(reqCourseObj[roster]);
                 for (let j = 0; courseCodesToAdd.length < 4 && j < reqCourseRosterObjEntriesList.length; j += 1) {
@@ -546,32 +601,12 @@ export default Vue.extend({
                 courseCodesToAdd.forEach(courseCodeToAdd => {
                   const courseSubjectToAdd = courseCodeToAdd.split(' ')[0];
                   const courseNumberToAdd = courseCodeToAdd.split(' ')[1];
-                  fetch(`https://classes.cornell.edu/api/2.0/search/classes.json?roster=${roster}&subject=${courseSubjectToAdd}&q=${courseCodeToAdd}`)
-                    .then(res => res.json())
-                    .then(resultJSON => {
-                      if (resultJSON.data !== null) {
-                        // check catalogNbr of resultJSON class matches number of course to add
-                        resultJSON.data.classes.forEach(resultJSONclass => {
-                          if (resultJSONclass.catalogNbr === courseNumberToAdd) {
-                            const course = resultJSONclass;
-                            course.roster = roster;
-
-                            const newCourse = this.$parent.createCourse(course, true);
-                            newCourse.compact = isPreview;
-                            // console.log(newCourse);
-                            if (this.subReqsCourseMapList[group] && this.subReqsCourseMapList[group][reqName]) {
-                              this.subReqsCourseMapList[group][reqName].push(newCourse);
-                            } else {
-                              this.subReqsCourseMapList[group][reqName] = [newCourse];
-                            }
-                          }
-                        });
-                      }
-                    });
+                  console.log(courseCodeToAdd);
+                  this.updateSubReqsCourseMapList(roster, courseSubjectToAdd, courseNumberToAdd, courseCodeToAdd, group, subReqName, isSeeAll);
                 });
               }
             }
-          } else {
+          } else if (subReqName === seeAllSubReqName) { // add all courses for a specific subReq
             for (let i = 0; i < requirement.courses.length; i += 1) {
               // console.log(requirement.courses);
               const reqCourseObj = requirement.courses[i];
@@ -583,37 +618,13 @@ export default Vue.extend({
                 const roster = reqCourseObjRosters[reqCourseObjRosters.length - 1];
                 // console.log(roster);
 
-
                 const reqCourseRosterObjEntriesList = Object.entries(reqCourseObj[roster]);
-                let addedCoursesCount = 0;
                 reqCourseRosterObjEntriesList.forEach(entry => {
                   const subject = entry[0];
                   const courseNumberList = entry[1];
                   courseNumberList.forEach(number => {
                     const courseCode = `${subject} ${number}`;
-                    fetch(`https://classes.cornell.edu/api/2.0/search/classes.json?roster=${roster}&subject=${subject}&q=${courseCode}`)
-                      .then(res => res.json())
-                      .then(resultJSON => {
-                        if (resultJSON.data !== null) {
-                          // check catalogNbr of resultJSON class matches number of course to add
-                          resultJSON.data.classes.forEach(resultJSONclass => {
-                            if (resultJSONclass.catalogNbr === number) {
-                              const course = resultJSONclass;
-                              course.roster = roster;
-
-                              const newCourse = this.$parent.createCourse(course, true);
-                              newCourse.compact = isPreview;
-                              // console.log(newCourse);
-                              if (this.subReqsCourseMapList[group] && this.subReqsCourseMapList[group][reqName]) {
-                                this.subReqsCourseMapList[group][reqName].push(newCourse);
-                              } else {
-                                this.subReqsCourseMapList[group][reqName] = [newCourse];
-                              }
-                              addedCoursesCount += 1;
-                            }
-                          });
-                        }
-                      });
+                    this.updateSubReqsCourseMapList(roster, subject, number, courseCode, group, subReqName, isSeeAll);
                   });
                 });
               }
@@ -623,6 +634,16 @@ export default Vue.extend({
           console.log(this.subReqsCourseMapList);
         }
       });
+    },
+    showSeeAll(group, specific, subReqName) {
+      this.subReqsCourseMapList = {};
+      this.subReqsCourseMapList[group] = {};
+      this.addRequirementsCourse(group, specific, subReqName, true);
+      this.isSeeAll = !this.isSeeAll;
+    },
+    backtoRequirements() {
+      this.isSeeAll = !this.isSeeAll;
+      this.subReqsCourseMapList = {};
     }
   }
 });
@@ -927,7 +948,38 @@ button.view {
   background-color: #d7d7d7;
 }
 
+.draggable-requirements {
+  &-wrapper {
+    margin-top: 2%;
+    margin-bottom: 2%;
+  }
+  &-seeAll {
+    &-wrapper {
+      display: flex;
+      justify-content: flex-end;
+    }
+    &-button {
+      font-size: 12px;
+      line-height: 15px;
+      color: #32A0F2;
+      padding: 1%;
+    }
+  }
+  &-courses{
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-left: -1%;
+    margin-bottom: 2%;
+    width: 100%;
+  }
+
+}
+
 .requirements {
+  &-courseWrapper {
+    padding: 1%;
+  }
   &-course {
     touch-action: none;
     cursor: grab;

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -311,6 +311,14 @@ export default Vue.extend({
   },
   mounted() {
     this.$el.addEventListener('touchmove', this.dragListener, { passive: false });
+    const service = Vue.$dragula.$service;
+    service.eventBus.$on('drag', () => {
+      this.scrollable = true;
+    });
+    service.eventBus.$on('drop', e => {
+      this.scrollable = true;
+      this.reqCourseDropHandler();
+    });
 
     this.getDisplays();
     const groups = computeRequirements(this.getCourseCodesArray(), this.user.college, this.user.major, this.user.minor);
@@ -349,7 +357,6 @@ export default Vue.extend({
         singleMenuRequirement.fulfilled = singleMenuRequirement.completed.length;
         singleMenuRequirement.required = singleMenuRequirement.ongoing.length + singleMenuRequirement.completed.length;
       }
-      console.log('in singleMenuReq');
       if (singleMenuRequirement.group !== 'UNIVERSITY') {
         this.subReqsCoursesMap[singleMenuRequirement.group] = {};
 
@@ -544,7 +551,6 @@ export default Vue.extend({
                   const newCourse = this.$parent.createCourse(course, true);
                   newCourse.compact = !isSeeAll;
                   newCourse.isReqCourse = true;
-                  console.log(newCourse);
                   if (this.subReqsCoursesMap[group] && this.subReqsCoursesMap[group][subReqName]) {
                     this.subReqsCoursesMap[group][subReqName].push(newCourse);
                   } else {
@@ -642,8 +648,6 @@ export default Vue.extend({
                 }
               }
             }
-            console.log('subReqsCoursesMap');
-            console.log(this.subReqsCoursesMap);
           }
         });
         Promise.all(courseAddPromises)
@@ -667,6 +671,9 @@ export default Vue.extend({
         .then(res => {
           this.isSeeAll = !this.isSeeAll;
         });
+    },
+    reqCourseDropHandler() {
+      this.$emit('reqCourseDropHandler');
     }
   }
 });

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -208,11 +208,13 @@
       </div>
       <div class="requirements-seeAllView" v-if="this.isSeeAll">
         <!-- loop through reqs array of req objects -->
+        {{Object.keys(subReqsCoursesMap)}}
         <div
           class="req"
           v-for="reqGroup in Object.keys(subReqsCoursesMap)"
           :key="reqGroup.id"
         >
+          {{Object.keys(subReqsCoursesMap[reqGroup])}}
           <div
             v-for="subReqName in Object.keys(subReqsCoursesMap[reqGroup])"
             :key="subReqName.id"
@@ -546,7 +548,8 @@ export default Vue.extend({
 
                 const newCourse = this.$parent.createCourse(course, true);
                 newCourse.compact = !isSeeAll;
-                // console.log(newCourse);
+                newCourse.isReqCourse = true;
+                console.log(newCourse);
                 if (this.subReqsCoursesMap[group] && this.subReqsCoursesMap[group][subReqName]) {
                   this.subReqsCoursesMap[group][subReqName].push(newCourse);
                 } else {

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -168,7 +168,6 @@ export default {
     });
     service.eventBus.$on('drop', e => {
       this.scrollable = true;
-      console.log(e.el);
     });
 
     this.buildCautions();

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -242,7 +242,7 @@ export default {
       confirmationModal.style.display = 'none';
     },
     addCourse(data) {
-      const newCourse = this.$parent.$parent.createCourse(data);
+      const newCourse = this.$parent.$parent.createCourse(data, false);
       this.courses.push(newCourse);
       const courseCode = `${data.subject} ${data.catalogNbr}`;
       this.openConfirmationModal(`Added ${courseCode} to ${this.type} ${this.year}`);

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -55,6 +55,7 @@
               :active="activatedCourse.uniqueID === course.uniqueID"
               class="semester-course"
               :semId="id"
+              :isReqCourse="course.isReqCourse"
               @delete-course="deleteCourse"
               @color-course="colorCourse"
               @updateBar="updateBar"
@@ -165,8 +166,9 @@ export default {
     service.eventBus.$on('drag', () => {
       this.scrollable = true;
     });
-    service.eventBus.$on('drop', () => {
+    service.eventBus.$on('drop', e => {
       this.scrollable = true;
+      console.log(e.el);
     });
 
     this.buildCautions();


### PR DESCRIPTION
### Summary <!-- Required -->
This draft pull request is the first phase of the requirements bar rework, that is, the incorporation of course cards in the requirements bar and the dragging of requirements bar courses into the schedule. At the moment, course data is gathered using the Cornell Roster API, but Firebase functions will be used instead going forward.

- [x] Generated course cards for ongoing, non self-check requirements
- [x] Requirement course card can be dragged into schedule
- [x] Implemented 'See All' feature to view more courses that fulfill a requirement

### Test Plan
When a user first loads up the requirements bar and clicks on the dropdown for a sub-requirement, if the sub-req is not self-check, then a maximum of four compact cards should be displayed. If more than four possible courses can fulfill the sub-req, a 'See All' option is displayed. When a user clicks on the 'See All' button, the requirements bar changes to a list of regular-sized course cards of 4+ courses that fulfill that sub-req. Requirements course cards should be draggable into the schedule.

### Notes for Future TODOs
- [ ] Get rid of any ts errors
- [ ] Use Firebase functions to fetch course data from courses json
- [ ] Refine dragging (i.e. prevent schedule cards from being dragged in, drag a copy of req course card)
- [ ] For the 'See All' option, consider fetching courses in batches
- [ ] For the 'See All' option, get courses not just from the most recent semester (i.e. maybe most recent spring and most recent fall?)


