### PR TITLE
Connect requirement graph algorithm to req-functions

### DIFF
--- a/src/requirements/__test__/requirement-graph.test.ts
+++ b/src/requirements/__test__/requirement-graph.test.ts
@@ -61,3 +61,17 @@ it('RequirementFulfillmentGraph works.', () => {
   expect(graph.existsEdge('Probability', 'MATH 4710')).toBeFalsy();
   expect(graph.existsEdge('Elective', 'MATH 4710')).toBeTruthy();
 });
+
+it('RequirementFulfillmentGraph.addRequirementNode() works', () => {
+  const graph = new RequirementFulfillmentGraph<string, string>(
+    s => s,
+    s => s
+  );
+  graph.addRequirementNode('foo');
+  expect(graph.getAllRequirements()).toEqual(['foo']);
+
+  // Test that adding node already exist doesn't erase edges connection.
+  graph.addEdge('foo', 'bar');
+  graph.addRequirementNode('foo');
+  expect(graph.getConnectedCoursesFromRequirement('foo')).toEqual(['bar']);
+});

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -214,15 +214,15 @@ export function computeRequirements(
     reqs: computeUniversityRequirementFulfillments(coursesTaken)
   });
 
-  // PART 2: check college & major requirements
+  // PART 2: check college & major & minor requirements
   if (!(college in requirementJson.college)) throw new Error('College not found.');
   const collegeReqs = requirementJson.college[college];
 
