### PR TITLE
Standardize colors with SCSS variables

### DIFF
--- a/src/assets/constants/colors.ts
+++ b/src/assets/constants/colors.ts
@@ -1,0 +1,45 @@
+export const reviewColors = {
+  red: '#d9534f',
+  orange: '#f0ad4e',
+  green: '#5cb85c'
+};
+
+export const coursesColorSet = [
+  {
+    text: 'Gray',
+    hex: '#C4C4C4'
+  },
+  {
+    text: 'Red',
+    hex: '#DA4A4A'
+  },
+  {
+    text: 'Orange',
+    hex: '#FFA53C'
+  },
+  {
+    text: 'Yellow',
+    hex: '#FFE142'
+  },
+  {
+    text: 'Green',
+    hex: '#58C913'
+  },
+  {
+    text: 'Blue',
+    hex: '#139DC9'
+  },
+  {
+    text: 'Purple',
+    hex: '#C478FF'
+  },
+  {
+    text: 'Pink',
+    hex: '#F296D3'
+  }
+];
+
+export const passiveGray = '#C4C4C4';
+export const activeBlue = '#32A0F2';
+export const lightPlaceholderGray = '#757575';
+export const darkPlaceholderGray = '#B6B6B6';

--- a/src/assets/constants/colors.ts
+++ b/src/assets/constants/colors.ts
@@ -38,8 +38,3 @@ export const coursesColorSet = [
     hex: '#F296D3'
   }
 ];
-
-export const passiveGray = '#C4C4C4';
-export const activeBlue = '#32A0F2';
-export const lightPlaceholderGray = '#757575';
-export const darkPlaceholderGray = '#B6B6B6';

--- a/src/assets/scss/_global.scss
+++ b/src/assets/scss/_global.scss
@@ -26,13 +26,8 @@
 }
 
 // colors
-$primary: #f15151;
-$error: #ef5777;
-$success: #1abc9c;
-$light: #f5f8fa;
-$medium: #657786;
-$dark: #34495e;
-$white: #fff;
+@import 'variables';
+
 // resets
 body {
   margin: 0;

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -36,5 +36,8 @@ $darkPlaceholderGray: #B6B6B6;
   darkPlaceholderGray: $darkPlaceholderGray;
 }
 
-// To import SCSS variables
+// To import into <script>
+// import { inactiveBlue, ... } from '@/assets/scss/_variables.scss';
+
+// To import into <style>
 // @import "@/assets/scss/_variables.scss";

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -11,12 +11,12 @@ $offWhite: #f8f8f8;
 $medGray: #858585;
 $darkGray: #3C3C3C;
 
-$emGreen: #1AA9A5;
+$emGreen: #148481;
 $chrisGreen: #105351;
-$sangBlue: #508197;
+$sangBlue: #4D7D92;
 $einBlue: #92C3E6;
 
-$inactiveBlue: #32A0F2;
+$yuxuanBlue: #32A0F2;
 $inactiveGray: #C4C4C4;
 $backgroundBlue: #F6FAFC;
 $primaryGray: #3D3D3D;
@@ -27,7 +27,7 @@ $darkPlaceholderGray: #B6B6B6;
 
 // Export for javascript
 :export {
-  inactiveBlue: $inactiveBlue;
+  yuxuanBlue: $yuxuanBlue;
   inactiveGray: $inactiveGray;
   backgroundBlue: $backgroundBlue;
   primaryGray: $primaryGray;
@@ -37,7 +37,7 @@ $darkPlaceholderGray: #B6B6B6;
 }
 
 // To import into <script>
-// import { inactiveBlue, ... } from '@/assets/scss/_variables.scss';
+// import { yuxuanBlue, ... } from '@/assets/scss/_variables.scss';
 
 // To import into <style>
 // @import "@/assets/scss/_variables.scss";

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1,0 +1,11 @@
+$primary: #f15151;
+$error: #ef5777;
+$success: #1abc9c;
+$light: #f5f8fa;
+$medium: #657786;
+$dark: #34495e;
+$white: #fff;
+
+$offWhite: #f8f8f8;
+$medGray: #858585;
+$darkGray: #3C3C3C;

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -5,7 +5,36 @@ $light: #f5f8fa;
 $medium: #657786;
 $dark: #34495e;
 $white: #fff;
+$black: #000;
 
 $offWhite: #f8f8f8;
 $medGray: #858585;
 $darkGray: #3C3C3C;
+
+$emGreen: #1AA9A5;
+$chrisGreen: #105351;
+$sangBlue: #508197;
+$einBlue: #92C3E6;
+
+$inactiveBlue: #32A0F2;
+$inactiveGray: #C4C4C4;
+$backgroundBlue: #F6FAFC;
+$primaryGray: #3D3D3D;
+$secondaryGray: #858585;
+
+$lightPlaceholderGray: #757575;
+$darkPlaceholderGray: #B6B6B6;
+
+// Export for javascript
+:export {
+  inactiveBlue: $inactiveBlue;
+  inactiveGray: $inactiveGray;
+  backgroundBlue: $backgroundBlue;
+  primaryGray: $primaryGray;
+  secondaryGray: $secondaryGray;
+  lightPlaceholderGray: $lightPlaceholderGray;
+  darkPlaceholderGray: $darkPlaceholderGray;
+}
+
+// To import SCSS variables
+// @import "@/assets/scss/_variables.scss";

