### PR TITLE
Flip linter config to always require .vue extension on vue components import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['*.ts', '*.tsx'],
+      files: ['*.ts', '*.tsx', '*.vue'],
       rules: {
         'import/extensions': [
           'error',

--- a/src/components/404.vue
+++ b/src/components/404.vue
@@ -22,9 +22,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-// eslint-disable-next-line import/extensions
 import Footer from '@/components/Footer.vue';
-// eslint-disable-next-line import/extensions
 import TopBar from '@/components/TopBar.vue';
 
 Vue.component('custom-footer', Footer);

--- a/src/components/BottomBar.vue
+++ b/src/components/BottomBar.vue
@@ -27,7 +27,6 @@
 </template>
 
 <script lang="ts">
-/* eslint-disable import/extensions */
 import Vue, { PropType } from 'vue';
 import BottomBarCourse from '@/components/BottomBarCourse.vue';
 import BottomBarTabView from '@/components/BottomBarTabView.vue';

--- a/src/components/BottomBarTabView.vue
+++ b/src/components/BottomBarTabView.vue
@@ -61,7 +61,6 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-// eslint-disable-next-line import/extensions
 import BottomBarTab from '@/components/BottomBarTab.vue';
 import { AppBottomBarCourse } from '@/user-data';
 

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -56,7 +56,7 @@
 
 <script>
 import Vue from 'vue';
-import CourseMenu from '@/components/Modals/CourseMenu';
+import CourseMenu from '@/components/Modals/CourseMenu.vue';
 import { clickOutside } from '@/utilities';
 
 Vue.component('coursemenu', CourseMenu);

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -74,7 +74,6 @@
 </template>
 
 <script lang="ts">
-/* eslint-disable import/extensions */
 import Vue from 'vue';
 
 import introJs from 'intro.js';

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -173,13 +173,9 @@
 <script lang="ts">
 import Vue from 'vue';
 import firebase, { User } from 'firebase/app';
-// eslint-disable-next-line import/extensions
 import introJs from 'intro.js';
 
-// eslint-disable-next-line import/extensions
 import Footer from '@/components/Footer.vue';
-
-// eslint-disable-next-line import/extensions
 import TopBar from '@/components/TopBar.vue';
 
 import * as fb from '@/firebaseConfig';

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -68,7 +68,7 @@
 
 <script>
 import Vue from 'vue';
-import Course from '@/components/Course';
+import Course from '@/components/Course.vue';
 import { coursesColorSet } from '../../assets/constants/colors';
 
 export default {

--- a/src/components/Modals/DeleteSemester.vue
+++ b/src/components/Modals/DeleteSemester.vue
@@ -22,7 +22,6 @@
 </template>
 
 <script lang="ts">
-/* eslint-disable import/extensions */
 import Vue from 'vue';
 import NewCourse from '@/components/Modals/NewCourse.vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';

--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -32,8 +32,8 @@
 
 <script>
 import Vue from 'vue';
-import NewCourse from '@/components/Modals/NewCourse';
-import NewSemester from '@/components/Modals/NewSemester';
+import NewCourse from '@/components/Modals/NewCourse.vue';
+import NewSemester from '@/components/Modals/NewSemester.vue';
 
 Vue.component('newCourse', NewCourse);
 Vue.component('newSemester', NewSemester);

--- a/src/components/Modals/Modal.vue
+++ b/src/components/Modals/Modal.vue
@@ -27,9 +27,9 @@
 
 <script>
 import Vue from 'vue';
-import NewCourse from '@/components/Modals/NewCourse';
-import NewSemester from '@/components/Modals/NewSemester';
-import EditSemester from '@/components/Modals/EditSemester';
+import NewCourse from '@/components/Modals/NewCourse.vue';
+import NewSemester from '@/components/Modals/NewSemester.vue';
+import EditSemester from '@/components/Modals/EditSemester.vue';
 
 Vue.component('newCourse', NewCourse);
 Vue.component('newSemester', NewSemester);

--- a/src/components/Modals/Onboarding.vue
+++ b/src/components/Modals/Onboarding.vue
@@ -50,8 +50,8 @@
 <script>
 import Vue from 'vue';
 import reqsData from '@/requirements/typed-requirement-json';
-import OnboardingBasic from '@/components/Modals/OnboardingBasic';
-import OnboardingTransfer from '@/components/Modals/OnboardingTransfer';
+import OnboardingBasic from '@/components/Modals/OnboardingBasic.vue';
+import OnboardingTransfer from '@/components/Modals/OnboardingTransfer.vue';
 import { clickOutside } from '@/utilities';
 import { lightPlaceholderGray } from '@/assets/scss/_variables.scss';
 

--- a/src/components/Modals/OnboardingTransfer.vue
+++ b/src/components/Modals/OnboardingTransfer.vue
@@ -186,7 +186,7 @@
 
 import reqsData from '@/requirements/data/exams/ExamCredit';
 import coursesJSON from '../../assets/courses/courses.json';
-import NewCourse from '@/components/Modals/NewCourse';
+import NewCourse from '@/components/Modals/NewCourse.vue';
 import { clickOutside } from '@/utilities';
 import { inactiveGray, yuxuanBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
 

--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -71,9 +71,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-// eslint-disable-next-line import/extensions
 import RequirementHeader from '@/components/RequirementHeader.vue';
-// eslint-disable-next-line import/extensions
 import SubRequirement from '@/components/SubRequirement.vue';
 
 import { SingleMenuRequirement } from '@/requirements/types';

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -39,17 +39,11 @@ import { Vue } from 'vue-property-decorator';
 import { PropType } from 'vue';
 // @ts-ignore
 import VueCollapse from 'vue2-collapse';
-// eslint-disable-next-line import/extensions
 import introJs from 'intro.js';
 
-// Disable import extension check because TS module resolution depends on it.
-// eslint-disable-next-line import/extensions
 import Course from '@/components/Course.vue';
-// eslint-disable-next-line import/extensions
 import Modal from '@/components/Modals/Modal.vue';
-// eslint-disable-next-line import/extensions
 import RequirementView from '@/components/RequirementView.vue';
-// eslint-disable-next-line import/extensions
 import SubRequirement from '@/components/SubRequirement.vue';
 import { BaseRequirement as Requirement, CourseTaken, SingleMenuRequirement } from '@/requirements/types';
 import { RequirementMap, computeRequirements, computeRequirementMap } from '@/requirements/reqs-functions';

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -117,14 +117,13 @@
 
 <script>
 import Vue from 'vue';
-// eslint-disable-next-line import/extensions
 import introJs from 'intro.js';
-import Course from '@/components/Course';
-import Modal from '@/components/Modals/Modal';
-import Confirmation from '@/components/Confirmation';
-import SemesterMenu from '@/components/Modals/SemesterMenu';
-import DeleteSemester from '@/components/Modals/DeleteSemester';
-import EditSemester from '@/components/Modals/EditSemester';
+import Course from '@/components/Course.vue';
+import Modal from '@/components/Modals/Modal.vue';
+import Confirmation from '@/components/Confirmation.vue';
+import SemesterMenu from '@/components/Modals/SemesterMenu.vue';
+import DeleteSemester from '@/components/Modals/DeleteSemester.vue';
+import EditSemester from '@/components/Modals/EditSemester.vue';
 
 import { clickOutside } from '@/utilities';
 

--- a/src/components/SemesterView.vue
+++ b/src/components/SemesterView.vue
@@ -78,12 +78,12 @@
 <script>
 import Vue from 'vue';
 import clone from 'clone';
-import Course from '@/components/Course';
-import Semester from '@/components/Semester';
-import Confirmation from '@/components/Confirmation';
-import Caution from '@/components/Caution';
-import DeleteSemester from '@/components/Modals/DeleteSemester';
-import EditSemester from '@/components/Modals/EditSemester';
+import Course from '@/components/Course.vue';
+import Semester from '@/components/Semester.vue';
+import Confirmation from '@/components/Confirmation.vue';
+import Caution from '@/components/Caution.vue';
+import DeleteSemester from '@/components/Modals/DeleteSemester.vue';
+import EditSemester from '@/components/Modals/EditSemester.vue';
 
 import { auth, userDataCollection } from '@/firebaseConfig';
 

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -72,9 +72,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-// eslint-disable-next-line import/extensions
 import CompletedSubReqCourse from '@/components/CompletedSubReqCourse.vue';
-// eslint-disable-next-line import/extensions
 import IncompleteSubReqCourse from '@/components/IncompleteSubReqCourse.vue';
 
 import { DisplayableRequirementFulfillment } from '@/requirements/types';


### PR DESCRIPTION


### Summary <!-- Required -->

Initially I make the TS components suppress the linter warning since js components are still the majority. As we are moving more files to TS, it's the time to flip the default.

### Test Plan <!-- Required -->

👀 