### PR TITLE
Unentangle major and minor name and display

### DIFF
--- a/src/components/RequirementHeader.vue
+++ b/src/components/RequirementHeader.vue
@@ -6,17 +6,33 @@
     </div>
       <!-- TODO change for multiple colleges -->
       <div v-if="reqIndex==numOfColleges" class="major">
-        <div :style="{'border-bottom': major.display ? `2px solid #${reqGroupColorMap[req.group][0]}` : '' }"
-          @click="activateMajor(id)" class="major-title" v-for="(major, id) in majors" :key="major.id" :class="{ pointer: multipleMajors }">
-          <p :style="{'font-weight': major.display ? '500' : '', 'color' : major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}"  class="major-title-top">{{major.majorFN}}</p>
-          <p :style="{'color': major.display ? `#${reqGroupColorMap[req.group][0]}` : ''}" class="major-title-bottom">({{user.collegeFN}})</p>
+        <div :style="{'border-bottom': id === displayedMajorIndex ? `2px solid #${reqGroupColorMap[req.group][0]}` : '' }"
+          @click="activateMajor(id)" class="major-title" v-for="(major, id) in majors" :key="id" :class="{ pointer: multipleMajors }">
+          <p
+            :style="{
+              'font-weight': id === displayedMajorIndex ? '500' : '',
+              'color' : id === displayedMajorIndex ? `#${reqGroupColorMap[req.group][0]}` : ''
+            }"
+            class="major-title-top"
+          >
+            {{major.majorFN}}
+          </p>
+          <p :style="{'color': id === displayedMajorIndex ? `#${reqGroupColorMap[req.group][0]}` : ''}" class="major-title-bottom">({{user.collegeFN}})</p>
         </div>
       </div>
       <div v-if="reqIndex==numOfColleges+majors.length" class="minor">
-        <div :style="{'border-bottom': minor.display ? `2px solid #${reqGroupColorMap[req.group][0]}` : '' }"
-          @click="activateMinor(id)" class="major-title" v-for="(minor, id) in minors" :key="minor.id"
+        <div :style="{'border-bottom': id === displayedMinorIndex ? `2px solid #${reqGroupColorMap[req.group][0]}` : '' }"
+          @click="activateMinor(id)" class="major-title" v-for="(minor, id) in minors" :key="id"
           :class="{ pointer: multipleMinors }">
-          <p :style="{'font-weight': minor.display ? '500' : '', 'color' : minor.display ? `#${reqGroupColorMap[req.group][0]}` : ''}"  class="minor-title-top">{{minor.minorFN}}</p>
+          <p
+            :style="{
+              'font-weight': id === displayedMinorIndex ? '500' : '',
+              'color' : id === displayedMinorIndex ? `#${reqGroupColorMap[req.group][0]}` : ''
+            }"
+            class="minor-title-top"
+          >
+            {{minor.minorFN}}
+          </p>
           <!-- <p :style="{'color': minor.display ? `#${reqGroupColorMap[req.group][0]}` : ''}" class="minor-title-bottom">({{user.collegeFN}})</p> Change for multiple colleges -->
         </div>
       </div>
@@ -26,7 +42,7 @@
         <div class="progress">
           <div
             class="progress-bar"
-            :style="{ 'background-color': `#${reqGroupColorMap[req.group][0]}`, width: `${(req.fulfilled/req.required)*100}%`}"
+            :style="{ 'background-color': `#${reqGroupColorMap[req.group][0]}`, width: progressWidth}"
             role="progressbar"
           ></div>
         </div>
