### PR TITLE
Exclude completed subreqs

### DIFF
--- a/src/components/RequirementView.vue
+++ b/src/components/RequirementView.vue
@@ -60,6 +60,7 @@
               :reqIndex="reqIndex"
               :toggleableRequirementChoice="toggleableRequirementChoices[subReq.id]"
               :color="reqGroupColorMap[req.group][0]"
+              :isCompleted="true"
               :rostersFromLastTwoYears="rostersFromLastTwoYears"
               :lastLoadedShowAllCourseId="lastLoadedShowAllCourseId"
               @changeToggleableRequirementChoice="changeToggleableRequirementChoice"

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -270,7 +270,7 @@ export default Vue.extend({
         });
         // Push crseInfoObjects onto subReqCoursesNotTakenArray for the subReqCourse slot
         subReqCoursesNotTakenArray.push(crseInfoObjects);
-      });      
+      });
       return subReqCoursesNotTakenArray;
     },
     getMaxFirstFourCrseInfoObjects(): CrseInfo[] {

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -270,8 +270,7 @@ export default Vue.extend({
         });
         // Push crseInfoObjects onto subReqCoursesNotTakenArray for the subReqCourse slot
         subReqCoursesNotTakenArray.push(crseInfoObjects);
-      });
-      // console.log(subReqCoursesNotTakenArray);
+      });      
       return subReqCoursesNotTakenArray;
     },
     getMaxFirstFourCrseInfoObjects(): CrseInfo[] {

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -10,16 +10,16 @@
       <div class="col-7" @click="toggleDescription()">
         <p
           v-bind:class="[
-            { 'sup-req': !this.isCompleted },
+            { 'sup-req': !this.isFulfilled },
             'pointer',
-            this.isCompleted ? 'completed-ptext' : 'incomplete-ptext',
+            this.isFulfilled ? 'completed-ptext' : 'incomplete-ptext',
           ]"
         >
           <span>{{ subReq.requirement.name }}</span>
         </p>
       </div>
       <div class="col">
-        <p v-if="!this.isCompleted" class="sup-req-progress text-right incomplete-ptext">
+        <p v-if="!this.isFulfilled" class="sup-req-progress text-right incomplete-ptext">
           {{
             subReq.fulfilledBy !== 'self-check'
               ? `${subReq.totalCountFulfilled || subReq.minCountFulfilled}/${
@@ -28,7 +28,7 @@
               : 'self check'
           }}
         </p>
-        <p v-if="this.isCompleted" class="text-right completed-ptext">
+        <p v-if="this.isFulfilled" class="text-right completed-ptext">
           <span
             >{{ subReq.minCountFulfilled }}/{{ subReq.minCountRequired }}
             {{ subReq.fulfilledBy }}</span
@@ -37,7 +37,7 @@
       </div>
       <div
         v-if="displayDescription"
-        :class="[{ 'completed-ptext': this.isCompleted }, 'description']"
+        :class="[{ 'completed-ptext': this.isFulfilled }, 'description']"
       >
         {{ subReq.requirement.description }}
         <a
@@ -81,7 +81,7 @@
         </div>
       </div>
       <div v-if="!this.isCompleted" class="separator"></div>
-      <div class="incompletesubreqcourse-wrapper" v-if="!this.isCompleted">
+      <div class="incompletesubreqcourse-wrapper" v-if="!this.isFulfilled">
         <div v-for="(subReqCrseInfoObjects, id) in subReqCoursesNotTakenArray" :key="id">
           <incompletesubreqcourse
             :subReq="subReq"
@@ -143,6 +143,7 @@ export default Vue.extend({
     subReq: Object as PropType<DisplayableRequirementFulfillment>,
     subReqIndex: Number, // Subrequirement index
     reqIndex: Number, // Requirement index
+    isCompleted: Boolean,
     toggleableRequirementChoice: {
       type: String,
       required: false,
@@ -169,7 +170,7 @@ export default Vue.extend({
     };
   },
   computed: {
-    isCompleted(): boolean {
+    isFulfilled(): boolean {
       return false;
     },
     selectedFulfillmentOption(): string {
@@ -191,11 +192,11 @@ export default Vue.extend({
   methods: {
     getSrc() {
       let src = dropdownCompletedSrc;
-      if (this.displayDescription && !this.isCompleted) {
+      if (this.displayDescription && !this.isFulfilled) {
         src = dropupIncompleteSrc;
-      } else if (this.displayDescription && this.isCompleted) {
+      } else if (this.displayDescription && this.isFulfilled) {
         src = dropupCompletedSrc;
-      } else if (!this.displayDescription && !this.isCompleted) {
+      } else if (!this.displayDescription && !this.isFulfilled) {
         src = dropdownIncompleteSrc;
       }
       return src;
@@ -205,7 +206,7 @@ export default Vue.extend({
     },
     toggleDescription() {
       this.displayDescription = !this.displayDescription;
-      if (this.displayDescription && !this.isCompleted) {
+      if (this.displayDescription && !this.isFulfilled) {
         this.getSubReqCourseObjects();
       }
     },
@@ -235,6 +236,9 @@ export default Vue.extend({
       }
     },
     generateSubReqCoursesNotTakenArray(): CrseInfo[][] {
+      const allTakenCourseIds = this.subReq.courses
+        .reduce((acc, course) => acc.concat(course), [])
+        .map(course => course.courseId);
       // Reset subReqCoursesNotTakenArray
       const subReqCoursesNotTakenArray: CrseInfo[][] = [];
       // Depending on fulfilledBy, subReqCourses is accessed differently from subReq
@@ -256,7 +260,10 @@ export default Vue.extend({
           );
 
           if (subReqCrseIds.length > 0) {
-            const crseInfoObject = { roster: subReqRoster, crseIds: subReqCrseIds };
+            const filteredSubReqCrseIds = subReqCrseIds.filter(
+              crseIds => this.isCompleted || !allTakenCourseIds.includes(crseIds)
+            );
+            const crseInfoObject = { roster: subReqRoster, crseIds: filteredSubReqCrseIds };
             crseInfoObjects.push(crseInfoObject);
             subReqCrseIds.forEach(subReqCrseId => seenCrseIds.add(subReqCrseId));
           }
@@ -264,6 +271,7 @@ export default Vue.extend({
         // Push crseInfoObjects onto subReqCoursesNotTakenArray for the subReqCourse slot
         subReqCoursesNotTakenArray.push(crseInfoObjects);
       });
+      // console.log(subReqCoursesNotTakenArray);
       return subReqCoursesNotTakenArray;
     },
     getMaxFirstFourCrseInfoObjects(): CrseInfo[] {


### PR DESCRIPTION
### Summary

This PR completes the [item on Monday](https://courseplan.monday.com/boards/433956786/pulses/754595352) and one of the stories to "Exclude Completed Courses from Sub-Req Course Suggestions". This endeavor successfully removed previously taken courses from both the four immediate suggested courses and see all from the requirements menu.

<img width="1552" alt="Screen Shot 2020-11-21 at 6 39 59 AM" src="https://user-images.githubusercontent.com/44352119/99876421-a1055e00-2bc4-11eb-95d5-c44c453f976b.png">
<img width="1552" alt="Screen Shot 2020-11-21 at 6 39 50 AM" src="https://user-images.githubusercontent.com/44352119/99876423-a1055e00-2bc4-11eb-94f2-b2d5ef70ea31.png">
