### PR TITLE
Update semester and course data functionally

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -38,6 +38,7 @@
         :isMobile="isMobile"
         :currSemID="currSemID"
         @compact-updated="compactVal = $event"
+        @edit-semesters="editSemesters"
         @updateBar="updateBar"
         @close-bar="closeBar"
         @updateRequirementsMenu="updateRequirementsMenu"
@@ -245,6 +246,10 @@ export default Vue.extend({
         });
     },
 
+    editSemesters(newSemesters: AppSemester[]) {
+      this.semesters = newSemesters;
+      this.updateRequirementsMenu();
+    },
     resizeEventHandler(e: any) {
       this.isMobile = window.innerWidth <= 440;
       this.isTablet = window.innerWidth <= 878;

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -182,7 +182,7 @@ export default Vue.extend({
     id: Number,
     type: String as PropType<'Fall' | 'Spring' | 'Winter' | 'Summer'>,
     year: Number,
-    courses: Array as PropType<AppCourse[]>,
+    courses: Array as PropType<readonly AppCourse[]>,
     compact: Boolean,
     activatedCourse: Object as PropType<AppCourse>,
     duplicatedCourseCodeList: Array as PropType<readonly string[]>,
@@ -304,7 +304,14 @@ export default Vue.extend({
         this.$emit('add-course-to-semester', season, year, newCourse);
         confirmationMsg = `Added ${courseCode} to ${season} ${year}`;
       } else {
-        this.courses.push(newCourse);
+        this.$emit(
+          'edit-semester',
+          this.id,
+          (semester: AppSemester): AppSemester => ({
+            ...semester,
+            courses: [...this.courses, newCourse],
+          })
+        );
         confirmationMsg = `Added ${courseCode} to ${this.type} ${this.year}`;
       }
       this.openConfirmationModal(confirmationMsg);
@@ -315,12 +322,6 @@ export default Vue.extend({
       });
     },
     deleteCourse(subject: string, number: string, uniqueID: number) {
-      for (let i = 0; i < this.courses.length; i += 1) {
-        if (this.courses[i].uniqueID === uniqueID) {
-          this.courses.splice(i, 1);
-          break;
-        }
-      }
       const courseCode = `${subject} ${number}`;
       this.openConfirmationModal(`Removed ${courseCode} from ${this.type} ${this.year}`);
       this.$gtag.event('delete-course', {
@@ -329,27 +330,41 @@ export default Vue.extend({
         value: 1,
       });
       // Update requirements menu
-      this.$emit('update-requirements-menu');
+      this.$emit(
+        'edit-semester',
+        this.id,
+        (semester: AppSemester): AppSemester => ({
+          ...semester,
+          courses: this.courses.filter(course => course.uniqueID !== uniqueID),
+        })
+      );
     },
     colorCourse(color: string, uniqueID: number) {
-      for (let i = 0; i < this.courses.length; i += 1) {
-        if (this.courses[i].uniqueID === uniqueID) {
-          this.courses[i].color = color;
-          break;
-        }
-      }
+      this.$emit(
+        'edit-semester',
+        this.id,
+        (semester: AppSemester): AppSemester => ({
+          ...semester,
+          courses: this.courses.map(course =>
+            course.uniqueID === uniqueID ? { ...course, color } : course
+          ),
+        })
+      );
     },
     updateBar(course: AppCourse, colorJustChanged: string, color: string) {
       this.$emit('updateBar', course, colorJustChanged, color);
     },
     editCourseCredit(credit: number, uniqueID: number) {
-      for (let i = 0; i < this.courses.length; i += 1) {
-        if (this.courses[i].uniqueID === uniqueID) {
-          this.courses[i].credits = credit;
-          break;
-        }
-      }
-      this.$emit('update-requirements-menu');
+      this.$emit(
+        'edit-semester',
+        this.id,
+        (semester: AppSemester): AppSemester => ({
+          ...semester,
+          courses: this.courses.map(course =>
+            course.uniqueID === uniqueID ? { ...course, credits: credit } : course
+          ),
+        })
+      );
     },
     dragListener(event: Event) {
       if (!this.$data.scrollable) event.preventDefault();
@@ -416,8 +431,16 @@ export default Vue.extend({
 
       this.isEditSemesterOpen = true;
     },
-    editSemester(seasonInput: string, yearInput: string) {
-      this.$emit('edit-semester', this.deleteSemID, seasonInput, yearInput);
+    editSemester(seasonInput: 'Fall' | 'Spring' | 'Winter' | 'Summer', yearInput: number) {
+      this.$emit(
+        'edit-semester',
+        this.deleteSemID,
+        (oldSemester: AppSemester): AppSemester => ({
+          ...oldSemester,
+          type: seasonInput,
+          year: yearInput,
+        })
+      );
     },
   },
   directives: {

--- a/src/user-data.ts
+++ b/src/user-data.ts
@@ -119,7 +119,7 @@ export type AppCourse = {
   readonly number: string;
   readonly name: string;
   readonly description: string;
-  credits: number;
+  readonly credits: number;
   readonly creditRange: readonly [number, number];
   readonly semesters: readonly string[];
   readonly prereqs: string;
@@ -128,17 +128,17 @@ export type AppCourse = {
   readonly instructors: readonly string[];
   readonly distributions: readonly string[];
   readonly lastRoster: string;
-  color: string;
-  check: boolean;
+  readonly color: string;
+  readonly check: boolean;
   uniqueID: number;
-  isReqCourse: boolean;
+  readonly isReqCourse: boolean;
 };
 
 export type AppSemester = {
-  courses: readonly AppCourse[];
+  readonly courses: readonly AppCourse[];
   id: number;
-  type: FirestoreSemesterType;
-  year: number;
+  readonly type: FirestoreSemesterType;
+  readonly year: number;
 };
 
 export type AppBottomBarCourse = {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request continues the refactoring that aims to make firestore realtime listening possible.

Right now our semester and course data update course is very imperative and the updates happen all over the place. This PR changes the implementation to make it more functional:

- Instead of pushing to the existing array, we create a new array.
- Instead of editing the field of course directly, we create a new object with the updated field.
- etc

Then, we centralize the imperative update to one place only: `Dashboard.vue`. In this way, we no longer need the `deep` watcher on the `semesters` array, and we have a much cleaner and more explicit data flow.

This update will also make a future PR easier. In a PR after this, I plan to make the firestore the source of truth. With the infra setup in this PR, all I need to do is to do the followings:

1. Convert `AppSemester[]` to `FirestoreSemester[]`
2. Update the user data collection document with the new `FirestoreSemester[]`
3. Firestore realtime listener will handle the rest!

### Test Plan <!-- Required -->

- Add semester still works
- Edit semester year and season works
- Delete semester still works
- Add course still works
- Edit course color and credits still works
- Delete course still works.