### PR TITLE
Store whether to display details/completed in requirement bar as local state

### DIFF
--- a/src/components/RequirementHeader.vue
+++ b/src/components/RequirementHeader.vue
@@ -55,10 +55,10 @@
         <!--View more college requirements -->
         <div class="row top">
           <div class="col-1 p-0" >
-            <button :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }" class="btn" @click="toggleDetails(req.name)">
+            <button :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }" class="btn" @click="toggleDetails()">
               <!-- svg for dropdown icon -->
               <img
-                v-if="displayDetails[req.name]"
+                v-if="displayDetails"
                 class="arrow arrow-up"
                 :src="require(`@/assets/images/dropup-${reqGroupColorMap[req.group][1]}.svg`)"
                 alt="dropup"
@@ -75,8 +75,8 @@
               <button
                   class="btn req-name"
                   :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }"
-                  @click="toggleDetails(req.name)">
-                  {{ displayDetails[req.name] ? "Hide" : "View" }} All {{ req.group.charAt(0) + req.group.substring(1).toLowerCase() }} Requirements
+                  @click="toggleDetails()">
+                  {{ displayDetails ? "Hide" : "View" }} All {{ req.group.charAt(0) + req.group.substring(1).toLowerCase() }} Requirements
               </button>
           </div>
         </div>
