### PR TITLE
Report illegally double-counted courses during requirement computation

### DIFF
--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -25,7 +25,7 @@ const getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy =
 });
 
 it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
-  const graph = buildRequirementFulfillmentGraph({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
     userChoiceOnFulfillmentStrategy: [],
@@ -33,7 +33,8 @@ it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
     getRequirementUniqueID: getUniqueID,
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+    allowDoubleCounting: () => false
   });
 
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410', 'CS3420']);
@@ -48,7 +49,7 @@ it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
 // This test ensures that we are actually using userCourses and drop any courses from pre-computed
 // course list that are not in userCourses.
 it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
-  const graph = buildRequirementFulfillmentGraph({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
     userCourses: ['CS3410', 'MATH4710'],
     userChoiceOnFulfillmentStrategy: [],
@@ -56,7 +57,8 @@ it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
     getRequirementUniqueID: getUniqueID,
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+    allowDoubleCounting: () => false
   });
 
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
@@ -66,7 +68,11 @@ it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
 
 // Following two tests test how we are removing edges depending on user choices on fulfillment strategy.
 it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
-  const graph = buildRequirementFulfillmentGraph<string, string, 1 | 2>({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<
+    string,
+    string,
+    1 | 2
+  >({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
     userChoiceOnFulfillmentStrategy: [1],
@@ -74,7 +80,8 @@ it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
     getRequirementUniqueID: getUniqueID,
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+    allowDoubleCounting: () => false
   });
 
   // In this case, 3420 is removed since user chooses strategy 1.
@@ -88,7 +95,11 @@ it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
 });
 
 it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
-  const graph = buildRequirementFulfillmentGraph<string, string, 1 | 2>({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<
+    string,
+    string,
+    1 | 2
+  >({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
     userChoiceOnFulfillmentStrategy: [2],
@@ -96,7 +107,8 @@ it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
     getRequirementUniqueID: getUniqueID,
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+    allowDoubleCounting: () => false
   });
 
   // In this case, 3410 is removed since user chooses strategy 2.
@@ -110,8 +122,12 @@ it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
 });
 
 // The following two tests test that we will remove edges incompatible with user supplied choices.
