### PR TITLE
Store whether to display requirement group detail/completed ones using state

### DIFF
--- a/src/components/RequirementHeader.vue
+++ b/src/components/RequirementHeader.vue
@@ -55,10 +55,10 @@
         <!--View more college requirements -->
         <div class="row top">
           <div class="col-1 p-0" >
-            <button :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }" class="btn" @click="toggleDetails(reqIndex)">
+            <button :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }" class="btn" @click="toggleDetails(req.name)">
               <!-- svg for dropdown icon -->
               <img
-                v-if="req.displayDetails"
+                v-if="displayDetails[req.name]"
                 class="arrow arrow-up"
                 :src="require(`@/assets/images/dropup-${reqGroupColorMap[req.group][1]}.svg`)"
                 alt="dropup"
@@ -75,8 +75,8 @@
               <button
                   class="btn req-name"
                   :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }"
-                  @click="toggleDetails(reqIndex)">
-                  {{ (req.displayDetails) ? "Hide" : "View" }} All {{ req.group.charAt(0) + req.group.substring(1).toLowerCase() }} Requirements
+                  @click="toggleDetails(req.name)">
+                  {{ displayDetails[req.name] ? "Hide" : "View" }} All {{ req.group.charAt(0) + req.group.substring(1).toLowerCase() }} Requirements
               </button>
           </div>
         </div>