@@ -69,24 +85,37 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
+
+import { SingleMenuRequirement } from '@/requirements/types';
+import { AppUser, AppMajor, AppMinor } from '@/user-data';
 
 export default Vue.extend({
   props: {
     reqIndex: Number,
-    majors: Array,
-    minors: Array,
-    req: Object,
-    reqGroupColorMap: Object,
-    user: Object,
+    majors: Array as PropType<readonly AppMajor[]>,
+    minors: Array as PropType<readonly AppMinor[]>,
+    displayedMajorIndex: Number,
+    displayedMinorIndex: Number,
+    req: Object as PropType<SingleMenuRequirement>,
+    reqGroupColorMap: Object as PropType<Readonly<Record<string, string[]>>>,
+    user: Object as PropType<AppUser>,
     showMajorOrMinorRequirements: Boolean,
     numOfColleges: Number
   },
-  data() {
-    return {
-      multipleMajors: this.majors.length > 1,
-      multipleMinors: this.minors.length > 1
-    };
+  computed: {
+    multipleMajors() {
+      return this.majors.length > 1;
+    },
+    multipleMinors() {
+      return this.minors.length > 1;
+    },
+    progressWidth() {
+      if (this.req.fulfilled != null && this.req.required != null) {
+        return `${this.req.fulfilled / this.req.required}%`;
+      }
+      return undefined;
+    }
   },
   methods: {
     toggleDetails(index: number) {

--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -4,6 +4,8 @@
       :reqIndex="reqIndex"
       :majors="majors"
       :minors="minors"
+      :displayedMajorIndex="displayedMajorIndex"
+      :displayedMinorIndex="displayedMinorIndex"
       :req="req"
       :reqGroupColorMap="reqGroupColorMap"
       :user="user"
@@ -20,7 +22,7 @@
         <div class="separator"></div>
         <div
           v-for="(subReq, id) in req.ongoing"
-          :key="subReq.id">
+          :key="id">
           <subrequirement
             :subReqIndex="id"
             :subReq="subReq"
@@ -47,7 +49,7 @@
 
       <!-- Completed requirements -->
         <div v-if="req.displayCompleted">
-          <div v-for="(subReq, id) in req.completed" :key="subReq.id">
+          <div v-for="(subReq, id) in req.completed" :key="id">
             <div class="separator" v-if="reqIndex < reqs.length - 1 || req.displayDetails"></div>
             <subrequirement
               :subReqIndex="id"
@@ -74,43 +76,36 @@ import RequirementHeader from '@/components/RequirementHeader.vue';
 // eslint-disable-next-line import/extensions
 import SubRequirement from '@/components/SubRequirement.vue';
 
-import { AppUser } from '@/user-data';
+import { SingleMenuRequirement } from '@/requirements/types';
+import { AppUser, AppMajor, AppMinor } from '@/user-data';
 
 Vue.component('requirementheader', RequirementHeader);
 Vue.component('subrequirement', SubRequirement);
 
-export type Major = {
-  display: boolean;
-  readonly major: string;
-  readonly majorFN: string;
-}
-export type Minor = {
-  display: boolean;
-  readonly minor: string;
-  readonly minorFN: string;
-}
+// reqGroupColorMap maps reqGroup to an array [<hex color for progress bar>, <color for arrow image>]
+const reqGroupColorMap = {
+  COLLEGE: ['1AA9A5', 'blue'],
+  MAJOR: ['105351', 'green'],
+  MINOR: ['92C3E6', 'lightblue']
+};
 
 export default Vue.extend({
   props: {
-    reqs: Array,
-    req: Object,
+    reqs: Array as PropType<readonly SingleMenuRequirement[]>,
+    req: Object as PropType<SingleMenuRequirement>,
     reqIndex: Number, // Index of this req in reqs array
-    majors: Array as PropType<readonly Major[]>,
-    minors: Array as PropType<readonly Minor[]>,
+    majors: Array as PropType<readonly AppMajor[]>,
+    minors: Array as PropType<readonly AppMinor[]>,
+    displayedMajorIndex: Number,
+    displayedMinorIndex: Number,
     user: Object as PropType<AppUser>,
     showMajorOrMinorRequirements: Boolean,
     numOfColleges: Number
   },
-  data() {
-    return {
-      // reqGroupColorMap maps reqGroup to an array [<hex color for progress bar>, <color for arrow image>]
-      reqGroupColorMap: {
-        UNIVERSITY: ['508197', 'grayblue'],
-        COLLEGE: ['1AA9A5', 'blue'],
-        MAJOR: ['105351', 'green'],
-        MINOR: ['92C3E6', 'lightblue']
-      },
-    };
+  computed: {
+    reqGroupColorMap() {
+      return reqGroupColorMap;
+    }
   },
   methods: {
     activateMajor(id: number) {

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -154,7 +154,7 @@ export type SingleMenuRequirement = {
   readonly ongoing: DisplayableRequirementFulfillment[];
   readonly completed: DisplayableRequirementFulfillment[];
   readonly name: string;
-  readonly group: string;
+  readonly group: 'COLLEGE' | 'MAJOR' | 'MINOR';
   readonly specific: string | null;
   displayDetails: boolean;
   displayCompleted: boolean;

--- a/src/user-data.ts
+++ b/src/user-data.ts
@@ -103,6 +103,16 @@ export type AppUser = {
   tookSwim: 'yes' | 'no';
 };
 
+export type AppMajor = {
+  readonly major: string;
+  readonly majorFN: string;
+};
+
+export type AppMinor = {
+  readonly minor: string;
+  readonly minorFN: string;
+};
+
 export type AppCourse = {
   readonly crseId: number;
   readonly subject: string;


### PR DESCRIPTION
### Summary

Right now our requirement related component is very messy. Since Vue allows you to mutate things directly, we are currently mixing mutable data along with immutable data together in a giant array. This makes reasoning about the correctness and data flow very hard.

This PR starts to unentangle mutable and immutable data, starting with major and minor. We have names for major and minor, which should be immutable. We also want to track which major/minor to display. This should be a local state tracked in `data` instead of being together in a mutable array.

To unentangle them, I make Requirement.vue track the index of the major/minor to display and pass this down, instead of tracking display status for each major minor object. I also did other related cleanup to ensure that all the mutable data only appears in `data`, and all immutable data only appears in `props` and `computed`.

### Test Plan

![toggle](https://user-images.githubusercontent.com/4290500/98560637-f7de6f80-2275-11eb-8806-7ed6f194e1cf.gif)