-  type DecoratedCollegeOrMajorRequirementWithSourceType = DecoratedCollegeOrMajorRequirement & {
+  type RequirementWithSourceType = DecoratedCollegeOrMajorRequirement & {
     readonly sourceType: 'College' | 'Major' | 'Minor';
     readonly sourceSpecificName: string;
   };
-  const requirementsToBeConsideredInGraph: readonly DecoratedCollegeOrMajorRequirementWithSourceType[] = [
+  const requirementsToBeConsideredInGraph: readonly RequirementWithSourceType[] = [
     ...collegeReqs.requirements.map(
       it => ({ ...it, sourceType: 'College', sourceSpecificName: college } as const)
     ),
@@ -247,7 +247,7 @@ export function computeRequirements(
   ];
 
   const requirementFulfillmentGraph = buildRequirementFulfillmentGraph<
-    DecoratedCollegeOrMajorRequirementWithSourceType,
+    RequirementWithSourceType,
     CourseTaken,
     undefined
   >({
@@ -288,7 +288,7 @@ export function computeRequirements(
   });
 
   type FulfillmentStatistics = {
-    readonly requirement: DecoratedCollegeOrMajorRequirementWithSourceType;
+    readonly requirement: RequirementWithSourceType;
     readonly courses: readonly (readonly CourseTaken[])[];
   } & RequirementFulfillmentStatistics;
   const collegeFulfillmentStatistics: FulfillmentStatistics[] = [];

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -124,56 +124,6 @@ function filterAndPartitionCoursesThatFulfillRequirement(
   return coursesThatFulfilledRequirement;
 }
 
-/**
- * @param coursesTaken a list of all taken courses.
- * @param allRequirements a list of all requirements to check.
- * @returns a naively computed list of requirement fulfillment, without any filtering and post-processing.
- */
-function computeRawRequirementFulfillment(
-  coursesTaken: readonly CourseTaken[],
-  allRequirements: readonly DecoratedCollegeOrMajorRequirement[]
-): readonly RequirementFulfillment<{}>[] {
-  return allRequirements.map(requirement => ({
-    requirement,
-    courses: filterAndPartitionCoursesThatFulfillRequirement(coursesTaken, requirement)
-  }));
-}
-
-/**
- * A monad that provides a post-processing framework for requirement fulfillment.
- *
- * Usage:
- * ```typescript
- * const filfillments = [
- *   { requirement: req1, courses: [c1, c2, c3], foo: 1 },
- *   { requirement: req2, courses: [c1, c3], foo: 2 },
- * ];
- * const processedFilfillments = postProcessRequirementsFulfillments(
- *   filfillments,
- *   ({ courses, foo }) => ({ bar: courses.length + foo })
- * );
- * // Will produce:
- * [
- *   { requirement: req1, courses: [c1, c2, c3], bar: 4 }, // bar = 3 + 1 = 4
- *   { requirement: req2, courses: [c1, c3], bar: 4 }, // bar = 2 + 2 = 4
- * ]
- * ```
- *
- * @param fulfillments a list of requirement fulfillment to post-process.
- * @param transformer the transformer that computes the new metadata.
- * @returns the post-processed requirement filfillments.
- */
-function postProcessRequirementsFulfillments<T extends {}, R extends {}>(
-  fulfillments: readonly RequirementFulfillment<T>[],
-  transformer: (currentFulfillmentWithMetadata: RequirementFulfillment<T>) => R
-): readonly RequirementFulfillment<R>[] {
-  return fulfillments.map(requirementFulfillment => {
-    const { requirement, courses } = requirementFulfillment;
-    const newMetadata = transformer(requirementFulfillment);
-    return { requirement, courses, ...newMetadata };
-  });
-}
-
 function computeFulfillmentStatistics<T extends {}>({ requirement, courses: coursesThatFulfilledRequirement }: RequirementFulfillment<T>): RequirementFulfillmentStatistics {
   let minCountFulfilled = 0;
   coursesThatFulfilledRequirement.forEach(coursesThatFulfilledSubRequirement => {
@@ -241,27 +191,6 @@ function computeFulfillmentStatistics<T extends {}>({ requirement, courses: cour
 }
 
 /**
- * @param allCoursesTakenWithInfo : object of courses taken with API information (CS 2110: {info})
- * @param allRequirements : requirements in requirements format from reqs.json (college, major, or university requirements)
- * @returns a list of university requirement filfillment status.
- */
-function computeCollegeOrMajorRequirementFulfillments(
-  coursesTaken: readonly CourseTaken[],
-  allRequirements: readonly DecoratedCollegeOrMajorRequirement[]
-): readonly RequirementFulfillment<RequirementFulfillmentStatistics>[] {
-  // Phase 1: Compute raw requirement fulfillment locally for each requirement.
-  const rawRequirementFulfillment = computeRawRequirementFulfillment(coursesTaken, allRequirements);
-
-  // Phase 2: Compute fulfillment statistics for each requirement.
-  const requirementFulfillmentWithStatistics = postProcessRequirementsFulfillments(
-    rawRequirementFulfillment,
-    computeFulfillmentStatistics
-  );
-
-  return requirementFulfillmentWithStatistics;
-}
-
-/**
  * @param coursesTaken a list of classes taken by the user, with some metadata (e.g. no. of credits)
  * helping to compute requirement progress.
  * @param college user's college.
@@ -285,46 +214,135 @@ export function computeRequirements(
     reqs: computeUniversityRequirementFulfillments(coursesTaken)
   });
 
-  // PART 2: check college requirements
+  // PART 2: check college & major requirements
   if (!(college in requirementJson.college)) throw new Error('College not found.');
   const collegeReqs = requirementJson.college[college];
+
+  type DecoratedCollegeOrMajorRequirementWithSourceType = DecoratedCollegeOrMajorRequirement & {
+    readonly sourceType: 'College' | 'Major' | 'Minor';
+    readonly sourceSpecificName: string;
+  };
+  const requirementsToBeConsideredInGraph: readonly DecoratedCollegeOrMajorRequirementWithSourceType[] = [
+    ...collegeReqs.requirements.map(
+      it => ({ ...it, sourceType: 'College', sourceSpecificName: college } as const)
+    ),
+    ...(majors || [])
+      .map(major => {
+        const majorRequirement = requirementJson.major[major];
+        if (majorRequirement == null) return [];
+        return majorRequirement.requirements.map(
+          it => ({ ...it, sourceType: 'Major', sourceSpecificName: major } as const)
+        );
+      })
+      .flat(),
+    ...(minors || [])
+      .map(minor => {
+        const minorRequirement = requirementJson.minor[minor];
+        if (minorRequirement == null) return [];
+        return minorRequirement.requirements.map(
+          it => ({ ...it, sourceType: 'Minor', sourceSpecificName: minor } as const)
+        );
+      })
+      .flat()
+  ];
+
+  const requirementFulfillmentGraph = buildRequirementFulfillmentGraph<
+    DecoratedCollegeOrMajorRequirementWithSourceType,
+    CourseTaken,
+    undefined
+  >({
+    requirements: requirementsToBeConsideredInGraph,
+    userCourses: coursesTaken,
+    userChoiceOnFulfillmentStrategy: [],
+    userChoiceOnDoubleCountingElimiation: [],
+    // TODO assign an unique ID to each requirement entry.
+    getRequirementUniqueID: requirement => `${requirement.name} ${requirement.description}`,
+    getCourseUniqueID: course => course.code,
+    getAllCoursesThatCanPotentiallySatisfyRequirement: requirement => (
+      requirement.courses
+        .map((eligibleCourses): readonly CourseTaken[] => {
+          const courses: CourseTaken[] = [];
+          Object.entries(eligibleCourses).forEach(([roster, mapping]) => {
+            Object.entries(mapping).forEach(([subject, numbers]) => {
+              numbers.forEach(number => {
+                courses.push({
+                  roster,
+                  subject,
+                  code: `${roster}: ${subject} ${number}`,
+                  number,
+                  credits: 0
+                });
+              });
+            });
+          });
+          return courses;
+        })
+        .flat()
+    ),
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy: () => ({
+      // Give back dummy value for now. Give it a real strategy when we have non-empty
+      // userChoiceOnFulfillmentStrategy
+      correspondingRequirement: requirementsToBeConsideredInGraph[0],
+      coursesOfChosenFulfillmentStrategy: []
+    })
+  });
+
+  type FulfillmentStatistics = {
+    readonly requirement: DecoratedCollegeOrMajorRequirementWithSourceType;
+    readonly courses: readonly (readonly CourseTaken[])[];
+  } & RequirementFulfillmentStatistics;
+  const collegeFulfillmentStatistics: FulfillmentStatistics[] = [];
+  const majorFulfillmentStatisticsMap = new Map<string, FulfillmentStatistics[]>();
+  const minorFulfillmentStatisticsMap = new Map<string, FulfillmentStatistics[]>();
+  requirementFulfillmentGraph.getAllRequirements().forEach(requirement => {
+    const courses = requirementFulfillmentGraph.getConnectedCoursesFromRequirement(requirement);
+    const requirementAndCourses = {
+      requirement,
+      courses: filterAndPartitionCoursesThatFulfillRequirement(courses, requirement)
+    };
+    const fulfillmentStatistics = {
+      ...requirementAndCourses, ...computeFulfillmentStatistics(requirementAndCourses)
+    };
+
+    switch (requirement.sourceType) {
+      case 'College':
+        collegeFulfillmentStatistics.push(fulfillmentStatistics);
+        break;
+      case 'Major': {
+        const existingArray = majorFulfillmentStatisticsMap.get(requirement.sourceSpecificName);
+        if (existingArray != null) {
+          existingArray.push(fulfillmentStatistics);
+        } else {
+          majorFulfillmentStatisticsMap.set(requirement.sourceSpecificName, [fulfillmentStatistics]);
+        }
+        break;
+      }
+      case 'Minor': {
+        const existingArray = minorFulfillmentStatisticsMap.get(requirement.sourceSpecificName);
+        if (existingArray != null) {
+          existingArray.push(fulfillmentStatistics);
+        } else {
+          minorFulfillmentStatisticsMap.set(requirement.sourceSpecificName, [fulfillmentStatistics]);
+        }
+        break;
+      }
+      default:
+        throw new Error();
+    }
+  });
 
   groups.push({
     groupName: 'College',
     specific: college,
-    reqs: computeCollegeOrMajorRequirementFulfillments(coursesTaken, collegeReqs.requirements)
+    reqs: collegeFulfillmentStatistics
   });
 
-  // PART 3: check major reqs
-  // Major is optional
-  if (majors != null) {
-    for (const maj of majors) {
-      if (maj in requirementJson.major) {
-        const majorReqs = requirementJson.major[maj];
-        groups.push({
-          groupName: 'Major',
-          specific: maj,
-          reqs: computeCollegeOrMajorRequirementFulfillments(coursesTaken, majorReqs.requirements)
-        });
-      }
-    }
-  }
-
-  // PART 4: check minor reqs
-  // Major is optional
-  if (minors != null) {
-    for (const min of minors) {
-      if (min in requirementJson.minor) {
-        const minorReqs = requirementJson.minor[min];
-        groups.push({
-          groupName: 'Minor',
-          specific: min,
-          reqs: computeCollegeOrMajorRequirementFulfillments(coursesTaken, minorReqs.requirements)
-        });
-      }
-    }
-  }
-
+  majorFulfillmentStatisticsMap.forEach((fulfillmentStatistics, majorName) => {
+    groups.push({ groupName: 'Major', specific: majorName, reqs: fulfillmentStatistics });
+  });
+  minorFulfillmentStatisticsMap.forEach((fulfillmentStatistics, minorName) => {
+    groups.push({ groupName: 'Minor', specific: minorName, reqs: fulfillmentStatistics });
+  });
 
   return groups;
 }

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -67,15 +67,17 @@ const buildRequirementFulfillmentGraph = <Requirement, Course, UserChoiceOnFulfi
   UserChoiceOnFulfillmentStrategy
 >): RequirementFulfillmentGraph<Requirement, Course> => {
   const graph = new RequirementFulfillmentGraph(getRequirementUniqueID, getCourseUniqueID);
-  const userCourseSet = new HashMap<Course, null>(getCourseUniqueID);
-  userCourses.forEach(course => userCourseSet.set(course, null));
+  const userCourseSet = new HashMap<Course, Course>(getCourseUniqueID);
+  userCourses.forEach(course => userCourseSet.set(course, course));
 
   // Phase 1:
   //   Building a rough graph by naively connecting requirements and courses based on
   //   `getAllCoursesThatCanPotentiallySatisfyRequirement`.
   requirements.forEach(requirement => {
+    graph.addRequirementNode(requirement);
     getAllCoursesThatCanPotentiallySatisfyRequirement(requirement).forEach(course => {
-      if (userCourseSet.has(course)) graph.addEdge(requirement, course);
+      const userCourse = userCourseSet.get(course);
+      if (userCourse != null) graph.addEdge(requirement, userCourse);
     });
   });
 

--- a/src/requirements/requirement-graph.ts
+++ b/src/requirements/requirement-graph.ts
@@ -42,6 +42,12 @@ export default class RequirementFulfillmentGraph<Requirement, Course> {
     return edges;
   }
 
+  public addRequirementNode(requirement: Requirement): void {
+    if (!this.requirementToCoursesMap.has(requirement)) {
+      this.requirementToCoursesMap.set(requirement, new HashSet(this.getCourseUniqueID));
+    }
+  }
+
   public addEdge(requirement: Requirement, course: Course): void {
     let existingCoursesLinkedToRequirement = this.requirementToCoursesMap.get(requirement);
     if (existingCoursesLinkedToRequirement == null) {

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -106,7 +106,7 @@ export type RequirementFulfillment<M extends {}> = {
   /** The original requirement object. */
   readonly requirement: BaseRequirement;
   /** A list of courses that satisfy this requirement. */
-  readonly courses: readonly CourseTaken[][];
+  readonly courses: readonly (readonly CourseTaken[])[];
 } & M;
 
 export type RequirementFulfillmentStatistics = {

--- a/src/requirements/util/collections.ts
+++ b/src/requirements/util/collections.ts
@@ -19,7 +19,8 @@ export class HashMap<K, V> {
   }
 
   get(key: K): V | undefined {
-    return this.backingMap.get(this.getUniqueHash(key))?.[1];
+    const entry = this.backingMap.get(this.getUniqueHash(key));
+    return entry == null ? undefined : entry[1];
   }
 
   has(key: K): boolean {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request connects my graph algorithm previously developed in isolation to the req-functions that are directly interacting with frontend. This is designed to be a 1-1 migration, so it doesn't introduce the ability of eliminating double-counting and fulfillment strategy choice yet.

Some code in the graph algorithm is tweaked a little bit to help resolve some bugs, which I will explain in individual comments. The change might look scary, but it's mostly replacing this block of code

https://github.com/cornell-dti/course-plan/blob/2af5e71a01dc534b7aeb977ea6006b46eff06808/src/requirements/reqs-functions.ts#L127-L175

with my graph algorithm.

### Test Plan <!-- Required -->

CI, and the requirement checks still work fine for me:

<img width="1680" alt="Screen Shot 2020-10-07 at 16 38 40" src="https://user-images.githubusercontent.com/4290500/95385149-95cbcc80-08bb-11eb-9af5-0bfd3f31f9e3.png">