@@ -95,6 +95,7 @@ export default Vue.extend({
     reqIndex: Number,
     majors: Array as PropType<readonly AppMajor[]>,
     minors: Array as PropType<readonly AppMinor[]>,
+    displayDetails: Object as PropType<Readonly<Record<string, boolean>>>,
     displayedMajorIndex: Number,
     displayedMinorIndex: Number,
     req: Object as PropType<SingleMenuRequirement>,
@@ -118,8 +119,8 @@ export default Vue.extend({
     }
   },
   methods: {
-    toggleDetails(index: number) {
-      this.$emit('toggleDetails', index);
+    toggleDetails(name: string) {
+      this.$emit('toggleDetails', name);
     },
     activateMajor(id: number) {
       this.$emit('activateMajor', id);

--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -4,6 +4,7 @@
       :reqIndex="reqIndex"
       :majors="majors"
       :minors="minors"
+      :displayDetails="displayDetails"
       :displayedMajorIndex="displayedMajorIndex"
       :displayedMinorIndex="displayedMinorIndex"
       :req="req"
@@ -17,7 +18,7 @@
     />
     <div v-if="showMajorOrMinorRequirements">
       <!--Show more of completed requirements -->
-      <div v-if="req.displayDetails">
+      <div v-if="displayDetails[req.name]">
         <p class="sub-title">In-Depth College Requirements</p>
         <div class="separator"></div>
         <div
@@ -42,17 +43,17 @@
               <!-- Toggle to display completed reqs -->
               <p
                 class="toggle"
-                v-if="req.displayCompleted"
-                v-on:click="turnCompleted(reqIndex, false)">HIDE</p>
-              <p class="toggle" v-else v-on:click="turnCompleted(reqIndex, true)">SHOW</p>
+                v-if="displayCompleted[req.name]"
+                v-on:click="turnCompleted(req.name, false)">HIDE</p>
+              <p class="toggle" v-else v-on:click="turnCompleted(req.name, true)">SHOW</p>
             </button>
           </div>
         </div>
 
       <!-- Completed requirements -->
-        <div v-if="req.displayCompleted">
+        <div v-if="displayCompleted[req.name]">
           <div v-for="(subReq, id) in req.completed" :key="id">
-            <div class="separator" v-if="reqIndex < reqs.length - 1 || req.displayDetails"></div>
+            <div class="separator" v-if="reqIndex < reqs.length - 1 || displayDetails[req.name]"></div>
             <subrequirement
               :subReqIndex="id"
               :subReq="subReq"
@@ -98,6 +99,8 @@ export default Vue.extend({
     reqIndex: Number, // Index of this req in reqs array
     majors: Array as PropType<readonly AppMajor[]>,
     minors: Array as PropType<readonly AppMinor[]>,
+    displayDetails: Object as PropType<Readonly<Record<string, boolean>>>,
+    displayCompleted: Object as PropType<Readonly<Record<string, boolean>>>,
     toggleableRequirementChoices: Object as PropType<Readonly<Record<string, string>>>,
     displayedMajorIndex: Number,
     displayedMinorIndex: Number,
@@ -126,8 +129,8 @@ export default Vue.extend({
     toggleDescription(index: number, type: 'ongoing' | 'completed', id: number) {
       this.$emit('toggleDescription', index, type, id);
     },
-    turnCompleted(index: number, bool: boolean) {
-      this.$emit('turnCompleted', index, bool);
+    turnCompleted(name: string, bool: boolean) {
+      this.$emit('turnCompleted', name, bool);
     }
   }
 });

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -17,6 +17,8 @@
         :majors="majors"
         :minors="minors"
         :toggleableRequirementChoices="toggleableRequirementChoices"
+        :displayDetails="displayDetails"
+        :displayCompleted="displayCompleted"
         :displayedMajorIndex="displayedMajorIndex"
         :displayedMinorIndex="displayedMinorIndex"
         :user="user"
@@ -59,14 +61,15 @@ Vue.component('requirementview', RequirementView);
 Vue.use(VueCollapse);
 
 type Data = {
-  actives: readonly boolean[];
-  modalShow: boolean;
-  reqs: SingleMenuRequirement[];
+  reqs: readonly SingleMenuRequirement[];
+  // map from requirement group (e.g. CS major requirement group) to whether to display details.
+  displayDetails: Readonly<Record<string, boolean>>;
+  // map from requirement group to whether to display completed ones.
+  displayCompleted: Readonly<Record<string, boolean>>;
   // map from requirement ID to option chosen
   toggleableRequirementChoices: Readonly<Record<string, string>>;
   displayedMajorIndex: number,
   displayedMinorIndex: number,
-  requirementsMap: RequirementMap;
   numOfColleges: number
 }
 // emoji for clipboard
@@ -95,8 +98,6 @@ export default Vue.extend({
       // currentEditID: 0,
       // isEditing: false,
       // display: [],
-      actives: [false],
-      modalShow: false,
       displayedMajorIndex: 0,
       displayedMinorIndex: 0,
       reqs: [
@@ -141,10 +142,9 @@ export default Vue.extend({
         //   ]
         // }
       ],
+      displayDetails: {},
+      displayCompleted: {},
       toggleableRequirementChoices: {},
-      requirementsMap: {
-        // CS 1110: 'MQR-AS'
-      },
       numOfColleges: 1
     };
   },
@@ -192,9 +192,7 @@ export default Vue.extend({
           completed: [],
           name: `${group.groupName.charAt(0) + group.groupName.substring(1).toLowerCase()} Requirements`,
           group: group.groupName.toUpperCase() as 'COLLEGE' | 'MAJOR' | 'MINOR',
-          specific: (group.specific) ? group.specific : null,
-          displayDetails: false,
-          displayCompleted: false
+          specific: group.specific,
         };
         group.reqs.forEach(req => {
           // Create progress bar with requirement with progressBar = true
@@ -239,8 +237,8 @@ export default Vue.extend({
       };
       this.recomputeRequirements();
     },
-    toggleDetails(index: number): void {
-      this.reqs[index].displayDetails = !this.reqs[index].displayDetails;
+    toggleDetails(name: string): void {
+      this.displayDetails = { ...this.displayDetails, [name]: !this.displayDetails[name] };
     },
     toggleDescription(index: number, type: 'ongoing' | 'completed', id: number): void {
       if (type === 'ongoing') {
@@ -251,8 +249,8 @@ export default Vue.extend({
         this.reqs[index].completed[id].displayDescription = !currentBool;
       }
     },
-    turnCompleted(index: number, bool: boolean): void {
-      this.reqs[index].displayCompleted = bool;
+    turnCompleted(name: string, bool: boolean): void {
+      this.displayCompleted = { ...this.displayCompleted, [name]: bool };
     },
     getCourseCodesArray(): readonly CourseTaken[] {
       const courses: CourseTaken[] = [];

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -144,7 +144,7 @@ export type RequirementFulfillmentStatistics = {
 
 export type GroupedRequirementFulfillmentReport = {
   readonly groupName: 'University' | 'College' | 'Major' | 'Minor';
-  readonly specific: string | null;
+  readonly specific: string;
   readonly reqs: readonly RequirementFulfillment<RequirementFulfillmentStatistics>[];
 };
 
@@ -157,9 +157,7 @@ export type SingleMenuRequirement = {
   readonly completed: DisplayableRequirementFulfillment[];
   readonly name: string;
   readonly group: 'COLLEGE' | 'MAJOR' | 'MINOR';
-  readonly specific: string | null;
-  displayDetails: boolean;
-  displayCompleted: boolean;
+  readonly specific: string;
   type?: string;
   fulfilled?: number;
   required?: number;


### PR DESCRIPTION
### Summary <!-- Required -->
 
In this notes of #194, I mentioned that storing whether to displaying details/completed requirement inside the array can cause the app to forget about its state during a full requirement recomputation.

This diff removes those fields from `SingleMenuRequirement` type and instead store it inside two separate fields `displayCompleted`/`displayDetails` that are independent of the requirement array. After this diff, recomputing the requirement won't also close all expanded details and completed requirement sections!

### Test Plan <!-- Required -->

- Toggle detail/completed still works.
- Now try to change requirement fulfillment option in toggleable requirement will not auto close expanded menus on the left!

### Notes

There are still some work to be done about dealing with toggle details within a subrequirement.