### PR TITLE
[easy] Move reqGroupColorMap from Requirements in RequirementView

### DIFF
--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -97,10 +97,20 @@ export default Vue.extend({
     reqIndex: Number, // Index of this req in reqs array
     majors: Array as PropType<readonly Major[]>,
     minors: Array as PropType<readonly Minor[]>,
-    reqGroupColorMap: Object,
     user: Object as PropType<AppUser>,
     showMajorOrMinorRequirements: Boolean,
     numOfColleges: Number
+  },
+  data() {
+    return {
+      // reqGroupColorMap maps reqGroup to an array [<hex color for progress bar>, <color for arrow image>]
+      reqGroupColorMap: {
+        UNIVERSITY: ['508197', 'grayblue'],
+        COLLEGE: ['1AA9A5', 'blue'],
+        MAJOR: ['105351', 'green'],
+        MINOR: ['92C3E6', 'lightblue']
+      },
+    };
   },
   methods: {
     activateMajor(id: number) {

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -16,7 +16,6 @@
         :reqIndex="index"
         :majors="majors"
         :minors="minors"
-        :reqGroupColorMap="reqGroupColorMap"
         :user="user"
         :showMajorOrMinorRequirements="showMajorOrMinorRequirements(index, req.group)"
         :numOfColleges="numOfColleges"
@@ -68,7 +67,6 @@ type Data = {
   majors: readonly Major[];
   minors: readonly Minor[];
   requirementsMap: RequirementMap;
-  reqGroupColorMap: {};
   numOfColleges: number
 }
 // emoji for clipboard
@@ -184,13 +182,6 @@ export default Vue.extend({
       ],
       requirementsMap: {
         // CS 1110: 'MQR-AS'
-      },
-      // reqGroupColorMap maps reqGroup to an array [<hex color for progress bar>, <color for arrow image>]
-      reqGroupColorMap: {
-        UNIVERSITY: ['508197', 'grayblue'],
-        COLLEGE: ['1AA9A5', 'blue'],
-        MAJOR: ['105351', 'green'],
-        MINOR: ['92C3E6', 'lightblue']
       },
       numOfColleges: 1
     };


### PR DESCRIPTION
### Summary <!-- Required -->

It's only used in RequirementView, so let's just move it there to pass one less prop.

### Test Plan <!-- Required -->

Requirements render as usual:

<img width="1792" alt="Screen Shot 2020-11-06 at 12 27 26" src="https://user-images.githubusercontent.com/4290500/98396295-86ab7c00-202b-11eb-9832-0749d541d64e.png">
