### PR TITLE
Add nullify check for cautionString

### DIFF
--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -85,6 +85,7 @@ export default Vue.extend({
   },
   computed: {
     cautionString() {
+      if (this.duplicatedCourseCodeList == null) return null;
       return this.duplicatedCourseCodeList.includes(`${this.subject} ${this.number}`)
         ? 'Duplicate'
         : null;

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -67,7 +67,10 @@ export default Vue.extend({
     prereqs: String,
     semesters: Array,
     color: String,
-    duplicatedCourseCodeList: Array,
+    duplicatedCourseCodeList: {
+      required: false,
+      type: Array,
+    },
     compact: Boolean,
     id: String,
     uniqueID: Number,


### PR DESCRIPTION
### Summary

The recent refactor for caution indicators introduced a minor bug that cancelled all fetchRequests to Firebase Functions to retrieve suggested courses in the requirements menu. It was because this.duplicatedCourseCodeList can sometimes be null.

Adding a null checker fixed that

<img width="1440" alt="Screen Shot 2020-11-22 at 5 53 54 PM" src="https://user-images.githubusercontent.com/44352119/99919532-0acc5780-2cec-11eb-94ea-891531129987.png">
