### PR TITLE
Setup type definition and checker code for toggleable requirements

### DIFF
--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -117,11 +117,11 @@ export default Vue.extend({
         if (req.requirement.progressBar) {
           singleMenuRequirement.type = this.getRequirementTypeDisplayName(req.requirement.fulfilledBy);
           singleMenuRequirement.fulfilled = req.totalCountFulfilled || req.minCountFulfilled;
-          singleMenuRequirement.required = (req.requirement.fulfilledBy !== 'self-check' && req.requirement.totalCount) || req.requirement.minCount;
+          singleMenuRequirement.required = (req.requirement.fulfilledBy !== 'self-check' && req.totalCountRequired) || req.minCountRequired;
         }
         // Default display value of false for all requirement lists
         const displayableRequirementFulfillment = { ...req, displayDescription: false };
-        if (!req.minCountFulfilled || req.minCountFulfilled < (req.requirement.minCount || 0)) {
+        if (!req.minCountFulfilled || req.minCountFulfilled < req.minCountRequired) {
           singleMenuRequirement.ongoing.push(displayableRequirementFulfillment);
         } else {
           singleMenuRequirement.completed.push(displayableRequirementFulfillment);

--- a/src/requirements/generator.ts
+++ b/src/requirements/generator.ts
@@ -4,20 +4,14 @@ import {
   DecoratedRequirementsJson,
   UniversityRequirements,
   DecoratedCollegeOrMajorRequirement,
-  EligibleCourses
+  EligibleCourses,
+  RequirementChecker
 } from './types';
 import sourceRequirements from './data';
 import filteredAllCourses from './filtered-all-courses';
 
-const getEligibleCourses = (requirement: CollegeOrMajorRequirement): readonly EligibleCourses[] => {
-  if (requirement.fulfilledBy === 'self-check') return [];
-  // eligibleCoursesMap[semester][subject]
-  // gives you all courses number of the courses eligible for the given requirements.
-  const { checker: requirementChecker } = requirement;
-  const subRequirementCheckers = typeof requirementChecker === 'function'
-    ? [requirementChecker]
-    : requirementChecker;
-  return subRequirementCheckers.map(oneRequirementChecker => {
+const getEligibleCoursesFromRequirementCheckers = (checkers: readonly RequirementChecker[]): readonly EligibleCourses[] => (
+  checkers.map(oneRequirementChecker => {
     const eligibleCoursesMap: { [semester: string]: number[] } = {};
     Object.entries(filteredAllCourses).forEach(([semester, courses]) => {
       const courseIdSet = new Set(
@@ -31,7 +25,41 @@ const getEligibleCourses = (requirement: CollegeOrMajorRequirement): readonly El
       }
     });
     return eligibleCoursesMap;
-  });
+  })
+);
+
+const decorateRequirementWithCourses = (
+  requirement: CollegeOrMajorRequirement,
+): DecoratedCollegeOrMajorRequirement => {
+  switch (requirement.fulfilledBy) {
+    case 'self-check':
+      return requirement;
+    case 'courses':
+    case 'credits': {
+      const { checker, ...rest } = requirement;
+      return {
+        ...rest,
+        courses: getEligibleCoursesFromRequirementCheckers(typeof checker === 'function' ? [checker] : checker)
+      };
+    }
+    case 'toggleable': {
+      const { fulfillmentOptions } = requirement;
+      return {
+        ...requirement,
+        fulfillmentOptions: Object.fromEntries(
+          Object.entries(fulfillmentOptions).map(([optionName, option]) => {
+            const { checker, ...rest } = option;
+            const courses = getEligibleCoursesFromRequirementCheckers(
+              typeof checker === 'function' ? [checker] : checker
+            );
+            return [optionName, { ...rest, courses }];
+          })
+        )
+      };
+    }
+    default:
+      throw new Error();
+  }
 };
 
 const produceSatisfiableCoursesAttachedRequirementJson = (): DecoratedRequirementsJson => {
@@ -65,13 +93,7 @@ const produceSatisfiableCoursesAttachedRequirementJson = (): DecoratedRequiremen
     university, college: {}, major: {}, minor: {}
   };
   const decorateRequirements = (requirements: readonly CollegeOrMajorRequirement[]) => (
-    requirements.map(requirement => {
-      if (requirement.fulfilledBy === 'self-check') return requirement;
-      const { checker, ...rest } = requirement;
-      return {
-        ...rest, courses: getEligibleCourses(requirement)
-      };
-    })
+    requirements.map(decorateRequirementWithCourses)
   );
   Object.entries(college).forEach(([collegeName, collegeRequirement]) => {
     const { requirements, ...rest } = collegeRequirement;

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -2,10 +2,12 @@ import buildRequirementFulfillmentGraph from './requirement-graph-builder';
 import requirementJson from './typed-requirement-json';
 import {
   CourseTaken,
+  EligibleCourses,
   DecoratedCollegeOrMajorRequirement,
   RequirementFulfillment,
   RequirementFulfillmentStatistics,
-  GroupedRequirementFulfillmentReport
+  GroupedRequirementFulfillmentReport,
+  Course
 } from './types';
 
 type RequirementMap = { readonly [code: string]: readonly string[] };
@@ -84,30 +86,96 @@ function computeUniversityRequirementFulfillments(
     {
       requirement: academicCreditsRequirements,
       courses: [coursesThatCountTowardsAcademicCredits],
-      minCountFulfilled: coursesThatCountTowardsAcademicCredits.reduce((accumulator, course) => accumulator + course.credits, 0)
+      minCountFulfilled: coursesThatCountTowardsAcademicCredits.reduce((accumulator, course) => accumulator + course.credits, 0),
+      minCountRequired: 120
     },
     // PE Credits
     {
       requirement: PERequirement,
       courses: [coursesThatCountTowardsPE],
-      minCountFulfilled: coursesThatCountTowardsPE.length
+      minCountFulfilled: coursesThatCountTowardsPE.length,
+      minCountRequired: 2
     },
     // Swim Test
-    { requirement: swimmingTestRequirement, courses: [] }
+    {
+      requirement: swimmingTestRequirement,
+      courses: [],
+      minCountFulfilled: 0,
+      minCountRequired: 0
+    }
   ];
+}
+
+function computeFulfillmentStatisticsFromCourses(
+  coursesThatFulfilledRequirement: readonly (readonly CourseTaken[])[],
+  counting: 'courses' | 'credits',
+  operator: 'and' | 'or',
+  minCountRequired: number,
+  totalCountRequired?: number,
+): RequirementFulfillmentStatistics & { readonly courses: readonly (readonly CourseTaken[])[] } {
+  let minCountFulfilled = 0;
+  coursesThatFulfilledRequirement.forEach(coursesThatFulfilledSubRequirement => {
+    if (coursesThatFulfilledSubRequirement.length === 0) {
+      return;
+    }
+
+    switch (counting) {
+      case 'courses':
+        minCountFulfilled += operator === 'or'
+          ? coursesThatFulfilledSubRequirement.length
+          : 1;
+        break;
+      case 'credits':
+        minCountFulfilled += operator === 'or'
+          ? coursesThatFulfilledSubRequirement
+            .map(course => course.credits)
+            .reduce((a, b) => a + b, 0)
+          : coursesThatFulfilledSubRequirement
+            .map(course => course.credits)
+            .reduce((a, b) => a + b);
+        break;
+      default:
+        throw new Error('Fulfillment type unknown.');
+    }
+  });
+
+  if (totalCountRequired === undefined) {
+    return { minCountFulfilled, minCountRequired, courses: coursesThatFulfilledRequirement };
+  }
+
+  let totalCountFulfilled = 0;
+  Array.from(new Set(coursesThatFulfilledRequirement.flat()).values()).forEach(courseThatFulfilledRequirement => {
+    // depending on what it is fulfilled by, either increase the count or credits you took
+    switch (counting) {
+      case 'courses':
+        totalCountFulfilled += 1;
+        return;
+      case 'credits':
+        totalCountFulfilled += courseThatFulfilledRequirement.credits;
+        return;
+      default:
+        throw new Error('Fulfillment type unknown.');
+    }
+  });
+
+  return {
+    minCountFulfilled,
+    minCountRequired,
+    totalCountFulfilled,
+    totalCountRequired,
+    courses: coursesThatFulfilledRequirement
+  };
 }
 
 /**
  * @param coursesTaken a list of all taken courses.
- * @param requirement the requirement to compute course fulfillment.
+ * @param requirementCourses a list of eligible courses from requirement data.
  * @returns a naively computed list of courses that fulfill the requirement, partitioned into sub-requirement filfillment.
  */
 function filterAndPartitionCoursesThatFulfillRequirement(
   coursesTaken: readonly CourseTaken[],
-  requirement: DecoratedCollegeOrMajorRequirement
+  requirementCourses: readonly EligibleCourses[],
 ): CourseTaken[][] {
-  if (requirement.fulfilledBy === 'self-check') return [];
-  const { courses: requirementCourses } = requirement;
   const coursesThatFulfilledRequirement: CourseTaken[][] = requirementCourses.map(() => []);
   coursesTaken.forEach(courseTaken => {
     const { roster, courseId } = courseTaken;
@@ -121,57 +189,43 @@ function filterAndPartitionCoursesThatFulfillRequirement(
   return coursesThatFulfilledRequirement;
 }
 
-function computeFulfillmentStatistics<T extends {}>({ requirement, courses: coursesThatFulfilledRequirement }: RequirementFulfillment<T>): RequirementFulfillmentStatistics {
-  if (requirement.fulfilledBy === 'self-check') {
-    return { minCountFulfilled: 0 };
+function computeFulfillmentCoursesAndStatistics(
+  requirement: DecoratedCollegeOrMajorRequirement,
+  coursesTaken: readonly CourseTaken[],
+): RequirementFulfillmentStatistics & { readonly courses: readonly (readonly CourseTaken[])[] } {
+  switch (requirement.fulfilledBy) {
+    case 'self-check':
+      return { minCountFulfilled: 0, minCountRequired: 0, courses: [] };
+    case 'courses':
+    case 'credits':
+      return computeFulfillmentStatisticsFromCourses(
+        filterAndPartitionCoursesThatFulfillRequirement(coursesTaken, requirement.courses),
+        requirement.fulfilledBy,
+        requirement.operator,
+        requirement.minCount,
+        requirement.totalCount
+      );
+    case 'toggleable': {
+      // Choose the max fulfillment progress as the statistics
+      // TODO: take user choices into account when we are going to integrating that.
+      return Object.values(requirement.fulfillmentOptions).map(option => (
+        computeFulfillmentStatisticsFromCourses(
+          filterAndPartitionCoursesThatFulfillRequirement(coursesTaken, option.courses),
+          option.counting,
+          option.operator,
+          option.minCount,
+          option.totalCount
+        )
+      )).reduce((max, current) => {
+        if (max.minCountFulfilled / max.minCountRequired < current.minCountFulfilled / current.minCountRequired) {
+          return current;
+        }
+        return max;
+      });
+    }
+    default:
+      throw new Error();
   }
-
-  let minCountFulfilled = 0;
-  coursesThatFulfilledRequirement.forEach(coursesThatFulfilledSubRequirement => {
-    if (coursesThatFulfilledSubRequirement.length === 0) {
-      return;
-    }
-
-    switch (requirement.fulfilledBy) {
-      case 'courses':
-        minCountFulfilled += requirement.operator === 'or'
-          ? coursesThatFulfilledSubRequirement.length
-          : 1;
-        break;
-      case 'credits':
-        minCountFulfilled += requirement.operator === 'or'
-          ? coursesThatFulfilledSubRequirement
-            .map(course => course.credits)
-            .reduce((a, b) => a + b, 0)
-          : coursesThatFulfilledSubRequirement
-            .map(course => course.credits)
-            .reduce((a, b) => a + b);
-        break;
-      default:
-        throw new Error('Fulfillment type unknown.');
-    }
-  });
-
-  if (requirement.totalCount === undefined) {
-    return { minCountFulfilled };
-  }
-
-  let totalCountFulfilled = 0;
-  Array.from(new Set(coursesThatFulfilledRequirement.flat()).values()).forEach(courseThatFulfilledRequirement => {
-    // depending on what it is fulfilled by, either increase the count or credits you took
-    switch (requirement.fulfilledBy) {
-      case 'courses':
-        totalCountFulfilled += 1;
-        return;
-      case 'credits':
-        totalCountFulfilled += courseThatFulfilledRequirement.credits;
-        return;
-      default:
-        throw new Error('Fulfillment type unknown.');
-    }
-  });
-
-  return { minCountFulfilled, totalCountFulfilled };
 }
 
 /**
@@ -242,28 +296,39 @@ export function computeRequirements(
     // TODO assign an unique ID to each requirement entry.
     getRequirementUniqueID: requirement => `${requirement.name} ${requirement.description}`,
     getCourseUniqueID: course => `${course.roster} ${course.courseId}`,
-    getAllCoursesThatCanPotentiallySatisfyRequirement: requirement => (
-      requirement.fulfilledBy === 'self-check'
-        ? []
-        : requirement.courses
-          .map((eligibleCourses): readonly CourseTaken[] => {
-            const courses: CourseTaken[] = [];
-            Object.entries(eligibleCourses).forEach(([roster, courseIds]) => {
-              courseIds.forEach(courseId => courses.push({
-                roster,
-                courseId,
-                // Only roster and courseId are used for equality comparison,
-                // so other dummy values doesn't matter.
-                code: 'DUMMY',
-                subject: 'DUMMY',
-                number: 'DUMMY',
-                credits: 0
-              }));
-            });
-            return courses;
-          })
-          .flat()
-    ),
+    getAllCoursesThatCanPotentiallySatisfyRequirement: requirement => {
+      let eligibleCoursesList: readonly EligibleCourses[];
+      switch (requirement.fulfilledBy) {
+        case 'self-check':
+          return [];
+        case 'courses':
+        case 'credits':
+          eligibleCoursesList = requirement.courses;
+          break;
+        case 'toggleable':
+          eligibleCoursesList = Object.values(requirement.fulfillmentOptions).map(it => it.courses).flat();
+          break;
+        default:
+          throw new Error();
+      }
+      return eligibleCoursesList.map((eligibleCourses): readonly CourseTaken[] => {
+        const courses: CourseTaken[] = [];
+        Object.entries(eligibleCourses).forEach(([roster, courseIds]) => {
+          courseIds.forEach(courseId => courses.push({
+            roster,
+            courseId,
+            // Only roster and courseId are used for equality comparison,
+            // so other dummy values doesn't matter.
+            code: 'DUMMY',
+            subject: 'DUMMY',
+            number: 'DUMMY',
+            credits: 0
+          }));
+        });
+        return courses;
+      })
+        .flat();
+    },
     getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy: () => ({
       // Give back dummy value for now. Give it a real strategy when we have non-empty
       // userChoiceOnFulfillmentStrategy
@@ -284,12 +349,8 @@ export function computeRequirements(
   const minorFulfillmentStatisticsMap = new Map<string, FulfillmentStatistics[]>();
   requirementFulfillmentGraph.getAllRequirements().forEach(requirement => {
     const courses = requirementFulfillmentGraph.getConnectedCoursesFromRequirement(requirement);
-    const requirementAndCourses = {
-      requirement,
-      courses: filterAndPartitionCoursesThatFulfillRequirement(courses, requirement)
-    };
     const fulfillmentStatistics = {
-      ...requirementAndCourses, ...computeFulfillmentStatistics(requirementAndCourses)
+      requirement, ...computeFulfillmentCoursesAndStatistics(requirement, courses)
     };
 
     switch (requirement.sourceType) {

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -61,7 +61,18 @@ type RequirementFulfillmentInformation<T = {}> =
        * - `totalCount` specifies how many courses/credits need to be earned in total.
        */
       readonly totalCount?: number;
-    } & T);
+    } & T)
+  | {
+      readonly fulfilledBy: 'toggleable';
+      readonly fulfillmentOptions: {
+        readonly [optionName: string]: {
+          readonly minCount: number;
+          readonly totalCount?: number;
+          readonly counting: 'credits' | 'courses';
+          readonly operator: 'and' | 'or';
+        } & T;
+      };
+    };
 export type BaseRequirement = RequirementCommon & RequirementFulfillmentInformation;
 
 export type UniversityRequirements = {
@@ -70,9 +81,11 @@ export type UniversityRequirements = {
   readonly requirements: readonly BaseRequirement[];
 };
 
-type Checker = (course: Course) => boolean;
+export type RequirementChecker = (course: Course) => boolean;
 export type CollegeOrMajorRequirement = RequirementCommon &
-  RequirementFulfillmentInformation<{ readonly checker: Checker | readonly Checker[] }>;
+  RequirementFulfillmentInformation<{
+    readonly checker: RequirementChecker | readonly RequirementChecker[];
+  }>;
 
 export type EligibleCourses = {
   // "FA20": [123456, 42, 65536, /* and another crseId */]
@@ -126,8 +139,10 @@ export type RequirementFulfillmentStatistics = {
    * When it's a number, it's either number of courses or number of credits.
    * When it's undefined, it means that the requirement is self-check.
    */
-  readonly minCountFulfilled?: number;
+  readonly minCountFulfilled: number;
+  readonly minCountRequired: number;
   readonly totalCountFulfilled?: number;
+  readonly totalCountRequired?: number;
 };
 
 export type GroupedRequirementFulfillmentReport = {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR setups the foundation for integrating toggleable requirements into the system. To build confidence of this relatively complex migration, I decided not to add any toggleable requirements into the system in this diff. Instead I will only change the type definition to accommodate for toggleable requirements and change relevant code to make everything type check again.
 
In the next diff, I'm planning to add the first toggleable requirement in #131 and implement relevant frontend changes.

### Test Plan <!-- Required -->

`npm run req-gen` creates the same json, which proves that all the non-toggleable requirement checker logic is still the same.

The frontend checking should also be unimpacted:

<img width="1846" alt="Screen Shot 2020-11-03 at 11 28 01" src="https://user-images.githubusercontent.com/4290500/98013074-e1dd3480-1dc7-11eb-8a46-b3cbf82771f3.png">
