### PR TITLE
Move prettier config to package.json

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  tabWidth: 2,
-  semi: true,
-  singleQuote: true,
-  arrowParens: 'avoid',
-};

--- a/package.json
+++ b/package.json
@@ -63,6 +63,12 @@
     "typescript": "~3.7.5",
     "vue-template-compiler": "^2.6.11"
   },
+  "prettier": {
+    "tabWidth": 2,
+    "semi": true,
+    "singleQuote": true,
+    "arrowParens": "avoid"
+  },
   "postcss": {
     "plugins": {
       "autoprefixer": {}


### PR DESCRIPTION
### Summary <!-- Required -->

Prettier vscode extension has some issues recognizing the js config:
https://github.com/prettier/prettier-vscode/issues/371#issuecomment-447757781
Move to package.json for better editor autoformat experience.

### Test Plan <!-- Required -->

CI format still passes, which shows this config movement changes nothing.
