### PR TITLE
Only apply completed-ptext to text to unbreak toggleable option UI

### DIFF
--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -18,7 +18,9 @@
       </button>
     </div>
     <div class="col-7" @click="toggleDescription(reqIndex, isCompleted, subReqIndex)">
-      <p v-bind:class="[{'sup-req': !this.isCompleted}, 'pointer', this.isCompleted ? 'completed-ptext' : 'incomplete-ptext']">{{subReq.requirement.name}}</p>
+      <p v-bind:class="[{'sup-req': !this.isCompleted}, 'pointer', this.isCompleted ? 'completed-ptext' : 'incomplete-ptext']">
+        <span>{{subReq.requirement.name}}</span>
+      </p>
     </div>
     <div class="col">
       <p v-if="!this.isCompleted" class="sup-req-progress text-right incomplete-ptext">{{
@@ -26,7 +28,9 @@
         ? `${subReq.totalCountFulfilled || subReq.minCountFulfilled}/${subReq.totalCountRequired
         || subReq.minCountRequired} ${subReq.fulfilledBy}`
         : 'self check' }}</p>
-      <p v-if="this.isCompleted" class="text-right completed-ptext">{{subReq.minCountFulfilled}}/{{subReq.minCountRequired}} {{ subReq.fulfilledBy }}</p>
+      <p v-if="this.isCompleted" class="text-right completed-ptext">
+        <span>{{subReq.minCountFulfilled}}/{{subReq.minCountRequired}} {{ subReq.fulfilledBy }}</span>
+      </p>
     </div>
   </div>
   <div v-if="subReq.displayDescription" :class="[{'completed-ptext': this.isCompleted}, 'description']">
@@ -47,7 +51,7 @@
             <div
               class="toggleable-requirements-dropdown-placeholder toggleable-requirements-dropdown-innerPlaceholder"
             >
-              {{ selectedFulfillmentOption }}
+              <span>{{ selectedFulfillmentOption }}</span>
             </div>
             <div class="toggleable-requirements-dropdown-placeholder toggleable-requirements-dropdown-arrow"></div>
           </div>
@@ -58,7 +62,7 @@
               class="toggleable-requirements-dropdown-content-item"
               @click="chooseFulfillmentOption(optionName)"
             >
-              {{optionName}}
+              <span>{{optionName}}</span>
             </div>
           </div>
         </div>
@@ -208,15 +212,12 @@ button.view {
   color: white;
   text-transform: uppercase;
 }
-.completed {
-   margin-top: 1rem;
-   &-ptext {
-     color: $lightPlaceholderGray;
-     font-size: 12px;
-     opacity: 0.8;
-     font-weight: normal;
-   }
- }
+.completed-ptext span {
+  color: $lightPlaceholderGray;
+  font-size: 12px;
+  opacity: 0.8;
+  font-weight: normal;
+}
 .incomplete {
   &-ptext {
     font-size: 14px;


### PR DESCRIPTION
### Summary <!-- Required -->

The old css code incorrectly makes the `opacity: 0.8` css cascading down to the dropdown container, causing a bad transparent UI (see first screenshot in test plan)

This diff fixes it by only applying it to text.

### Test Plan <!-- Required -->

Previous:
<img width="374" alt="wrong" src="https://user-images.githubusercontent.com/4290500/99104738-617cb780-25af-11eb-9c22-fddfb8d072a8.png">

Fixed (filled state):
<img width="395" alt="correct-filled" src="https://user-images.githubusercontent.com/4290500/99104748-6477a800-25af-11eb-87d3-1568a930e3ba.png">

Fixed (unfilled state):
<img width="375" alt="correct-unfilled" src="https://user-images.githubusercontent.com/4290500/99104749-6477a800-25af-11eb-8dda-b96160d74b89.png">
