### PR TITLE
Implement phase 1, 2-1, 3-1 for requirement graph builder

### DIFF
--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -1,0 +1,151 @@
+import buildRequirementFulfillmentGraph from '../requirement-graph-builder';
+
+const requirements = ['CS3410/CS3420', 'Probability', 'Elective'];
+const getUniqueID = (it: string) => it;
+const getAllCoursesThatCanPotentiallySatisfyRequirement = (
+  requirement: string
+): readonly string[] => {
+  switch (requirement) {
+    case 'CS3410/CS3420':
+      return ['CS3410', 'CS3420'];
+    case 'Probability':
+      return ['MATH4710'];
+    case 'Elective':
+      return ['CS3410', 'CS3420', 'MATH4710'];
+    default:
+      throw new Error('Should not get here!');
+  }
+};
+// If choice is 1, pick 3410 fulfillment strategy, else, choose 3420
+const getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy = (
+  choice: 1 | 2
+) => ({
+  correspondingRequirement: 'CS3410/CS3420',
+  coursesOfChosenFulfillmentStrategy: [choice === 1 ? 'CS3410' : 'CS3420']
+});
+
+it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
+  const graph = buildRequirementFulfillmentGraph({
+    requirements,
+    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: [],
+    userChoiceOnDoubleCountingElimiation: [],
+    getRequirementUniqueID: getUniqueID,
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+  });
+
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410', 'CS3420']);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([
+    'CS3410',
+    'CS3420',
+    'MATH4710'
+  ]);
+});
+
+// This test ensures that we are actually using userCourses and drop any courses from pre-computed
+// course list that are not in userCourses.
+it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
+  const graph = buildRequirementFulfillmentGraph({
+    requirements,
+    userCourses: ['CS3410', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: [],
+    userChoiceOnDoubleCountingElimiation: [],
+    getRequirementUniqueID: getUniqueID,
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+  });
+
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual(['CS3410', 'MATH4710']);
+});
+
+// Following two tests test how we are removing edges depending on user choices on fulfillment strategy.
+it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
+  const graph = buildRequirementFulfillmentGraph<string, string, 1 | 2>({
+    requirements,
+    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: [1],
+    userChoiceOnDoubleCountingElimiation: [],
+    getRequirementUniqueID: getUniqueID,
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+  });
+
+  // In this case, 3420 is removed since user chooses strategy 1.
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([
+    'CS3410',
+    'CS3420',
+    'MATH4710'
+  ]);
+});
+
+it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
+  const graph = buildRequirementFulfillmentGraph<string, string, 1 | 2>({
+    requirements,
+    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: [2],
+    userChoiceOnDoubleCountingElimiation: [],
+    getRequirementUniqueID: getUniqueID,
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+  });
+
+  // In this case, 3410 is removed since user chooses strategy 1.
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3420']);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([
+    'CS3410',
+    'CS3420',
+    'MATH4710'
+  ]);
+});
+
+// The following two tests test that we will remove edges incompatible with user supplied choices.
+it('buildRequirementFulfillmentGraph phase 3-1 test 1', () => {
+  const graph = buildRequirementFulfillmentGraph<string, string, 1 | 2>({
+    requirements,
+    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: [1],
+    userChoiceOnDoubleCountingElimiation: [['Probability', 'MATH4710']],
+    getRequirementUniqueID: getUniqueID,
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+  });
+
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
+  // We need a functional phase 3-2 to eliminate CS3410 here.
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual(['CS3410', 'CS3420']);
+});
+
+it('buildRequirementFulfillmentGraph phase 3-1 test 2', () => {
+  const graph = buildRequirementFulfillmentGraph<string, string, 1 | 2>({
+    requirements,
+    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: [1],
+    userChoiceOnDoubleCountingElimiation: [['Elective', 'MATH4710']],
+    getRequirementUniqueID: getUniqueID,
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+  });
+
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([]);
+  // We need a functional phase 3-2 to eliminate CS3410 here.
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([
+    'CS3410',
+    'CS3420',
+    'MATH4710'
+  ]);
+});

--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -99,7 +99,7 @@ it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
     getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
   });
 
