### PR TITLE
Factor out alerts from AppCourse object

### DIFF
--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -23,16 +23,7 @@
           <span v-if="!compact && semesterString" class="course-semesters">{{
             semesterString
           }}</span>
-          <!-- <div v-if="!compact && alerts.requirement" class="course-outerWrapper course-tooltip">
-            <div class="course-iconWrapper course-iconWrapper--info">
-              <img class="course-icon course-icon--info" src="../assets/images/info.svg" />
-            </div>
-            <div
-              class="course-tooltiptext course-tooltiptext--info"
-              v-html="requirementString"
-            ></div>
-          </div> -->
-          <div v-if="alerts.caution" class="course-outerWrapper course-tooltip">
+          <div v-if="cautionString" class="course-outerWrapper course-tooltip">
             <div v-if="!compact" class="course-iconWrapper course-iconWrapper--caution">
               <img class="course-icon course-icon--caution" src="../assets/images/caution.svg" />
             </div>
@@ -76,7 +67,7 @@ export default Vue.extend({
     prereqs: String,
     semesters: Array,
     color: String,
-    alerts: Object,
+    duplicatedCourseCodeList: Array,
     compact: Boolean,
     id: String,
     uniqueID: Number,
@@ -93,14 +84,11 @@ export default Vue.extend({
     };
   },
   computed: {
-    requirementString() {
-      return this.alerts.requirement;
-    },
-
     cautionString() {
-      return this.alerts.caution;
+      return this.duplicatedCourseCodeList.includes(`${this.subject} ${this.number}`)
+        ? 'Duplicate'
+        : null;
     },
-
     semesterString() {
       let semesterString = '';
       this.semesters.forEach(semester => {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -23,7 +23,6 @@
           :user="user"
           :key="requirementsKey"
           :startTour="startTour"
-          @requirementsMap="loadRequirementsMap"
           @createCourse="createCourse"
           @showTourEndWindow="showTourEnd"
         />
@@ -388,35 +387,11 @@ export default Vue.extend({
     updateRequirementsMenu() {
       this.requirementsKey += 1;
     },
-
-    loadRequirementsMap(requirementsMap: RequirementMap) {
-      // Get map of requirements
-      this.buildRequirementsAlert(requirementsMap);
-    },
     showTourEnd() {
       if (!this.isMobile) {
         this.showTourEndWindow = true;
       }
     },
-    buildRequirementsAlert(requirementsMap: RequirementMap) {
-      // Update semesters with alerts
-      this.semesters.forEach(semester => {
-        semester.courses.forEach(course => {
-          const courseCode = `${course.subject} ${course.number}`;
-          if (courseCode in requirementsMap) {
-            // Add and to parse array to natural language
-            const courseReqs = requirementsMap[courseCode] as string[];
-            if (courseReqs.length > 1) {
-              const listLength = courseReqs.length;
-              courseReqs[listLength - 2] = `${courseReqs[listLength - 2]}, and ${courseReqs.pop()}`;
-            }
-            const parsedCourseReqs = `Satisfies ${courseReqs.join(', ')} Requirements`;
-            course.alerts.requirement = parsedCourseReqs;
-          }
-        });
-      });
-    },
-
     changeBottomCourseFocus(newBottomCourseFocus: number) {
       this.bottomBar.bottomCourseFocus = newBottomCourseFocus;
     },

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -52,11 +52,7 @@ import {
   CourseTaken,
   SingleMenuRequirement,
 } from '@/requirements/types';
-import {
-  RequirementMap,
-  computeRequirements,
-  computeRequirementMap,
-} from '@/requirements/reqs-functions';
+import { RequirementMap, computeRequirements } from '@/requirements/reqs-functions';
 import { AppUser, AppMajor, AppMinor, AppSemester, FirestoreSemesterCourse } from '@/user-data';
 import { getRostersFromLastTwoYears } from '@/utilities';
 import getCourseEquivalentsFromUserExams from '@/requirements/data/exams/ExamCredit';
@@ -190,8 +186,6 @@ export default Vue.extend({
         this.user.major,
         this.user.minor
       );
-      // Send satisfied credits data back to dashboard to build alerts
-      this.$emit('requirementsMap', computeRequirementMap(groups));
       // Turn result into data readable by requirements menu
       const singleMenuRequirements = groups.map(group => {
         const singleMenuRequirement: SingleMenuRequirement = {

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -85,6 +85,7 @@
             <course
               v-bind="course"
               :courseObj="course"
+              :duplicatedCourseCodeList="duplicatedCourseCodeList"
               :id="course.subject + course.number"
               :uniqueID="course.uniqueID"
               :compact="compact"
@@ -189,6 +190,7 @@ export default Vue.extend({
     courses: Array as PropType<AppCourse[]>,
     compact: Boolean,
     activatedCourse: Object as PropType<AppCourse>,
+    duplicatedCourseCodeList: Array as PropType<readonly string[]>,
     semesters: Array as PropType<readonly AppSemester[]>,
     isFirstSem: Boolean,
   },
@@ -218,7 +220,6 @@ export default Vue.extend({
       this.isShadow = false;
       this.isDraggedFrom = false;
     });
-    this.buildCautions();
   },
   beforeDestroy() {
     this.$el.removeEventListener('touchmove', this.dragListener);
@@ -307,7 +308,6 @@ export default Vue.extend({
       this.courses.push(newCourse);
       const courseCode = `${data.subject} ${data.catalogNbr}`;
       this.openConfirmationModal(`Added ${courseCode} to ${this.type} ${this.year}`);
-      this.buildCautions();
       this.$gtag.event('add-course', {
         event_category: 'course',
         event_label: 'add',
@@ -354,20 +354,17 @@ export default Vue.extend({
     dragListener(event: Event) {
       if (!this.$data.scrollable) event.preventDefault();
     },
-    buildCautions() {
-      this.buildDuplicateCautions();
-    },
-    buildDuplicateCautions() {
-      this.$emit('build-duplicate-cautions');
-    },
+    // TODO: unused
     buildIncorrectPlacementCautions() {
       if (this.courses) {
         this.courses.forEach(course => {
           if (!course.semesters.includes(this.type))
+            // @ts-ignore
             course.alerts.caution = `Course unavailable in the ${this.type}`;
         });
       }
     },
+
     checkCourseDuplicate(key: string) {
       if (this.courses) {
         // @ts-ignore

--- a/src/user-data.ts
+++ b/src/user-data.ts
@@ -128,7 +128,6 @@ export type AppCourse = {
   readonly instructors: readonly string[];
   readonly distributions: readonly string[];
   readonly lastRoster: string;
-  readonly alerts: { requirement: string | null; caution: string | null };
   color: string;
   check: boolean;
   uniqueID: number;
@@ -271,8 +270,6 @@ export const firestoreCourseToAppCourse = (
   // Create course from saved color. Otherwise, create course from subject color group
   const color = course.color || addColor(subject);
 
-  const alerts = { requirement: null, caution: null };
-
   const isReqCourse = isRequirementsCourse;
 
   return {
@@ -291,7 +288,6 @@ export const firestoreCourseToAppCourse = (
     distributions,
     lastRoster,
     color,
-    alerts,
     check: true,
     uniqueID,
     isReqCourse,


### PR DESCRIPTION
### Summary <!-- Required -->

We want to eventually make the data from firestore as the single source of truth. Therefore, we should aim to reduce the different between `FirestoreSemesterCourse` and `AppCourse`. In particular, we should avoid making `AppCourse` contain information that is not in the database (i.e. the stuff that can be computed on demand on the frontend).

The alerts information is one such example. In additional to introducing differences between frontend data type and db data type, this field inside `AppCourse` is also mutated in many different places. It's one of the reason that forces us to use the inefficient deep watch on semester array. Eliminating this mutable field from the object can also help make the flow cleaner.

This refactor diff computes a duplicate course id array instead. Then each course component can use this array to decide whether to display the duplicate warning. While coding for this diff, I also found some unused code, which I will annotate in the PR comments.

### Test Plan <!-- Required -->

Try to add two courses that are the same. The warnings still exist.