### PR TITLE
Unbreak update-user-data script

### DIFF
--- a/functions/update-user-data.js
+++ b/functions/update-user-data.js
@@ -1,11 +1,17 @@
 const admin = require('firebase-admin');
+const fs = require('fs');
 const serviceAccount = require('./service-account.json');
-const filteredAllCourses = require('./filtered-all-courses.json');
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
   databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
 });
+
+const filteredCoursesPaths = fs.readdirSync('./filtered_courses/');
+
+const filteredAllCourses = filteredCoursesPaths
+  .map(path => require('./filtered_courses/' + path))
+  .reduce((accum, currentValue) => Object.assign(accum, currentValue));
 
 const db = admin.firestore();
 const userDataCollection = db.collection('userData');


### PR DESCRIPTION

### Summary <!-- Required -->

The script is broken because we do longer have a `filtered-all-courses.json` in the place. A previous PR updates all the other code, but not this code. This diff fixes it.

### Test Plan <!-- Required -->

It still runs