-it('buildRequirementFulfillmentGraph phase 3-1 test 1', () => {
-  const graph = buildRequirementFulfillmentGraph<string, string, 1 | 2>({
+it('buildRequirementFulfillmentGraph phase 3 test 1', () => {
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<
+    string,
+    string,
+    1 | 2
+  >({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
     userChoiceOnFulfillmentStrategy: [1],
@@ -119,7 +135,8 @@ it('buildRequirementFulfillmentGraph phase 3-1 test 1', () => {
     getRequirementUniqueID: getUniqueID,
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+    allowDoubleCounting: () => false
   });
 
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
@@ -128,8 +145,12 @@ it('buildRequirementFulfillmentGraph phase 3-1 test 1', () => {
   expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual(['CS3410', 'CS3420']);
 });
 
-it('buildRequirementFulfillmentGraph phase 3-1 test 2', () => {
-  const graph = buildRequirementFulfillmentGraph<string, string, 1 | 2>({
+it('buildRequirementFulfillmentGraph phase 3 test 2', () => {
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<
+    string,
+    string,
+    1 | 2
+  >({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
     userChoiceOnFulfillmentStrategy: [1],
@@ -137,7 +158,8 @@ it('buildRequirementFulfillmentGraph phase 3-1 test 2', () => {
     getRequirementUniqueID: getUniqueID,
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+    allowDoubleCounting: () => false
   });
 
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
@@ -148,4 +170,67 @@ it('buildRequirementFulfillmentGraph phase 3-1 test 2', () => {
     'CS3420',
     'MATH4710'
   ]);
+});
+
+// The following 3 tests test that we will detect all double counted courses.
+it('buildRequirementFulfillmentGraph phase 4 test 1', () => {
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string, 1 | 2>(
+    {
+      requirements,
+      userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+      userChoiceOnFulfillmentStrategy: [1],
+      userChoiceOnDoubleCountingElimiation: [
+        ['CS3410/CS3420', 'CS3410'],
+        ['Probability', 'MATH4710']
+      ],
+      getRequirementUniqueID: getUniqueID,
+      getCourseUniqueID: getUniqueID,
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+      allowDoubleCounting: () => false
+    }
+  );
+
+  // User specified how to break tie for every double-counted courses, so we are happy here.
+  expect(illegallyDoubleCountedCourses).toEqual([]);
+});
+
+it('buildRequirementFulfillmentGraph phase 4 test 2', () => {
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string, 1 | 2>(
+    {
+      requirements,
+      userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+      userChoiceOnFulfillmentStrategy: [1],
+      userChoiceOnDoubleCountingElimiation: [['CS3410/CS3420', 'CS3410']],
+      getRequirementUniqueID: getUniqueID,
+      getCourseUniqueID: getUniqueID,
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+      allowDoubleCounting: () => false
+    }
+  );
+
+  // User doesn't specify whether to use MATH4710 to fulfill elective or probability, so MATH4710
+  // appears in the double counted list.
+  expect(illegallyDoubleCountedCourses).toEqual(['MATH4710']);
+});
+
+it('buildRequirementFulfillmentGraph phase 4 test 3', () => {
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string, 1 | 2>(
+    {
+      requirements,
+      userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+      userChoiceOnFulfillmentStrategy: [1],
+      userChoiceOnDoubleCountingElimiation: [['CS3410/CS3420', 'CS3410']],
+      getRequirementUniqueID: getUniqueID,
+      getCourseUniqueID: getUniqueID,
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
+      allowDoubleCounting: requirement => requirement === 'Probability'
+    }
+  );
+
+  // Similar to the test case above, but we allowed Probability to be double-counted, so the list is
+  // empty.
+  expect(illegallyDoubleCountedCourses).toEqual([]);
 });

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -246,7 +246,7 @@ export function computeRequirements(
       .flat()
   ];
 
-  const requirementFulfillmentGraph = buildRequirementFulfillmentGraph<
+  const { requirementFulfillmentGraph } = buildRequirementFulfillmentGraph<
     RequirementWithSourceType,
     CourseTaken,
     undefined
@@ -284,7 +284,10 @@ export function computeRequirements(
       // userChoiceOnFulfillmentStrategy
       correspondingRequirement: requirementsToBeConsideredInGraph[0],
       coursesOfChosenFulfillmentStrategy: []
-    })
+    }),
+    // TODO: Replace this dummy implementation once we decided how to determine if a requirement is
+    // double-countable. Meanwhile, make it always return true to match the old behavior.
+    allowDoubleCounting: () => true
   });
 
   type FulfillmentStatistics = {


### PR DESCRIPTION
### Summary <!-- Required -->

According to our meeting in the Saturday, we decided to give up on enforcing that we have a graph free of double-counted courses all the time. Instead, we give warnings. This diff implements the decision.

Now in additional to the graph, we also return a list of **illegally** double-counted courses. The word *illegal* is important here, since we know that they are requirements that explicitly allow double-counting (e.g. probability requirement in engineering). To account for the requirement that can be double-counted, we use the return value from the new function `allowDoubleCounting: (requirement: Requirement) => boolean` passed to the graph computation algorithm.

The frontend UI can then look up the graph for each illegally double-counted course to decide what warning message to display. e.g. `MATH 4710` is in the list. After looking up the graph from `MATH 4710`, we found that it's connected to `CHEM requirement` and `external specialization` requirements that both don't allow double-counting, then we can show warning messages like `MATH 4710 is used to satisfy both CHEM requirement and external specialization, but both requirements don't allow double counting`.

### Test Plan <!-- Required -->

`yarn test`

Modified the old unit tests to add `allowDoubleCounting` parameter. Added new unit tests on the list of the illegally double-counted courses.