-  // In this case, 3410 is removed since user chooses strategy 1.
+  // In this case, 3410 is removed since user chooses strategy 2.
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3420']);
   expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
   expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -33,7 +33,7 @@ type BuildRequirementFulfillmentGraphParameters<
   /** See RequirementFulfillmentGraph for its usage. */
   readonly getCourseUniqueID: (c: Course) => string;
   /**
-   * Aaively give a list of courses that can satisfy a requirement. Most of the time this function
+   * Naively give a list of courses that can satisfy a requirement. Most of the time this function
    * should just return the pre-computed course list. For requirements have multiple fulfillment
    * strategies, it will return the union of all pre-computed course list.
    */

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -1,0 +1,122 @@
+import RequirementFulfillmentGraph from './requirement-graph';
+import { HashMap } from './util/collections';
+
+type BuildRequirementFulfillmentGraphParameters<
+  Requirement,
+  Course,
+  UserChoiceOnFulfillmentStrategy
+> = {
+  /**
+   * A list of applicable requirements in the system. e.g. if the user is CS major
+   * in COE, then the list should contain all university requirements, COE requirements, and CS major
+   * requirements.
+   */
+  readonly requirements: readonly Requirement[];
+  /** A list of courses user inputted into course plan, regardless of semesters. */
+  readonly userCourses: readonly Course[];
+  /**
+   * Some requirements might have several different ways to fulfill them. This is a list of objects
+   * that describe user's choices. The exact shape of the object is opaque to function. The only way
+   * for this function to use objects in this array is via
+   * `getAllRelevantCoursesUnderFulfillmentStrategy`.
+   */
+  readonly userChoiceOnFulfillmentStrategy: readonly UserChoiceOnFulfillmentStrategy[];
+  /**
+   * A list of (requirement, course) tuple that describe how the user decides how a course is used to
+   * satisfy requirements. Suppose a course c can be used to satisfy both r1 and r2, but the
+   * requirements do not allow double counting, then a tuple (r1, c) means that we should keep the
+   * (r1, c) edge in the graph and drop the (r2, c) edge.
+   */
+  readonly userChoiceOnDoubleCountingElimiation: readonly (readonly [Requirement, Course])[];
+  /** See RequirementFulfillmentGraph for its usage. */
+  readonly getRequirementUniqueID: (r: Requirement) => string;
+  /** See RequirementFulfillmentGraph for its usage. */
+  readonly getCourseUniqueID: (c: Course) => string;
+  /**
+   * Aaively give a list of courses that can satisfy a requirement. Most of the time this function
+   * should just return the pre-computed course list. For requirements have multiple fulfillment
+   * strategies, it will return the union of all pre-computed course list.
+   */
+  readonly getAllCoursesThatCanPotentiallySatisfyRequirement: (
+    requirement: Requirement
+  ) => readonly Course[];
+  /**
+   * For a requirement with multiple fulfillment strategies, this function should return the list of
+   * courses bind to one fulfillment strategies.
+   */
+  readonly getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy: (
+    choice: UserChoiceOnFulfillmentStrategy
+  ) => {
+    readonly correspondingRequirement: Requirement;
+    readonly coursesOfChosenFulfillmentStrategy: Course[];
+  };
+};
+
+const buildRequirementFulfillmentGraph = <Requirement, Course, UserChoiceOnFulfillmentStrategy>({
+  requirements,
+  userCourses,
+  userChoiceOnFulfillmentStrategy,
+  userChoiceOnDoubleCountingElimiation,
+  getRequirementUniqueID,
+  getCourseUniqueID,
+  getAllCoursesThatCanPotentiallySatisfyRequirement,
+  getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+}: BuildRequirementFulfillmentGraphParameters<
+  Requirement,
+  Course,
+  UserChoiceOnFulfillmentStrategy
+>): RequirementFulfillmentGraph<Requirement, Course> => {
+  const graph = new RequirementFulfillmentGraph(getRequirementUniqueID, getCourseUniqueID);
+  const userCourseSet = new HashMap<Course, null>(getCourseUniqueID);
+  userCourses.forEach(course => userCourseSet.set(course, null));
+
+  // Phase 1:
+  //   Building a rough graph by naively connecting requirements and courses based on
+  //   `getAllCoursesThatCanPotentiallySatisfyRequirement`.
+  requirements.forEach(requirement => {
+    getAllCoursesThatCanPotentiallySatisfyRequirement(requirement).forEach(course => {
+      if (userCourseSet.has(course)) graph.addEdge(requirement, course);
+    });
+  });
+
+  // Phase 2-1: Respect user's choices on fulfillment strategies.
+  userChoiceOnFulfillmentStrategy.forEach(choice => {
+    const {
+      correspondingRequirement,
+      coursesOfChosenFulfillmentStrategy
+    } = getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy(choice);
+    const coursesToKeepSet = new HashMap<Course, null>(getCourseUniqueID);
+    coursesOfChosenFulfillmentStrategy.forEach(course => coursesToKeepSet.set(course, null));
+
+    graph.getConnectedCoursesFromRequirement(correspondingRequirement).forEach(connectedCourse => {
+      if (!coursesToKeepSet.has(connectedCourse)) {
+        graph.removeEdge(correspondingRequirement, connectedCourse);
+      }
+    });
+  });
+
+  // Phase 2-2:
+  //   Auto-select fulfillment for requirements with multiple fulfillment strategies
+  //   but without user choice.
+  // TODO: not implemented.
+
+  // Phase 3-1: Respect user's choices on double-counted courses.
+  userChoiceOnDoubleCountingElimiation.forEach(([chosenRequirement, course]) => {
+    const chosenRequirementUniqueID = getRequirementUniqueID(chosenRequirement);
+
+    graph.getConnectedRequirementsFromCourse(course).forEach(connectedRequirement => {
+      if (getRequirementUniqueID(connectedRequirement) !== chosenRequirementUniqueID) {
+        graph.removeEdge(connectedRequirement, course);
+      }
+    });
+  });
+
+  // Phase 3-2: Auto-choose a requirement-course pair for double counted courses without user choice.
+  // TODO: not implemented.
+  // Important note for this phase: We need to support requirements that allow double counting.
+
+  // Phase MAX_INT: PROFIT!
+  return graph;
+};
+
+export default buildRequirementFulfillmentGraph;


### PR DESCRIPTION
### Summary <!-- Required -->

This PR implements part of the 3-phase algorithm defined in this issue comment: https://github.com/cornell-dti/course-plan/issues/139#issuecomment-694641551. I omitted phase 2-2 and phase 3-2 in this PR to keep it relatively small. Phase 2-2 and 3-2 are tricky enough to deserve their own PRs.

Similar to #140, I keep the type of requirement, course and user choice type generic, so that the algorithm itself is flexible enough to allow different types of requirement, course and user choice representation. Information is extracted from those objects via functions like `getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy`. In this way, we can easily write unit tests that can have a very different representation of `Requirement`, `Course`, etc compared to prod code. As a result, we can write tests using raw strings as requirement/courses to get easily-understable test assertions. It also allows us to keep this function unchanged while we are changing concrete requirement and course type for frontend UI
purposes.

### Test Plan <!-- Required -->

`npm run test`

The added test no only tests the function, but also serves as a tutorial on how to use my `buildRequirementFulfillmentGraph` function.