### PR TITLE
Migrating OnboardingTransfer.vue to TypeScript

### DIFF
--- a/src/requirements/data/exams/ExamCredit.ts
+++ b/src/requirements/data/exams/ExamCredit.ts
@@ -70,7 +70,7 @@ export default function getCourseEquivalents(
   return APCourseEquivalents.concat(IBCourseEquivalents);
 }
 
-const examData: ExamData = {
+export const examData: ExamData = {
   AP: [
     {
       name: 'Computer Science A',


### PR DESCRIPTION
### Summary <!-- Required -->

I'm about to integrate AP/IB exams into requirement graph, but found that @benjamin-shen's changes broke `OnboardingTransfer.vue`. This isn't caught by CI because `OnboardingTransfer.vue` is in JS. This PR turns `OnboardingTransfer.vue` as much as I can.

It turns out that the existing code inside `OnboardingTransfer.vue` is very messy. I'm not sure how to setup type for many code, since the existing code seems to push all kind of stuff with different types into the same object/array. Therefore, I added a lot of `@ts-ignore`. (@rmz38 might have more context on this)

For the `@ts-ignore` due to changed exam data format, I added `// TODO: UNBREAK reqsData FORMAT` above it. I will fix them in the next diff.

### Test Plan <!-- Required -->

This is a type-annotation only change. Since it passes CI, it should be good.