### PR TITLE
Give a unique ID for each requirement

### DIFF
--- a/src/requirements/generator.ts
+++ b/src/requirements/generator.ts
@@ -122,6 +122,26 @@ const produceSatisfiableCoursesAttachedRequirementJson = (): DecoratedRequiremen
     const { requirements, ...rest } = minorRequirement;
     decoratedJson.minor[minorName] = { ...rest, requirements: decorateRequirements(requirements) };
   });
+
+  // Check no duplicate requirement identifier
+  const allRequirementIDs = [
+    ...Object.entries(decoratedJson.college).map(
+      ([code, requirements]) => ['COLLEGE', code, requirements] as const
+    ),
+    ...Object.entries(decoratedJson.major).map(
+      ([code, requirements]) => ['MAJOR', code, requirements] as const
+    ),
+    ...Object.entries(decoratedJson.minor).map(
+      ([code, requirements]) => ['MINOR', code, requirements] as const
+    ),
+  ].flatMap(([category, code, { requirements }]) =>
+    requirements.map(it => `${category}-${code}-${it.name}`)
+  );
+  const idSet = new Set(allRequirementIDs);
+  if (idSet.size !== allRequirementIDs.length) {
+    throw new Error('There are some duplicate requirement IDs!');
+  }
+
   return decoratedJson;
 };
 

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -209,8 +209,8 @@ export function computeRequirements(
     userCourses: coursesTaken,
     userChoiceOnFulfillmentStrategy: [],
     userChoiceOnDoubleCountingElimiation: [],
-    // TODO assign an unique ID to each requirement entry.
-    getRequirementUniqueID: requirement => `${requirement.name} ${requirement.description}`,
+    getRequirementUniqueID: requirement =>
+      `${requirement.sourceType}-${requirement.sourceSpecificName}-${requirement.name}`,
     getCourseUniqueID: course => `${course.roster} ${course.courseId}`,
     getAllCoursesThatCanPotentiallySatisfyRequirement: requirement => {
       let eligibleCoursesList: readonly EligibleCourses[];


### PR DESCRIPTION
### Summary <!-- Required -->

By giving each requirement a unique ID, we can test whether two requirement objects are the same much easily. It also gives us a way to avoid using array index as a way to find requirement in the frontend. It will also give me a space-efficient way to store user's choice on toggleable requirements, since I only need to use the requirement ID to tell which requirement is the choice associated with.

### Test Plan <!-- Required -->

- Check that every requirement in the generated json has a unique id
- Requirement checking still works in frontend.