### PR TITLE
Unbreak auto-saving drag & drop courses

### DIFF
--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -189,7 +189,20 @@ export default Vue.extend({
     semesters: Array as PropType<readonly AppSemester[]>,
     isFirstSem: Boolean,
   },
-
+  watch: {
+    courses: {
+      handler() {
+        this.$emit(
+          'edit-semester',
+          this.id,
+          (semester: AppSemester): AppSemester => ({
+            ...semester,
+            courses: this.courses,
+          })
+        );
+      },
+    },
+  },
   mounted() {
     this.$el.addEventListener('touchmove', this.dragListener, { passive: false });
     // @ts-ignore


### PR DESCRIPTION
### Summary <!-- Required -->

#213 breaks the drag and drop saving functionality, because in drag and drop, the courses are updated by the `v-dragula` directive implicitly, so my migration missed that. This diff uses a watcher to watch for the changes made by dragula and correctly report such changes to parent.

### Test Plan <!-- Required -->

On master it will no longer remember your d&d choices. It's fixed in this diff.