--- a/src/assets/scss/introjs.scss
+++ b/src/assets/scss/introjs.scss
@@ -1,3 +1,5 @@
+@import "@/assets/scss/_variables.scss";
+
 .introjs-tooltip {
     background-color: white;
     border-radius: 9px;
@@ -12,7 +14,7 @@
 .introjs-donebutton{
     color: white !important;
     background-image: none !important;
-    background-color: #508197 !important;
+    background-color: $sangBlue !important;
     text-shadow: none;
     border: none;
     border-radius: 3px;
@@ -21,7 +23,7 @@
     &:hover,
     &:focus {
       color: white !important;
-      background-color: #508197;
+      background-color: $sangBlue;
       background-image: none;
     }
 }
@@ -31,14 +33,14 @@
     background-image: none;
     padding-left: 0px;
     background-color: white;
-    color: #508197;
+    color: $sangBlue;
     &:active,
     &:focus,
     &:hover {
       background-image: none;
       background-color:transparent; 
       padding-left: 0px;
-      color: #508197;
+      color: $sangBlue;
       background-color: white;
       box-shadow:none;
     }
@@ -46,26 +48,26 @@
 .introjs-nextbutton{
     color: white !important;
     background-image: none;
-    background-color: #508197;
+    background-color: $sangBlue;
     text-shadow: none;
     border: none;
     border-radius: 3px;
 }
 .introjs-nextbutton:hover{
     color: white !important;
-    background-color: #508197;
+    background-color: $sangBlue;
     background-image: none;
 }
 .introjs-nextbutton:focus{
     color: white !important;
-    background-color: #508197;
+    background-color: $sangBlue;
     background-image: none;
 }
 .introjs-prevbutton{
     display:none !important;
 }
 a:not([href]) {
-    color: #508197;
+    color: $sangBlue;
 }
 .introjs-bullets {
     display:none;

--- a/src/components/BottomBarCourse.vue
+++ b/src/components/BottomBarCourse.vue
@@ -200,6 +200,8 @@
 </template>
 
 <script>
+import { reviewColors } from '../assets/constants/colors';
+
 export default {
   data() {
     return {
@@ -231,9 +233,8 @@ export default {
     },
 
     reviewsColor(review, flip = false) {
-      const colors = ['#d9534f', '#f0ad4e', '#5cb85c'];
+      const colors = Object.values(reviewColors);
       let index;
-
       if (review < 2) {
         index = 0;
       } else if (review >= 2 && review < 4) {

--- a/src/components/BottomBarCourse.vue
+++ b/src/components/BottomBarCourse.vue
@@ -270,12 +270,14 @@ export default {
 </script>
 
 <style scoped lang="scss">
+  @import "@/assets/scss/_variables.scss";
+
   .bottombarcourse {
     position: fixed;
     bottom: 0;
     left: 0;
     width: 100%;
-    background-color: #FFF;
+    background-color: $white;
 
     left: 29.5rem;
     width: calc(100vw - 29.5rem);
@@ -292,7 +294,7 @@ export default {
           float: left;
           height: 16.25rem;
           width: 40%;
-          background: #F8F8F8;
+          background: $offWhite;
           overflow: auto;
         }
       }
@@ -302,7 +304,7 @@ export default {
           float: right;
           height: 16.25rem;
           width: 60%;
-          background: #FFF;
+          background: $white;
           overflow: auto;
         }
       }
@@ -440,7 +442,7 @@ export default {
           float: none;
           overflow: none;
           display: flex;
-          background: #F8F8F8;
+          background: $offWhite;
           flex-shrink: 0;
           .info {
             width: 100%;
@@ -453,7 +455,7 @@ export default {
           height: auto;
           float: none;
           display: flex;
-          background: #FFF;
+          background: $white;
           overflow: none;
           flex-shrink: 0;
         }

--- a/src/components/BottomBarCourse.vue
+++ b/src/components/BottomBarCourse.vue
@@ -200,7 +200,7 @@
 </template>
 
 <script>
-import { reviewColors } from '../assets/constants/colors';
+import { reviewColors } from '@/assets/constants/colors';
 
 export default {
   data() {

--- a/src/components/BottomBarTabView.vue
+++ b/src/components/BottomBarTabView.vue
@@ -145,6 +145,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 .bottombartabview {
   width: 100%;
   display: flex;
@@ -173,7 +175,7 @@ export default {
       color: white;
       width: 9rem;
       height: 1.75rem;
-      background-color: #508197;
+      background-color: $sangBlue;
       border-top-left-radius: 5px;
       border-top-right-radius: 5px;
       display: flex;

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -188,13 +188,14 @@ export default {
 
 <style scoped lang="scss">
 // TODO: font families
-// TODO: common variables (colors)
+@import "@/assets/scss/_variables.scss";
+
 .course {
   width: 21.375rem;
   border-radius: 0.5rem;
   display: flex;
   flex-direction: row;
-  background-color: white;
+  background-color: $white;
   box-shadow: -4px -4px 10px #efefef, 4px 4px 10px #efefef;
   position: relative;
   height: 5.625rem;
@@ -282,7 +283,7 @@ export default {
   &-code {
     font-size: 14px;
     line-height: 17px;
-    color: #858585;
+    color: $medGray;
 
     &--min {
       color: #3d3d3d;
@@ -397,8 +398,8 @@ export default {
 .course-tooltip .course-tooltiptext {
   visibility: hidden;
   width: 120px;
-  color: #858585;
-  background-color: #fff;
+  color: $medGray;
+  background-color: $white;
   text-align: center;
   padding: 0.5rem;
   border-radius: 6px;

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -246,273 +246,275 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
-    .logo {
-      width: 12rem;
-    }
-    .section{
-      padding:0px;
-      margin: 0px;
-      max-width: 100%;
-    }
-    .container {
-      max-width: 100%;
-    }
-    .top-bar{
-      padding:59px 0px 0px 104px;
+  @import "@/assets/scss/_variables.scss";
 
-      @media (max-width: 1154px) {
-        padding: 59px 104px 0px 104px;
-        display: flex;
-        flex-direction: column;
-      }
-    }
-    .top-section {
-      @media (max-width: 1154px) {
-        display: flex;
-        justify-content: center;
-        text-align: center;
-        max-width: 100%;
-      }
-    }
-    .signin-button{
-      color: #1AA9A5;
-      font-weight: 550;
-      border-color: #1AA9A5;
-      padding: 10px 30px;
-      border-radius: 6px;
-    }
-    .plan{
-      padding:59px 0px 59px 104px;
-    }
-    .plan-head{
-      padding-bottom: 30px;
-      font-size: 60px;
-      line-height: 60px;
-      color: #4F4F4F;
-    }
-    .plan-subhead{
-      padding-bottom: 30px;
-      font-style: normal;
-      font-weight: 300;
-      font-size: 25px;
-      line-height: 35px;
-      color: #000000;
-    }
-    input{
-        width: 100%;
-        height: 100%;
-        border-radius: 6px;
-        border-color:#1AA9A5;
-        padding : 15px 30px;
-    }
-    .email{
-      padding: 20px;
-      @media (max-width: 767px) {
-        width: 350px;
-        max-width: 350px;
-        flex: unset;
-      }
-    }
-    .email-button{
-      border: 0;
-      background-color: #1AA9A5;
-      border-radius : 6px;
-      border-color: #1AA9A5;
-      width: 100%;
-      padding : 15px 30px;
-      color: white;
-      &:hover,
-      &:focus,
-      &:active {
-          border-color: #13807c;
-          background-color: #13807c;
-      }
+  .logo {
+    width: 12rem;
+  }
+  .section{
+    padding:0px;
+    margin: 0px;
+    max-width: 100%;
+  }
+  .container {
+    max-width: 100%;
+  }
+  .top-bar{
+    padding:59px 0px 0px 104px;
 
-      &--top {
-        width: 13.5rem;
-        @media (max-width: 1154px) {
-          margin-bottom: 1rem;
-        }
-      }
-    }
-    .email-top{
-      padding: 20px 20px 20px 20px;
-    }
-    .image-wrapper {
-      overflow: hidden;
-      @media (max-width: 1154px) {
-        display: none;
-      }
-      &--drag {
-        overflow: unset;
-      }
-      &--laptop {
-        display: block;
-      }
-      &--semester {
-        display: flex;
-        justify-content: flex-end;
-      }
-    }
-    .laptop{
-      position: relative;
-      width: 900px;
-      @media (max-width: 1154px) {
-        max-width: inherit;
-      }
-    }
-    .women{
-      position: relative;
-    }
-    .women-wrapper {
-      margin-top: -120px
-    }
-
-    .new{
-      background-color: #1AA9A5;
-      padding:50px 0px 96px 104px;
-      @media (min-width: 1155px) {
-        margin-bottom: -120px;
-      }
-    }
-    .new-1{
-      text-align: left;
-        padding: 120px 0px 59px 104px;
-    }
-    .tasks{
+    @media (max-width: 1154px) {
+      padding: 59px 104px 0px 104px;
       display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 10px;
+      flex-direction: column;
     }
-    .tasks-wrapper {
+  }
+  .top-section {
+    @media (max-width: 1154px) {
+      display: flex;
+      justify-content: center;
+      text-align: center;
+      max-width: 100%;
+    }
+  }
+  .signin-button{
+    color: $emGreen;
+    font-weight: 550;
+    border-color: $emGreen;
+    padding: 10px 30px;
+    border-radius: 6px;
+  }
+  .plan{
+    padding:59px 0px 59px 104px;
+  }
+  .plan-head{
+    padding-bottom: 30px;
+    font-size: 60px;
+    line-height: 60px;
+    color: #4F4F4F;
+  }
+  .plan-subhead{
+    padding-bottom: 30px;
+    font-style: normal;
+    font-weight: 300;
+    font-size: 25px;
+    line-height: 35px;
+    color: $black;
+  }
+  input{
+      width: 100%;
+      height: 100%;
+      border-radius: 6px;
+      border-color:$emGreen;
+      padding : 15px 30px;
+  }
+  .email{
+    padding: 20px;
+    @media (max-width: 767px) {
+      width: 350px;
+      max-width: 350px;
+      flex: unset;
+    }
+  }
+  .email-button{
+    border: 0;
+    background-color: $emGreen;
+    border-radius : 6px;
+    border-color: $emGreen;
+    width: 100%;
+    padding : 15px 30px;
+    color: white;
+    &:hover,
+    &:focus,
+    &:active {
+        border-color: #13807c;
+        background-color: #13807c;
+    }
+
+    &--top {
+      width: 13.5rem;
       @media (max-width: 1154px) {
-        max-width: 100%;
-        flex: unset;
+        margin-bottom: 1rem;
       }
     }
-    .sub{
-        font-weight: normal;
-        font-size: 24px;
-        color: #FFFFFF;
-        margin: 0;
+  }
+  .email-top{
+    padding: 20px 20px 20px 20px;
+  }
+  .image-wrapper {
+    overflow: hidden;
+    @media (max-width: 1154px) {
+      display: none;
+    }
+    &--drag {
+      overflow: unset;
+    }
+    &--laptop {
+      display: block;
+    }
+    &--semester {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+  .laptop{
+    position: relative;
+    width: 900px;
+    @media (max-width: 1154px) {
+      max-width: inherit;
+    }
+  }
+  .women{
+    position: relative;
+  }
+  .women-wrapper {
+    margin-top: -120px
+  }
 
-        &--task {
-          margin-left: 2rem;
-        }
+  .new{
+    background-color: $emGreen;
+    padding:50px 0px 96px 104px;
+    @media (min-width: 1155px) {
+      margin-bottom: -120px;
     }
-    .head{
-        font-weight: 600;
-        font-size: 40px;
-        color: #FFFFFF;
-        padding-bottom: 0px;
+  }
+  .new-1{
+    text-align: left;
+      padding: 120px 0px 59px 104px;
+  }
+  .tasks{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+  }
+  .tasks-wrapper {
+    @media (max-width: 1154px) {
+      max-width: 100%;
+      flex: unset;
     }
-    .head-center{
+  }
+  .sub{
+      font-weight: normal;
+      font-size: 24px;
+      color: #FFFFFF;
+      margin: 0;
+
+      &--task {
+        margin-left: 2rem;
+      }
+  }
+  .head{
       font-weight: 600;
       font-size: 40px;
       color: #FFFFFF;
       padding-bottom: 0px;
-    }
+  }
+  .head-center{
+    font-weight: 600;
+    font-size: 40px;
+    color: #FFFFFF;
+    padding-bottom: 0px;
+  }
 
-    .women {
-      @media (max-width: 1274px) {
-        width: 62vw;
-      }
+  .women {
+    @media (max-width: 1274px) {
+      width: 62vw;
     }
-    .drag{
-      background-color:  #105351;
-      padding:59px 104px 0px 104px;
-      @media (max-width: 1154px) {
-        display: flex;
-        justify-content: center;
-      }
+  }
+  .drag{
+    background-color: $chrisGreen;
+    padding:59px 104px 0px 104px;
+    @media (max-width: 1154px) {
+      display: flex;
+      justify-content: center;
     }
-    .preview{
-      position: relative;
+  }
+  .preview{
+    position: relative;
 
-      @media (max-width: 1274px) {
-        width: 62vw;
-      }
+    @media (max-width: 1274px) {
+      width: 62vw;
     }
-    .schedule{
-      margin-top: 16px;
-      width: 650px;
+  }
+  .schedule{
+    margin-top: 16px;
+    width: 650px;
 
-      @media (max-width: 1274px) {
-        width: 50vw;
-      }
+    @media (max-width: 1274px) {
+      width: 50vw;
+    }
+  }
+  .comment{
+    text-align: left;
+    padding: 170px 30px 250px 30px;
+    @media (max-width: 1154px) {
+      max-width: 100%;
+      flex: unset;
+    }
+  }
+  .semester{
+    background-color:  $einBlue;
+    padding:0px 0px 0px 104px;
+    @media (max-width: 1154px) {
+      display: flex;
+      justify-content: center;
+    }
+  }
+  .first{
+    background-color:  $sangBlue;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 180px 100px 104px 100px;
+
+    @media (max-width: 720px) {
+      padding: 40px 30px 40px 30px;
+    }
+  }
+  input:focus::placeholder {
+    color: transparent;
+  }
+  button{
+    outline: none;
+  }
+  p {
+    padding: 0;
+  }
+  .container.inside{
+    max-width: 600px;
+  }
+  @media (max-width:1154px) {
+    img#hide{
+      display: none;
+    }
+    .top-bar{
+      padding:50px;
+    }
+    .new{
+      padding:0px 50px 100px 50px;
+    }
+    .phonepad{
+      padding:50px;
+      text-align: center;
     }
     .comment{
-      text-align: left;
-      padding: 170px 30px 250px 30px;
-      @media (max-width: 1154px) {
-        max-width: 100%;
-        flex: unset;
-      }
+      text-align:center;
+      padding: 100px 30px 100px 30px;
     }
-    .semester{
-      background-color:  #92C3E6;
-      padding:0px 0px 0px 104px;
-      @media (max-width: 1154px) {
-        display: flex;
-        justify-content: center;
-      }
+    .input{
+      width:200px;
     }
-    .first{
-      background-color:  #508197;
-      display: flex;
-      flex-direction: column;
+    .center{
+      display:flex;
       justify-content: center;
       align-items: center;
-      text-align: center;
-      padding: 180px 100px 104px 100px;
+      margin: 0;
+    }
 
-      @media (max-width: 720px) {
-        padding: 40px 30px 40px 30px;
-      }
-    }
-    input:focus::placeholder {
-      color: transparent;
-    }
-    button{
-      outline: none;
-    }
-    p {
-      padding: 0;
-    }
-    .container.inside{
-      max-width: 600px;
-    }
-    @media (max-width:1154px) {
-      img#hide{
-        display: none;
-      }
-      .top-bar{
-        padding:50px;
-      }
-      .new{
-        padding:0px 50px 100px 50px;
-      }
-      .phonepad{
-        padding:50px;
-        text-align: center;
-      }
-      .comment{
-        text-align:center;
-        padding: 100px 30px 100px 30px;
-      }
-      .input{
-        width:200px;
-      }
-      .center{
-        display:flex;
-        justify-content: center;
-        align-items: center;
-        margin: 0;
-      }
-
-    }
-    *, html {padding:0; margin:0;}
+  }
+  *, html {padding:0; margin:0;}
 
 
 </style>

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -69,6 +69,7 @@
 <script>
 import Vue from 'vue';
 import Course from '@/components/Course';
+import coursesColorSet from '../../assets/constants/colors';
 
 export default {
   props: {
@@ -81,40 +82,7 @@ export default {
       isLeft: (this.semId % 2 === 0 && !this.isCompact) || (this.semId % 4 === 0 && this.isCompact),
       // TODO: better version for all breakpoints
       // isLeft: this.semId % numPerRow() === 0,
-      colors: [
-        {
-          text: 'Gray',
-          hex: '#C4C4C4'
-        },
-        {
-          text: 'Red',
-          hex: '#DA4A4A'
-        },
-        {
-          text: 'Orange',
-          hex: '#FFA53C'
-        },
-        {
-          text: 'Yellow',
-          hex: '#FFE142'
-        },
-        {
-          text: 'Green',
-          hex: '#58C913'
-        },
-        {
-          text: 'Blue',
-          hex: '#139DC9'
-        },
-        {
-          text: 'Purple',
-          hex: '#C478FF'
-        },
-        {
-          text: 'Pink',
-          hex: '#F296D3'
-        }
-      ],
+      colors: coursesColorSet,
       displayColors: false,
       displayEditCourseCredits: false
     };

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -143,9 +143,11 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 .courseMenu {
   &-content {
-    background: #ffffff;
+    background: $white;
     border: 1px solid #acacac;
     box-sizing: border-box;
     border-radius: 9px;

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -69,7 +69,7 @@
 <script>
 import Vue from 'vue';
 import Course from '@/components/Course';
-import coursesColorSet from '../../assets/constants/colors';
+import { coursesColorSet } from '../../assets/constants/colors';
 
 export default {
   props: {

--- a/src/components/Modals/DeleteSemester.vue
+++ b/src/components/Modals/DeleteSemester.vue
@@ -64,6 +64,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 .deleteSemesterModal {
   padding: 1rem;
 
@@ -116,9 +118,9 @@ export default {
   &-button {
     width: 4.75rem;
     height: 2rem;
-    color: #508197;
+    color: $sangBlue;
     border-radius: 3px;
-    border: 1px solid #508197;
+    border: 1px solid $sangBlue;
     background-color: #ffffff;
     display: flex;
     justify-content: center;
@@ -137,7 +139,7 @@ export default {
 
     &--delete {
       color: #ffffff;
-      background-color: #508197;
+      background-color: $sangBlue;
       margin-left: 0.8rem;
       border: none;
       display: flex;

--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -81,12 +81,13 @@ export default {
 </script>
 
 <style lang="scss">
+@import "@/assets/scss/_variables.scss";
 
 .modal {
   padding: 1rem;
 
   &-content {
-    background: #ffffff;
+    background: $white;
     border-radius: 9px;
     margin-left: auto;
     margin-right: auto;
@@ -128,13 +129,13 @@ export default {
     color: #5b676d;
     border-radius: 3px;
     border: 1px solid #3d3d3d;
-    background-color: #ffffff;
+    background-color: $white;
     display: flex;
     justify-content: center;
 
     &--add {
-      color: #ffffff;
-      background-color: #508197;
+      color: $white;
+      background-color: $sangBlue;
       margin-left: 0.5rem;
       border: none;
     }
@@ -144,7 +145,7 @@ export default {
   padding: 1rem;
 
   &-content {
-    background: #ffffff;
+    background: $white;
     border-radius: 9px;
     margin-left: auto;
     margin-right: auto;
@@ -192,10 +193,10 @@ export default {
   &-button {
     width: 4.75rem;
     height: 2rem;
-    color: #508197;
+    color: $sangBlue;
     border-radius: 3px;
-    border: 1px solid #508197;
-    background-color: #ffffff;
+    border: 1px solid $sangBlue;
+    background-color: $white;
     display: flex;
     justify-content: center;
 
@@ -212,8 +213,8 @@ export default {
     }
 
     &--delete {
-      color: #ffffff;
-      background-color: #508197;
+      color: $white;
+      background-color: $sangBlue;
       margin-left: 0.8rem;
       border: none;
       display: flex;
@@ -223,7 +224,7 @@ export default {
 
     &--disabled {
       opacity: .3;
-      border: 1px solid #508197;
+      border: 1px solid $sangBlue;
       background-color: #CCCCCC;
     }
   }

--- a/src/components/Modals/Modal.vue
+++ b/src/components/Modals/Modal.vue
@@ -175,12 +175,13 @@ export default {
 </script>
 
 <style lang="scss">
-// TODO: font family
+@import "@/assets/scss/_variables.scss";
+
 .modal {
   padding: 1rem;
 
   &-content {
-    background: #ffffff;
+    background: $white;
     border-radius: 9px;
     margin-left: auto;
     margin-right: auto;
@@ -221,20 +222,20 @@ export default {
     color: #5b676d;
     border-radius: 3px;
     border: 1px solid #3d3d3d;
-    background-color: #ffffff;
+    background-color: $white;
     display: flex;
     justify-content: center;
 
     &--add {
-      color: #ffffff;
-      background-color: #508197;
+      color: $white;
+      background-color: $sangBlue;
       margin-left: 0.5rem;
       border: none;
     }
 
     &--disabled {
       opacity: .3;
-      border: 1px solid #508197;
+      border: 1px solid $sangBlue;
       background-color: #CCCCCC;
     }
   }

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -114,8 +114,9 @@ import spring from '@/assets/images/springEmoji.svg';
 import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
 import {
-  passiveGray, activeBlue, lightPlaceholderGray, darkPlaceholderGray
-} from '@/assets/constants/colors';
+  inactiveGray, inactiveBlue, lightPlaceholderGray, darkPlaceholderGray
+} from '@/assets/scss/_variables.scss';
+
 
 const clickOutside = {
   bind(el, binding, vnode) {
@@ -221,11 +222,11 @@ export default {
 
       if (contentShown) {
         // clicked box when content shown. So then hide content
-        displayOptions.boxBorder = passiveGray;
-        displayOptions.arrowColor = passiveGray;
+        displayOptions.boxBorder = inactiveGray;
+        displayOptions.arrowColor = inactiveGray;
       } else {
-        displayOptions.boxBorder = activeBlue;
-        displayOptions.arrowColor = activeBlue;
+        displayOptions.boxBorder = inactiveBlue;
+        displayOptions.arrowColor = inactiveBlue;
       }
     },
     showHideSeasonContent() {
@@ -240,8 +241,8 @@ export default {
         displayOptions.stopClose = false;
       } else if (displayOptions.shown) {
         displayOptions.shown = false;
-        displayOptions.boxBorder = passiveGray;
-        displayOptions.arrowColor = passiveGray;
+        displayOptions.boxBorder = inactiveGray;
+        displayOptions.arrowColor = inactiveGray;
       }
     },
     closeSeasonDropdownIfOpen() {
@@ -258,8 +259,8 @@ export default {
       }
       const displayOptions = this.displayOptions[type];
       displayOptions.shown = false;
-      displayOptions.boxBorder = passiveGray;
-      displayOptions.arrowColor = passiveGray;
+      displayOptions.boxBorder = inactiveGray;
+      displayOptions.arrowColor = inactiveGray;
       displayOptions.placeholderColor = lightPlaceholderGray;
     },
     selectSeason(text) {
@@ -272,8 +273,8 @@ export default {
       const displayOptions = this.displayOptions[type];
       displayOptions.shown = false;
       displayOptions.stopClose = false;
-      displayOptions.boxBorder = passiveGray;
-      displayOptions.arrowColor = passiveGray;
+      displayOptions.boxBorder = inactiveGray;
+      displayOptions.arrowColor = inactiveGray;
       displayOptions.placeholderColor = darkPlaceholderGray;
 
       if (type === 'season') {

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -114,7 +114,7 @@ import spring from '@/assets/images/springEmoji.svg';
 import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
 import {
-  inactiveGray, inactiveBlue, lightPlaceholderGray, darkPlaceholderGray
+  inactiveGray, yuxuanBlue, lightPlaceholderGray, darkPlaceholderGray
 } from '@/assets/scss/_variables.scss';
 
 
@@ -225,8 +225,8 @@ export default {
         displayOptions.boxBorder = inactiveGray;
         displayOptions.arrowColor = inactiveGray;
       } else {
-        displayOptions.boxBorder = inactiveBlue;
-        displayOptions.arrowColor = inactiveBlue;
+        displayOptions.boxBorder = yuxuanBlue;
+        displayOptions.arrowColor = yuxuanBlue;
       }
     },
     showHideSeasonContent() {

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -109,10 +109,13 @@
 
 <script>
 
-import fall from '../../assets/images/fallEmoji.svg';
-import spring from '../../assets/images/springEmoji.svg';
-import winter from '../../assets/images/winterEmoji.svg';
-import summer from '../../assets/images/summerEmoji.svg';
+import fall from '@/assets/images/fallEmoji.svg';
+import spring from '@/assets/images/springEmoji.svg';
+import winter from '@/assets/images/winterEmoji.svg';
+import summer from '@/assets/images/summerEmoji.svg';
+import {
+  passiveGray, activeBlue, lightPlaceholderGray, darkPlaceholderGray
+} from '@/assets/constants/colors';
 
 const clickOutside = {
   bind(el, binding, vnode) {
@@ -127,7 +130,6 @@ const clickOutside = {
     document.body.removeEventListener('click', el.event);
   }
 };
-
 
 // enum to define seasons as integers in season order
 const SeasonsEnum = Object.freeze({
@@ -219,11 +221,11 @@ export default {
 
       if (contentShown) {
         // clicked box when content shown. So then hide content
-        displayOptions.boxBorder = '#C4C4C4';
-        displayOptions.arrowColor = '#C4C4C4';
+        displayOptions.boxBorder = passiveGray;
+        displayOptions.arrowColor = passiveGray;
       } else {
-        displayOptions.boxBorder = '#32A0F2';
-        displayOptions.arrowColor = '#32A0F2';
+        displayOptions.boxBorder = activeBlue;
+        displayOptions.arrowColor = activeBlue;
       }
     },
     showHideSeasonContent() {
@@ -238,8 +240,8 @@ export default {
         displayOptions.stopClose = false;
       } else if (displayOptions.shown) {
         displayOptions.shown = false;
-        displayOptions.boxBorder = '#C4C4C4';
-        displayOptions.arrowColor = '#C4C4C4';
+        displayOptions.boxBorder = passiveGray;
+        displayOptions.arrowColor = passiveGray;
       }
     },
     closeSeasonDropdownIfOpen() {
@@ -256,9 +258,9 @@ export default {
       }
       const displayOptions = this.displayOptions[type];
       displayOptions.shown = false;
-      displayOptions.boxBorder = '#C4C4C4';
-      displayOptions.arrowColor = '#C4C4C4';
-      displayOptions.placeholderColor = '#757575';
+      displayOptions.boxBorder = passiveGray;
+      displayOptions.arrowColor = passiveGray;
+      displayOptions.placeholderColor = lightPlaceholderGray;
     },
     selectSeason(text) {
       this.selectOption('season', text);
@@ -270,9 +272,9 @@ export default {
       const displayOptions = this.displayOptions[type];
       displayOptions.shown = false;
       displayOptions.stopClose = false;
-      displayOptions.boxBorder = '#C4C4C4';
-      displayOptions.arrowColor = '#C4C4C4';
-      displayOptions.placeholderColor = '#B6B6B6';
+      displayOptions.boxBorder = passiveGray;
+      displayOptions.arrowColor = passiveGray;
+      displayOptions.placeholderColor = darkPlaceholderGray;
 
       if (type === 'season') {
         this.seasonText = '';

--- a/src/components/Modals/Onboarding.scss
+++ b/src/components/Modals/Onboarding.scss
@@ -1,3 +1,5 @@
+@import "@/assets/scss/_variables.scss";
+
 input {
   background-color: none;
 }
@@ -187,7 +189,7 @@ input {
 
   &-add {
     cursor: pointer;
-    color: #1AA9A5;
+    color: $emGreen;
   }
 
   &-remove {
@@ -245,7 +247,7 @@ input {
   }
 
   &-button {
-    background: #1AA9A5;
+    background: $emGreen;
     border: 0;
     box-sizing: border-box;
     border-radius: 1px;

--- a/src/components/Modals/Onboarding.vue
+++ b/src/components/Modals/Onboarding.vue
@@ -52,7 +52,7 @@ import Vue from 'vue';
 import reqsData from '@/requirements/typed-requirement-json';
 import OnboardingBasic from '@/components/Modals/OnboardingBasic';
 import OnboardingTransfer from '@/components/Modals/OnboardingTransfer';
-import { lightPlaceholderGray } from '@/assets/constants/colors';
+import { lightPlaceholderGray } from '@/assets/scss/_variables.scss';
 
 require('@/assets/images/timeline1.svg');
 

--- a/src/components/Modals/Onboarding.vue
+++ b/src/components/Modals/Onboarding.vue
@@ -52,6 +52,7 @@ import Vue from 'vue';
 import reqsData from '@/requirements/typed-requirement-json';
 import OnboardingBasic from '@/components/Modals/OnboardingBasic';
 import OnboardingTransfer from '@/components/Modals/OnboardingTransfer';
+import { lightPlaceholderGray } from '@/assets/constants/colors';
 
 require('@/assets/images/timeline1.svg');
 
@@ -87,7 +88,7 @@ export default {
     if (this.user.college !== '') {
       collegeText = this.user.collegeFN;
       collegeAcronym = this.user.college;
-      collegePlaceholderColor = '#757575';
+      collegePlaceholderColor = lightPlaceholderGray;
     }
 
     let majorText = placeholderText;
@@ -96,7 +97,7 @@ export default {
     if ('major' in this.user && this.user.major.length > 0) {
       majorText = this.user.majorFN;
       majorAcronym = this.user.major;
-      majorPlaceholderColor = '#757575';
+      majorPlaceholderColor = lightPlaceholderGray;
     }
 
     let minorText = placeholderText;
@@ -105,7 +106,7 @@ export default {
     if ('minor' in this.user && this.user.minor.length > 0) {
       minorText = this.user.minorFN;
       minorAcronym = this.user.minor;
-      minorPlaceholderColor = '#757575';
+      minorPlaceholderColor = lightPlaceholderGray;
     }
 
     return {

--- a/src/components/Modals/OnboardingBasic.vue
+++ b/src/components/Modals/OnboardingBasic.vue
@@ -178,6 +178,7 @@
 <script>
 
 import reqsData from '@/requirements/typed-requirement-json';
+import { passiveGray, activeBlue, lightPlaceholderGray } from '@/assets/constants/colors';
 
 const placeholderText = 'Select one';
 
@@ -207,7 +208,7 @@ export default {
     if (this.user.college !== '') {
       collegeText = this.user.collegeFN;
       collegeAcronym = this.user.college;
-      collegePlaceholderColor = '#757575';
+      collegePlaceholderColor = lightPlaceholderGray;
     }
 
     let majorText = placeholderText;
@@ -216,7 +217,7 @@ export default {
     if ('major' in this.user && this.user.major.length > 0) {
       majorText = this.user.majorFN;
       majorAcronym = this.user.major;
-      majorPlaceholderColor = '#757575';
+      majorPlaceholderColor = lightPlaceholderGray;
     }
     let minorText = placeholderText;
     let minorAcronym = '';
@@ -224,7 +225,7 @@ export default {
     if ('minor' in this.user && this.user.minor.length > 0) {
       minorText = this.user.minorFN;
       minorAcronym = this.user.minor;
-      minorPlaceholderColor = '#757575';
+      minorPlaceholderColor = lightPlaceholderGray;
     }
     return {
       // TODO: Get real college, major, and minor lists
@@ -296,7 +297,7 @@ export default {
               stopClose: false,
               boxBorder: '',
               arrowColor: '',
-              placeholderColor: '#757575',
+              placeholderColor: lightPlaceholderGray,
               placeholder: major.placeholder[i],
               acronym: major.acronym[i]
             };
@@ -327,7 +328,7 @@ export default {
               stopClose: false,
               boxBorder: '',
               arrowColor: '',
-              placeholderColor: '#757575',
+              placeholderColor: lightPlaceholderGray,
               placeholder: minor.placeholder[i],
               acronym: minor.acronym[i]
             };
@@ -446,11 +447,11 @@ export default {
 
       if (contentShown) {
         // clicked box when content shown. So then hide content
-        displayOptions.boxBorder = '#C4C4C4';
-        displayOptions.arrowColor = '#C4C4C4';
+        displayOptions.boxBorder = passiveGray;
+        displayOptions.arrowColor = passiveGray;
       } else {
-        displayOptions.boxBorder = '#32A0F2';
-        displayOptions.arrowColor = '#32A0F2';
+        displayOptions.boxBorder = activeBlue;
+        displayOptions.arrowColor = activeBlue;
       }
     },
     showHideCollegeContent(i) {
@@ -469,8 +470,8 @@ export default {
         displayOptions.stopClose = false;
       } else if (displayOptions.shown) {
         displayOptions.shown = false;
-        displayOptions.boxBorder = '#C4C4C4';
-        displayOptions.arrowColor = '#C4C4C4';
+        displayOptions.boxBorder = passiveGray;
+        displayOptions.arrowColor = passiveGray;
       }
     },
     closeCollegeDropdownIfOpen(event, i) {
@@ -488,9 +489,9 @@ export default {
       displayOptions.placeholder = text;
       displayOptions.acronym = acronym;
       displayOptions.shown = false;
-      displayOptions.arrowColor = '#C4C4C4';
-      displayOptions.boxBorder = '#C4C4C4';
-      displayOptions.placeholderColor = '#757575';
+      displayOptions.arrowColor = passiveGray;
+      displayOptions.boxBorder = passiveGray;
+      displayOptions.placeholderColor = lightPlaceholderGray;
       this.$emit('updateBasic', this.displayOptions.major, this.displayOptions.college, this.displayOptions.minor);
     },
     selectCollege(text, acronym, i) {

--- a/src/components/Modals/OnboardingBasic.vue
+++ b/src/components/Modals/OnboardingBasic.vue
@@ -178,7 +178,7 @@
 <script>
 
 import reqsData from '@/requirements/typed-requirement-json';
-import { passiveGray, activeBlue, lightPlaceholderGray } from '@/assets/constants/colors';
+import { inactiveGray, inactiveBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
 
 const placeholderText = 'Select one';
 
@@ -447,11 +447,11 @@ export default {
 
       if (contentShown) {
         // clicked box when content shown. So then hide content
-        displayOptions.boxBorder = passiveGray;
-        displayOptions.arrowColor = passiveGray;
+        displayOptions.boxBorder = inactiveGray;
+        displayOptions.arrowColor = inactiveGray;
       } else {
-        displayOptions.boxBorder = activeBlue;
-        displayOptions.arrowColor = activeBlue;
+        displayOptions.boxBorder = inactiveBlue;
+        displayOptions.arrowColor = inactiveBlue;
       }
     },
     showHideCollegeContent(i) {
@@ -470,8 +470,8 @@ export default {
         displayOptions.stopClose = false;
       } else if (displayOptions.shown) {
         displayOptions.shown = false;
-        displayOptions.boxBorder = passiveGray;
-        displayOptions.arrowColor = passiveGray;
+        displayOptions.boxBorder = inactiveGray;
+        displayOptions.arrowColor = inactiveGray;
       }
     },
     closeCollegeDropdownIfOpen(event, i) {
@@ -489,8 +489,8 @@ export default {
       displayOptions.placeholder = text;
       displayOptions.acronym = acronym;
       displayOptions.shown = false;
-      displayOptions.arrowColor = passiveGray;
-      displayOptions.boxBorder = passiveGray;
+      displayOptions.arrowColor = inactiveGray;
+      displayOptions.boxBorder = inactiveGray;
       displayOptions.placeholderColor = lightPlaceholderGray;
       this.$emit('updateBasic', this.displayOptions.major, this.displayOptions.college, this.displayOptions.minor);
     },

--- a/src/components/Modals/OnboardingBasic.vue
+++ b/src/components/Modals/OnboardingBasic.vue
@@ -178,7 +178,7 @@
 <script>
 
 import reqsData from '@/requirements/typed-requirement-json';
-import { inactiveGray, inactiveBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
+import { inactiveGray, yuxuanBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
 
 const placeholderText = 'Select one';
 
@@ -450,8 +450,8 @@ export default {
         displayOptions.boxBorder = inactiveGray;
         displayOptions.arrowColor = inactiveGray;
       } else {
-        displayOptions.boxBorder = inactiveBlue;
-        displayOptions.arrowColor = inactiveBlue;
+        displayOptions.boxBorder = yuxuanBlue;
+        displayOptions.arrowColor = yuxuanBlue;
       }
     },
     showHideCollegeContent(i) {

--- a/src/components/Modals/OnboardingTransfer.vue
+++ b/src/components/Modals/OnboardingTransfer.vue
@@ -187,11 +187,12 @@
 import reqsData from '@/requirements/data/exams/ExamCredit';
 import coursesJSON from '../../assets/courses/courses.json';
 import NewCourse from '@/components/Modals/NewCourse';
+import { passiveGray, activeBlue, lightPlaceholderGray } from '@/assets/constants/colors';
 
 Vue.component('newCourse', NewCourse);
 
 const placeholderText = 'Select one';
-const placeholderColor = '#757575';
+const placeholderColor = lightPlaceholderGray;
 
 const clickOutside = {
   bind(el, binding, vnode) {
@@ -254,7 +255,7 @@ export default {
               stopClose: false,
               boxBorder: '',
               arrowColor: '',
-              placeholderColor: '#757575',
+              placeholderColor: lightPlaceholderGray,
               placeholder: this.user.exam[x][sec],
               acronym: ''
             };
@@ -332,11 +333,11 @@ export default {
       const contentShown = displayOptions.shown;
       displayOptions.shown = !contentShown;
       if (contentShown) {
-        displayOptions.boxBorder = '#C4C4C4';
-        displayOptions.arrowColor = '#C4C4C4';
+        displayOptions.boxBorder = passiveGray;
+        displayOptions.arrowColor = passiveGray;
       } else {
-        displayOptions.boxBorder = '#32A0F2';
-        displayOptions.arrowColor = '#32A0F2';
+        displayOptions.boxBorder = activeBlue;
+        displayOptions.arrowColor = activeBlue;
       }
     },
     showHideExamContent(i) {
@@ -360,16 +361,16 @@ export default {
             displayOptions[key].stopClose = false;
           } else if (key !== 'equivCourse' && displayOptions[key].shown) {
             displayOptions[key].shown = false;
-            displayOptions[key].boxBorder = '#C4C4C4';
-            displayOptions[key].arrowColor = '#C4C4C4';
+            displayOptions[key].boxBorder = passiveGray;
+            displayOptions[key].arrowColor = passiveGray;
           }
         });
       } else if (displayOptions.stopClose) {
         displayOptions.stopClose = false;
       } else if ('equivCourse' && displayOptions.shown) {
         displayOptions.shown = false;
-        displayOptions.boxBorder = '#C4C4C4';
-        displayOptions.arrowColor = '#C4C4C4';
+        displayOptions.boxBorder = passiveGray;
+        displayOptions.arrowColor = passiveGray;
       }
     },
     closeTypeDropdownIfOpen(event, i) {
@@ -427,9 +428,9 @@ export default {
       }
       displayOptions.placeholder = text;
       displayOptions.shown = false;
-      displayOptions.arrowColor = '#C4C4C4';
-      displayOptions.boxBorder = '#C4C4C4';
-      displayOptions.placeholderColor = '#757575';
+      displayOptions.arrowColor = passiveGray;
+      displayOptions.boxBorder = passiveGray;
+      displayOptions.placeholderColor = lightPlaceholderGray;
       this.$emit('updateTransfer', this.displayOptions.exam, this.displayOptions.class, this.tookSwimTest);
     },
     // Clear a major if a new college is selected and the major is not in it

--- a/src/components/Modals/OnboardingTransfer.vue
+++ b/src/components/Modals/OnboardingTransfer.vue
@@ -187,7 +187,7 @@
 import reqsData from '@/requirements/data/exams/ExamCredit';
 import coursesJSON from '../../assets/courses/courses.json';
 import NewCourse from '@/components/Modals/NewCourse';
-import { inactiveGray, inactiveBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
+import { inactiveGray, yuxuanBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
 
 Vue.component('newCourse', NewCourse);
 
@@ -336,8 +336,8 @@ export default {
         displayOptions.boxBorder = inactiveGray;
         displayOptions.arrowColor = inactiveGray;
       } else {
-        displayOptions.boxBorder = inactiveBlue;
-        displayOptions.arrowColor = inactiveBlue;
+        displayOptions.boxBorder = yuxuanBlue;
+        displayOptions.arrowColor = yuxuanBlue;
       }
     },
     showHideExamContent(i) {

--- a/src/components/Modals/OnboardingTransfer.vue
+++ b/src/components/Modals/OnboardingTransfer.vue
@@ -187,7 +187,7 @@
 import reqsData from '@/requirements/data/exams/ExamCredit';
 import coursesJSON from '../../assets/courses/courses.json';
 import NewCourse from '@/components/Modals/NewCourse';
-import { passiveGray, activeBlue, lightPlaceholderGray } from '@/assets/constants/colors';
+import { inactiveGray, inactiveBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
 
 Vue.component('newCourse', NewCourse);
 
@@ -333,11 +333,11 @@ export default {
       const contentShown = displayOptions.shown;
       displayOptions.shown = !contentShown;
       if (contentShown) {
-        displayOptions.boxBorder = passiveGray;
-        displayOptions.arrowColor = passiveGray;
+        displayOptions.boxBorder = inactiveGray;
+        displayOptions.arrowColor = inactiveGray;
       } else {
-        displayOptions.boxBorder = activeBlue;
-        displayOptions.arrowColor = activeBlue;
+        displayOptions.boxBorder = inactiveBlue;
+        displayOptions.arrowColor = inactiveBlue;
       }
     },
     showHideExamContent(i) {
@@ -361,16 +361,16 @@ export default {
             displayOptions[key].stopClose = false;
           } else if (key !== 'equivCourse' && displayOptions[key].shown) {
             displayOptions[key].shown = false;
-            displayOptions[key].boxBorder = passiveGray;
-            displayOptions[key].arrowColor = passiveGray;
+            displayOptions[key].boxBorder = inactiveGray;
+            displayOptions[key].arrowColor = inactiveGray;
           }
         });
       } else if (displayOptions.stopClose) {
         displayOptions.stopClose = false;
       } else if ('equivCourse' && displayOptions.shown) {
         displayOptions.shown = false;
-        displayOptions.boxBorder = passiveGray;
-        displayOptions.arrowColor = passiveGray;
+        displayOptions.boxBorder = inactiveGray;
+        displayOptions.arrowColor = inactiveGray;
       }
     },
     closeTypeDropdownIfOpen(event, i) {
@@ -428,8 +428,8 @@ export default {
       }
       displayOptions.placeholder = text;
       displayOptions.shown = false;
-      displayOptions.arrowColor = passiveGray;
-      displayOptions.boxBorder = passiveGray;
+      displayOptions.arrowColor = inactiveGray;
+      displayOptions.boxBorder = inactiveGray;
       displayOptions.placeholderColor = lightPlaceholderGray;
       this.$emit('updateTransfer', this.displayOptions.exam, this.displayOptions.class, this.tookSwimTest);
     },

--- a/src/components/Modals/TourWindow.vue
+++ b/src/components/Modals/TourWindow.vue
@@ -58,6 +58,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 .blackout{
   z-index: 100;
   background-color:rgba(0,0,0,0.5);
@@ -85,7 +87,7 @@ export default {
   height: 66%;
   display: flex;
   justify-content: center;
-  background-color: #1AA9A5;
+  background-color: $emGreen;
   border-top-left-radius: 9px;
   border-top-right-radius: 9px;
   img{
@@ -112,7 +114,7 @@ export default {
     width: 90%;
   }
   button{
-    background-color: #508197;
+    background-color: $sangBlue;
     color: white;
     border: none;
     padding-right: .7em;

--- a/src/components/RequirementHeader.vue
+++ b/src/components/RequirementHeader.vue
@@ -100,6 +100,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 .major, .minor{
   display: flex;
   padding-bottom: 25px;
@@ -204,7 +206,7 @@ button.active {
   margin: 0.3125rem 0 0 0;
   font-size: 12px;
   line-height: 12px;
-  color: #3C3C3C;
+  color: $darkGray;
 
    &-credits {
      font-weight: bold;

--- a/src/components/RequirementHeader.vue
+++ b/src/components/RequirementHeader.vue
@@ -168,25 +168,25 @@ export default {
   font-weight: 600;
   font-size: 16px;
   line-height: 16px;
-  color: #000000;
+  color: $black;
 }
 .major {
   font-style: normal;
   font-weight: bold;
   font-size: 14px;
   line-height: 17px;
-  color: #000000;
+  color: $black;
   &-college {
     font-style: normal;
     font-weight: normal;
     font-size: 12px;
     line-height: 15px;
-    color: #000000;
+    color: $black;
   }
 }
 button.active {
-  color: #508197;
-  border-bottom: solid 10px #508197;
+  color: $sangBlue;
+  border-bottom: solid 10px $sangBlue;
   padding-bottom: 2px;
   margin: 5px;
 }
@@ -195,8 +195,8 @@ button.active {
   width: 14px;
 }
 .arrow {
-  fill: #1AA9A5;
-  color:#1AA9A5;
+  fill: $emGreen;
+  color:$emGreen;
   margin-top: -2px;
     &-up {
      margin-top: 4px;

--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -106,6 +106,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 .btn {
   padding: 0;
   display: flex;
@@ -135,7 +137,7 @@ export default {
   font-weight: bold;
   font-size: 14px;
   line-height: 14px;
-  color: #3C3C3C;
+  color: $darkGray;
 }
 button.active {
   color: #508197;

--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -140,8 +140,8 @@ export default {
   color: $darkGray;
 }
 button.active {
-  color: #508197;
-  border-bottom: solid 10px #508197;
+  color: $sangBlue;
+  border-bottom: solid 10px $sangBlue;
   padding-bottom: 2px;
   margin: 5px;
 }

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -316,6 +316,7 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
 .requirements, .fixed {
   height: 100vh;
   width: 25rem;
@@ -334,7 +335,7 @@ h1.title {
   font-weight: 550;
   font-size: 22px;
   line-height: 29px;
-  color: #000000;
+  color: $black;
 }
 .req {
   margin-top: auto;

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -430,7 +430,7 @@ export default {
   border-radius: 11px;
 
   &-addSemesterButton {
-    background: #508197;
+    background: $sangBlue;
     border-radius: 8px;
     min-height: 2.5rem;
     min-width: 9rem;

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -415,6 +415,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 @mixin hover-button {
   border-color: #15a6cf;
   background: rgba(0, 0, 0, 0.03);
@@ -455,7 +457,7 @@ export default {
   &-top {
     display: flex;
     justify-content: space-between;
-    color: #858585;
+    color: $medGray;
     margin-left: 1.125rem;
     margin-right: 1.125rem;
   }

--- a/src/components/SemesterView.vue
+++ b/src/components/SemesterView.vue
@@ -356,6 +356,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 .semesterView {
   width: 100%;
   display: flex;
@@ -373,7 +375,7 @@ export default {
     border-radius: 8px;
     min-height: 2.5rem;
     min-width: 9rem;
-    color: #ffffff;
+    color: $white;
     border: none;
   }
 
@@ -390,7 +392,7 @@ export default {
 
   &-switch {
     display: flex;
-    color: #858585;
+    color: $medGray;
     align-items: center;
   }
 

--- a/src/components/SemesterView.vue
+++ b/src/components/SemesterView.vue
@@ -371,7 +371,7 @@ export default {
   }
 
   &-addSemesterButton {
-    background: #508197;
+    background: $sangBlue;
     border-radius: 8px;
     min-height: 2.5rem;
     min-width: 9rem;

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -86,6 +86,8 @@ export default {
 
 
 <style scoped lang="scss">
+@import "@/assets/scss/_variables.scss";
+
 .btn {
   padding: 0;
   display: flex;
@@ -124,16 +126,16 @@ export default {
   cursor: pointer;
 }
 button.active {
-  color: #508197;
-  border-bottom: solid 10px #508197;
+  color: $sangBlue;
+  border-bottom: solid 10px $sangBlue;
   padding-bottom: 2px;
   margin: 5px;
 }
 .arrow {
   height: 14px;
   width: 14px;
-  fill: #1AA9A5;
-  color:#1AA9A5;
+  fill: $emGreen;
+  color:$emGreen;
   margin-top: -2px;
     &-up {
      margin-top: 4px;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,11 +7,11 @@ import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
 import 'intro.js/introjs.css';
 import './assets/scss/introjs.scss';
+import './assets/scss/app.scss';
 
 import App from './App.vue';
 import router from './router/index';
 import store from './store';
-import './assets/scss/app.scss';
 
 import * as fb from './firebaseConfig';
 


### PR DESCRIPTION
### Summary
The colors used for CoursePlan was super decentralized. Every instance of using colors with hex codes is just copy-pasted directly from the designs. This PR is a massive overhaul to centralize the colors with SCSS variables.

The variables can be seen at and changed at `src/assets/scss/_variables.scss`.

**Instructions to import global color variables** 
```JS
// To import into <script>
import { inactiveBlue, ... } from '@/assets/scss/_variables.scss';

// To import into <style>
@import "@/assets/scss/_variables.scss";
```

### Test Plan
All color schemes should work as before and color names consistent with the designs defined here.
<img width="606" alt="Screen Shot 2020-10-24 at 7 06 00 PM" src="https://user-images.githubusercontent.com/44352119/97095317-f5500900-162b-11eb-9633-acbab3d52569.png">

<img width="754" alt="Screen Shot 2020-10-24 at 7 03 29 PM" src="https://user-images.githubusercontent.com/44352119/97095323-ff720780-162b-11eb-95c8-b33d22e8736c.png">
<img width="311" alt="Screen Shot 2020-10-24 at 7 03 19 PM" src="https://user-images.githubusercontent.com/44352119/97095325-ff720780-162b-11eb-9a6b-0e6718015940.png">
<img width="972" alt="Screen Shot 2020-10-24 at 7 03 10 PM" src="https://user-images.githubusercontent.com/44352119/97095326-000a9e00-162c-11eb-8fa4-9b0312ff3040.png">
<img width="1435" alt="Screen Shot 2020-10-24 at 7 03 00 PM" src="https://user-images.githubusercontent.com/44352119/97095327-000a9e00-162c-11eb-8354-b1ccba94ed4d.png">

This pull request is predominately a refactoring effort involving CSS and minor changes in JS (all involving the altering of Hex codes). Nothing should be broken as a result.