### PR TITLE
Respect user's choice on toggleable requirement when computing it

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -271,6 +271,7 @@ export default Vue.extend({
      * Creates a course on frontend with either user or API data
      */
     createCourse(course: FirestoreSemesterCourse): AppCourse {
+      this.updateRequirementsMenu();
       return firestoreCourseToAppCourse(
         course,
         () => this.incrementID(),

--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -28,7 +28,6 @@
             :subReq="subReq"
             :reqIndex="reqIndex"
             :toggleableRequirementChoice="toggleableRequirementChoices[subReq.id]"
-            :changeToggleableRequirementChoice="changeToggleableRequirementChoice"
             :color="reqGroupColorMap[req.group][0]"
             :isCompleted="false"
             @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
@@ -58,8 +57,10 @@
               :subReqIndex="id"
               :subReq="subReq"
               :reqIndex="reqIndex"
+              :toggleableRequirementChoice="toggleableRequirementChoices[subReq.id]"
               :color="reqGroupColorMap[req.group][0]"
               :isCompleted="true"
+              @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
               @toggleDescription="toggleDescription"
             />
           </div>

--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -27,8 +27,11 @@
             :subReqIndex="id"
             :subReq="subReq"
             :reqIndex="reqIndex"
+            :toggleableRequirementChoice="toggleableRequirementChoices[subReq.id]"
+            :changeToggleableRequirementChoice="changeToggleableRequirementChoice"
             :color="reqGroupColorMap[req.group][0]"
             :isCompleted="false"
+            @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
             @toggleDescription="toggleDescription"
           />
         </div>
@@ -94,6 +97,7 @@ export default Vue.extend({
     reqIndex: Number, // Index of this req in reqs array
     majors: Array as PropType<readonly AppMajor[]>,
     minors: Array as PropType<readonly AppMinor[]>,
+    toggleableRequirementChoices: Object as PropType<Readonly<Record<string, string>>>,
     displayedMajorIndex: Number,
     displayedMinorIndex: Number,
     user: Object as PropType<AppUser>,
@@ -111,6 +115,9 @@ export default Vue.extend({
     },
     activateMinor(id: number) {
       this.$emit('activateMinor', id);
+    },
+    changeToggleableRequirementChoice(requirementID: string, option: string) {
+      this.$emit('changeToggleableRequirementChoice', requirementID, option);
     },
     toggleDetails(index: number) {
       this.$emit('toggleDetails', index);

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -92,16 +92,23 @@ export default Vue.extend({
     subReq: Object as PropType<DisplayableRequirementFulfillment>,
     subReqIndex: Number, // Subrequirement index
     reqIndex: Number, // Requirement index
+    toggleableRequirementChoice: {
+      type: String,
+      required: false,
+    },
     color: String,
     isCompleted: Boolean
   },
   data() {
-    return {
-      showFulfillmentOptionsDropdown: false,
-      selectedFulfillmentOption: this.subReq.requirement.fulfilledBy !== 'toggleable'
-        ? ''
-        : Object.keys(this.subReq.requirement.fulfillmentOptions)[0]
-    }
+    return { showFulfillmentOptionsDropdown: false };
+  },
+  computed: {
+    selectedFulfillmentOption(): string {
+      if (this.subReq.requirement.fulfilledBy !== 'toggleable') {
+        return '';
+      }
+      return this.toggleableRequirementChoice || Object.keys(this.subReq.requirement.fulfillmentOptions)[0];
+    },
   },
   directives: {
     'click-outside': clickOutside
@@ -126,8 +133,8 @@ export default Vue.extend({
       this.showFulfillmentOptionsDropdown = false;
     },
     chooseFulfillmentOption(option: string) {
-      this.selectedFulfillmentOption = option;
       this.showFulfillmentOptionsDropdown = false;
+      this.$emit('changeToggleableRequirementChoice', this.subReq.id, option);
     },
   },
 });

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -102,8 +102,15 @@ function filterAndPartitionCoursesThatFulfillRequirement(
   return coursesThatFulfilledRequirement;
 }
 
+type RequirementWithIDSourceType = DecoratedCollegeOrMajorRequirement & {
+  readonly id: string;
+  readonly sourceType: 'College' | 'Major' | 'Minor';
+  readonly sourceSpecificName: string;
+};
+
 function computeFulfillmentCoursesAndStatistics(
-  requirement: DecoratedCollegeOrMajorRequirement,
+  requirement: RequirementWithIDSourceType,
+  toggleableRequirementChoices: Readonly<Record<string, string>>,
   coursesTaken: readonly CourseTaken[]
 ): RequirementFulfillmentStatistics & { readonly courses: readonly (readonly CourseTaken[])[] } {
   switch (requirement.fulfilledBy) {
@@ -119,27 +126,18 @@ function computeFulfillmentCoursesAndStatistics(
         requirement.totalCount
       );
     case 'toggleable': {
-      // Choose the max fulfillment progress as the statistics
-      // TODO: take user choices into account when we are going to integrating that.
-      return Object.values(requirement.fulfillmentOptions)
-        .map(option =>
-          computeFulfillmentStatisticsFromCourses(
-            filterAndPartitionCoursesThatFulfillRequirement(coursesTaken, option.courses),
-            option.counting,
-            option.operator,
-            option.minCount,
-            option.totalCount
-          )
-        )
-        .reduce((max, current) => {
-          if (
-            max.minCountFulfilled / max.minCountRequired <
-            current.minCountFulfilled / current.minCountRequired
-          ) {
-            return current;
-          }
-          return max;
-        });
+      const option =
+        requirement.fulfillmentOptions[
+          toggleableRequirementChoices[requirement.id] ||
+            Object.keys(requirement.fulfillmentOptions)[0]
+        ];
+      return computeFulfillmentStatisticsFromCourses(
+        filterAndPartitionCoursesThatFulfillRequirement(coursesTaken, option.courses),
+        option.counting,
+        option.operator,
+        option.minCount,
+        option.totalCount
+      );
     }
     default:
       throw new Error();
@@ -149,6 +147,7 @@ function computeFulfillmentCoursesAndStatistics(
 /**
  * @param coursesTaken a list of classes taken by the user, with some metadata (e.g. no. of credits)
  * helping to compute requirement progress.
+ * @param toggleableRequirementChoices an object map from toggleable requirement IDs to choices
  * @param college user's college.
  * @param majors user's list of majors.
  * @param minors user's list of minors.
@@ -156,6 +155,7 @@ function computeFulfillmentCoursesAndStatistics(
  */
 export function computeRequirements(
   coursesTaken: readonly CourseTaken[],
+  toggleableRequirementChoices: Readonly<Record<string, string>>,
   college: string,
   majors: readonly string[] | null,
   minors: readonly string[] | null
@@ -169,23 +169,37 @@ export function computeRequirements(
   const universityReqs = requirementJson.university.UNI;
   const collegeReqs = requirementJson.college[college];
 
-  type RequirementWithSourceType = DecoratedCollegeOrMajorRequirement & {
-    readonly sourceType: 'College' | 'Major' | 'Minor';
-    readonly sourceSpecificName: string;
-  };
-  const requirementsToBeConsideredInGraph: readonly RequirementWithSourceType[] = [
+  const requirementsToBeConsideredInGraph: readonly RequirementWithIDSourceType[] = [
     ...universityReqs.requirements.map(
-      it => ({ ...it, sourceType: 'College', sourceSpecificName: college } as const)
+      it =>
+        ({
+          ...it,
+          id: `College-UNI-${it.name}`,
+          sourceType: 'College',
+          sourceSpecificName: college,
+        } as const)
     ),
     ...collegeReqs.requirements.map(
-      it => ({ ...it, sourceType: 'College', sourceSpecificName: college } as const)
+      it =>
+        ({
+          ...it,
+          id: `College-${college}-${it.name}`,
+          sourceType: 'College',
+          sourceSpecificName: college,
+        } as const)
     ),
     ...(majors || [])
       .map(major => {
         const majorRequirement = requirementJson.major[major];
         if (majorRequirement == null) return [];
         return majorRequirement.requirements.map(
-          it => ({ ...it, sourceType: 'Major', sourceSpecificName: major } as const)
+          it =>
+            ({
+              ...it,
+              id: `Major-${major}-${it.name}`,
+              sourceType: 'Major',
+              sourceSpecificName: major,
+            } as const)
         );
       })
       .flat(),
@@ -194,23 +208,61 @@ export function computeRequirements(
         const minorRequirement = requirementJson.minor[minor];
         if (minorRequirement == null) return [];
         return minorRequirement.requirements.map(
-          it => ({ ...it, sourceType: 'Minor', sourceSpecificName: minor } as const)
+          it =>
+            ({
+              ...it,
+              id: `Minor-${minor}-${it.name}`,
+              sourceType: 'Minor',
+              sourceSpecificName: minor,
+            } as const)
         );
       })
       .flat(),
   ];
+  type UserChoiceOnFulfillmentStrategy = {
+    readonly correspondingRequirement: RequirementWithIDSourceType;
+    readonly coursesOfChosenFulfillmentStrategy: readonly CourseTaken[];
+  };
+  const userChoiceOnFulfillmentStrategy = requirementsToBeConsideredInGraph
+    .map((requirement): UserChoiceOnFulfillmentStrategy | null => {
+      if (requirement.fulfilledBy !== 'toggleable') {
+        return null;
+      }
+      const optionName =
+        toggleableRequirementChoices[requirement.id] ||
+        Object.keys(requirement.fulfillmentOptions)[0];
+
+      const courses: CourseTaken[] = [];
+      requirement.fulfillmentOptions[optionName].courses.forEach(eligibleCourses => {
+        Object.entries(eligibleCourses).forEach(([roster, courseIds]) => {
+          courseIds.forEach(courseId =>
+            courses.push({
+              roster,
+              courseId,
+              // Only roster and courseId are used for equality comparison,
+              // so other dummy values doesn't matter.
+              code: 'DUMMY',
+              subject: 'DUMMY',
+              number: 'DUMMY',
+              credits: 0,
+            })
+          );
+        });
+      });
+      return { correspondingRequirement: requirement, coursesOfChosenFulfillmentStrategy: courses };
+    })
+    .filter((it): it is UserChoiceOnFulfillmentStrategy => it != null);
 
   const { requirementFulfillmentGraph } = buildRequirementFulfillmentGraph<
-    RequirementWithSourceType,
+    RequirementWithIDSourceType,
     CourseTaken,
-    undefined
+    UserChoiceOnFulfillmentStrategy
   >({
     requirements: requirementsToBeConsideredInGraph,
     userCourses: coursesTaken,
-    userChoiceOnFulfillmentStrategy: [],
+    userChoiceOnFulfillmentStrategy,
     userChoiceOnDoubleCountingElimiation: [],
-    getRequirementUniqueID: requirement =>
-      `${requirement.sourceType}-${requirement.sourceSpecificName}-${requirement.name}`,
+    getRequirementUniqueID: requirement => requirement.id,
     getCourseUniqueID: course => `${course.roster} ${course.courseId}`,
     getAllCoursesThatCanPotentiallySatisfyRequirement: requirement => {
       let eligibleCoursesList: readonly EligibleCourses[];
@@ -250,19 +302,15 @@ export function computeRequirements(
         })
         .flat();
     },
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy: () => ({
-      // Give back dummy value for now. Give it a real strategy when we have non-empty
-      // userChoiceOnFulfillmentStrategy
-      correspondingRequirement: requirementsToBeConsideredInGraph[0],
-      coursesOfChosenFulfillmentStrategy: [],
-    }),
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy: it => it,
     // TODO: Replace this dummy implementation once we decided how to determine if a requirement is
     // double-countable. Meanwhile, make it always return true to match the old behavior.
     allowDoubleCounting: () => true,
   });
 
   type FulfillmentStatistics = {
-    readonly requirement: RequirementWithSourceType;
+    readonly id: string;
+    readonly requirement: RequirementWithIDSourceType;
     readonly courses: readonly (readonly CourseTaken[])[];
   } & RequirementFulfillmentStatistics;
   const collegeFulfillmentStatistics: FulfillmentStatistics[] = [];
@@ -271,8 +319,9 @@ export function computeRequirements(
   requirementFulfillmentGraph.getAllRequirements().forEach(requirement => {
     const courses = requirementFulfillmentGraph.getConnectedCoursesFromRequirement(requirement);
     const fulfillmentStatistics = {
+      id: requirement.id,
       requirement,
-      ...computeFulfillmentCoursesAndStatistics(requirement, courses),
+      ...computeFulfillmentCoursesAndStatistics(requirement, toggleableRequirementChoices, courses),
     };
 
     switch (requirement.sourceType) {

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -48,7 +48,7 @@ type BuildRequirementFulfillmentGraphParameters<
     choice: UserChoiceOnFulfillmentStrategy
   ) => {
     readonly correspondingRequirement: Requirement;
-    readonly coursesOfChosenFulfillmentStrategy: Course[];
+    readonly coursesOfChosenFulfillmentStrategy: readonly Course[];
   };
   /**
    * Report whether a requirement allows a course connected to it to also be used to fulfill some

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -121,6 +121,8 @@ export type DecoratedRequirementsJson = {
 };
 
 export type RequirementFulfillment<M extends {}> = {
+  /** ID of the requirement */
+  readonly id: string;
   /** The original requirement object. */
   readonly requirement: BaseRequirement;
   /** A list of courses that satisfy this requirement. */


### PR DESCRIPTION
### Summary <!-- Required -->

This PR integrates toggleable user choices with the requirement graph computation. Now the algorithm will respect user choices! The core of the algorithm is implemented a while ago, so this PR is mostly connecting stuff.

Storing user choices in DB will be done in a future PR. In this PR, I only lifted the state of user choices to the Requirement.vue, so that the graph algorithm can use this data.

### Test Plan <!-- Required -->

![toggleable](https://user-images.githubusercontent.com/4290500/98870115-d5e51880-2440-11eb-9bec-1e7f9e8327b2.gif)


### Notes

You can see in the screenshot that all menus will be collapsed when the user changes the choice. This is a problem that I plan to deal it in another diff. 

Cause:
Right now we have to recompute requirement fulfillment completely, when some of the input changes. Unfortunately, the state of whether to display each menu is entangled the fulfillment data, so when nuking the requirement fulfillment during recomputation those display states are also gone.

Plan:
In a future PR, I plan to separate the display data with fulfillment data to fully solve this problem.