### PR TITLE
[easy] Remove unused color field in SingleMenuRequirement

### DIFF
--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -102,7 +102,6 @@ export default Vue.extend({
         name: `${group.groupName.charAt(0) + group.groupName.substring(1).toLowerCase()} Requirements`,
         group: group.groupName.toUpperCase(),
         specific: (group.specific) ? group.specific : null,
-        color: '105351',
         displayDetails: false,
         displayCompleted: false
       };

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -156,7 +156,6 @@ export type SingleMenuRequirement = {
   readonly name: string;
   readonly group: string;
   readonly specific: string | null;
-  readonly color: string;
   displayDetails: boolean;
   displayCompleted: boolean;
   type?: string;


### PR DESCRIPTION
### Summary <!-- Required -->

The field doesn't seem to be used anywhere. It's probably there before we have `reqGroupColorMap`.

### Test Plan <!-- Required -->

👀 , and CI passes.