@@ -95,7 +95,7 @@ export default Vue.extend({
     reqIndex: Number,
     majors: Array as PropType<readonly AppMajor[]>,
     minors: Array as PropType<readonly AppMinor[]>,
-    displayDetails: Object as PropType<Readonly<Record<string, boolean>>>,
+    displayDetails: Boolean,
     displayedMajorIndex: Number,
     displayedMinorIndex: Number,
     req: Object as PropType<SingleMenuRequirement>,
@@ -119,8 +119,8 @@ export default Vue.extend({
     }
   },
   methods: {
-    toggleDetails(name: string) {
-      this.$emit('toggleDetails', name);
+    toggleDetails() {
+      this.$emit('toggleDetails');
     },
     activateMajor(id: number) {
       this.$emit('activateMajor', id);

--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -18,7 +18,7 @@
     />
     <div v-if="showMajorOrMinorRequirements">
       <!--Show more of completed requirements -->
-      <div v-if="displayDetails[req.name]">
+      <div v-if="displayDetails">
         <p class="sub-title">In-Depth College Requirements</p>
         <div class="separator"></div>
         <div
@@ -32,7 +32,6 @@
             :color="reqGroupColorMap[req.group][0]"
             :isCompleted="false"
             @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
-            @toggleDescription="toggleDescription"
           />
         </div>
 
@@ -41,19 +40,16 @@
           <div class="col-1 text-right">
             <button class="btn float-right" :style="{ 'color': `#${reqGroupColorMap[req.group][0]}` }">
               <!-- Toggle to display completed reqs -->
-              <p
-                class="toggle"
-                v-if="displayCompleted[req.name]"
-                v-on:click="turnCompleted(req.name, false)">HIDE</p>
-              <p class="toggle" v-else v-on:click="turnCompleted(req.name, true)">SHOW</p>
+              <p class="toggle" v-if="displayCompleted" v-on:click="turnCompleted(false)">HIDE</p>
+              <p class="toggle" v-else v-on:click="turnCompleted(true)">SHOW</p>
             </button>
           </div>
         </div>
 
       <!-- Completed requirements -->
-        <div v-if="displayCompleted[req.name]">
+        <div v-if="displayCompleted">
           <div v-for="(subReq, id) in req.completed" :key="id">
-            <div class="separator" v-if="reqIndex < reqs.length - 1 || displayDetails[req.name]"></div>
+            <div class="separator" v-if="reqIndex < reqs.length - 1 || displayDetails"></div>
             <subrequirement
               :subReqIndex="id"
               :subReq="subReq"
@@ -62,7 +58,6 @@
               :color="reqGroupColorMap[req.group][0]"
               :isCompleted="true"
               @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
-              @toggleDescription="toggleDescription"
             />
           </div>
         </div>
@@ -99,14 +94,18 @@ export default Vue.extend({
     reqIndex: Number, // Index of this req in reqs array
     majors: Array as PropType<readonly AppMajor[]>,
     minors: Array as PropType<readonly AppMinor[]>,
-    displayDetails: Object as PropType<Readonly<Record<string, boolean>>>,
-    displayCompleted: Object as PropType<Readonly<Record<string, boolean>>>,
     toggleableRequirementChoices: Object as PropType<Readonly<Record<string, string>>>,
     displayedMajorIndex: Number,
     displayedMinorIndex: Number,
     user: Object as PropType<AppUser>,
     showMajorOrMinorRequirements: Boolean,
     numOfColleges: Number
+  },
+  data() {
+    return {
+      displayDetails: false,
+      displayCompleted: false,
+    };
   },
   computed: {
     reqGroupColorMap() {
@@ -123,14 +122,11 @@ export default Vue.extend({
     changeToggleableRequirementChoice(requirementID: string, option: string) {
       this.$emit('changeToggleableRequirementChoice', requirementID, option);
     },
-    toggleDetails(index: number) {
-      this.$emit('toggleDetails', index);
+    toggleDetails() {
+      this.displayDetails = !this.displayDetails;
     },
-    toggleDescription(index: number, type: 'ongoing' | 'completed', id: number) {
-      this.$emit('toggleDescription', index, type, id);
-    },
-    turnCompleted(name: string, bool: boolean) {
-      this.$emit('turnCompleted', name, bool);
+    turnCompleted(bool: boolean) {
+      this.displayCompleted = bool;
     }
   }
 });

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -17,8 +17,6 @@
         :majors="majors"
         :minors="minors"
         :toggleableRequirementChoices="toggleableRequirementChoices"
-        :displayDetails="displayDetails"
-        :displayCompleted="displayCompleted"
         :displayedMajorIndex="displayedMajorIndex"
         :displayedMinorIndex="displayedMinorIndex"
         :user="user"
@@ -27,9 +25,6 @@
         @changeToggleableRequirementChoice="chooseToggleableRequirementOption"
         @activateMajor="activateMajor"
         @activateMinor="activateMinor"
-        @toggleDetails="toggleDetails"
-        @toggleDescription="toggleDescription"
-        @turnCompleted="turnCompleted"
       />
     </div>
     </div>
@@ -62,10 +57,6 @@ Vue.use(VueCollapse);
 
 type Data = {
   reqs: readonly SingleMenuRequirement[];
-  // map from requirement group (e.g. CS major requirement group) to whether to display details.
-  displayDetails: Readonly<Record<string, boolean>>;
-  // map from requirement group to whether to display completed ones.
-  displayCompleted: Readonly<Record<string, boolean>>;
   // map from requirement ID to option chosen
   toggleableRequirementChoices: Readonly<Record<string, string>>;
   displayedMajorIndex: number,
@@ -142,8 +133,6 @@ export default Vue.extend({
         //   ]
         // }
       ],
-      displayDetails: {},
-      displayCompleted: {},
       toggleableRequirementChoices: {},
       numOfColleges: 1
     };
@@ -236,21 +225,6 @@ export default Vue.extend({
         [requirementID]: option,
       };
       this.recomputeRequirements();
-    },
-    toggleDetails(name: string): void {
-      this.displayDetails = { ...this.displayDetails, [name]: !this.displayDetails[name] };
-    },
-    toggleDescription(index: number, type: 'ongoing' | 'completed', id: number): void {
-      if (type === 'ongoing') {
-        const currentBool = this.reqs[index].ongoing[id].displayDescription;
-        this.reqs[index].ongoing[id].displayDescription = !currentBool;
-      } else if (type === 'completed') {
-        const currentBool = this.reqs[index].completed[id].displayDescription;
-        this.reqs[index].completed[id].displayDescription = !currentBool;
-      }
-    },
-    turnCompleted(name: string, bool: boolean): void {
-      this.displayCompleted = { ...this.displayCompleted, [name]: bool };
     },
     getCourseCodesArray(): readonly CourseTaken[] {
       const courses: CourseTaken[] = [];

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="subrequirement">
   <div class="row depth-req">
-    <div class="col-1" @click="toggleDescription(reqIndex, isCompleted, subReqIndex)">
+    <div class="col-1" @click="toggleDescription()">
       <button class="btn">
         <img
-          v-if="subReq.displayDescription"
+          v-if="displayDescription"
           class="arrow arrow-up"
           :src="getSrc()"
           alt="dropup"
@@ -17,7 +17,7 @@
         />
       </button>
     </div>
-    <div class="col-7" @click="toggleDescription(reqIndex, isCompleted, subReqIndex)">
+    <div class="col-7" @click="toggleDescription()">
       <p v-bind:class="[{'sup-req': !this.isCompleted}, 'pointer', this.isCompleted ? 'completed-ptext' : 'incomplete-ptext']">
         <span>{{subReq.requirement.name}}</span>
       </p>
@@ -33,7 +33,7 @@
       </p>
     </div>
   </div>
-  <div v-if="subReq.displayDescription" :class="[{'completed-ptext': this.isCompleted}, 'description']">
+  <div v-if="displayDescription" :class="[{'completed-ptext': this.isCompleted}, 'description']">
     {{ subReq.requirement.description }} <a class="more"
     :style="{ 'color': `#${color}` }"
     :href="subReq.requirement.source" target="_blank">
@@ -104,7 +104,10 @@ export default Vue.extend({
     isCompleted: Boolean
   },
   data() {
-    return { showFulfillmentOptionsDropdown: false };
+    return {
+      displayDescription: false,
+      showFulfillmentOptionsDropdown: false,
+    };
   },
   computed: {
     selectedFulfillmentOption(): string {
@@ -120,18 +123,17 @@ export default Vue.extend({
   methods: {
     getSrc() {
       let src = dropdownCompletedSrc;
-      if (this.subReq.displayDescription && !this.isCompleted) {
+      if (this.displayDescription && !this.isCompleted) {
         src = dropupIncompleteSrc;
-      } else if (this.subReq.displayDescription && this.isCompleted) {
+      } else if (this.displayDescription && this.isCompleted) {
         src = dropupCompletedSrc;
-      } else if (!this.subReq.displayDescription && !this.isCompleted) {
+      } else if (!this.displayDescription && !this.isCompleted) {
         src = dropdownIncompleteSrc;
       }
       return src;
     },
-    toggleDescription(reqIndex: number, isCompleted: boolean, subReqIndex: number) {
-      const type = isCompleted ? 'completed' : 'ongoing';
-      this.$emit('toggleDescription', reqIndex, type, subReqIndex);
+    toggleDescription() {
+      this.displayDescription = !this.displayDescription;
     },
     closeMenuIfOpen() {
       this.showFulfillmentOptionsDropdown = false;

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -149,7 +149,7 @@ export type GroupedRequirementFulfillmentReport = {
 };
 
 export type DisplayableRequirementFulfillment = RequirementFulfillment<
-  RequirementFulfillmentStatistics & { displayDescription: boolean }
+  RequirementFulfillmentStatistics
 >;
 
 export type SingleMenuRequirement = {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR makes each requirement view store the display state instead of making them managed at a central place.

### Test Plan <!-- Required -->

- Toggling detail and completed section still works.
- Now changing toggleable requirements no longer auto collapse subrequirement details!