### PR TITLE
Standardize bot tokens in CI

### DIFF
--- a/.github/workflows/cleanup-workflow.yml
+++ b/.github/workflows/cleanup-workflow.yml
@@ -13,7 +13,7 @@ jobs:
           ref: gh-pages
       - name: Purge Static Assets
         env:
-          ACCESS_TOKEN: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           git rm -rf ${{ github.event.number }} || echo "Nothing to remove"
           git config user.name "deployment-bot"


### PR DESCRIPTION
### Summary

GitHub finally supports [org-wide secrets](https://github.blog/changelog/2020-05-14-organization-secrets/). It's time to migrate away repo-specific tokens, and use the org-wide token `BOT_TOKEN` and `FIREBASE_TOKEN` instead. It makes it much easier to routinely rotate the tokens for better security.

### Test Plan

Everything should still pass in CI.