### PR TITLE
Store toggleableRequirementChoices in firestore

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -20,11 +20,13 @@
           class="dashboard-reqs"
           v-if="loaded && (!isTablet || (isOpeningRequirements && isTablet))"
           :semesters="semesters"
+          :toggleableRequirementChoices="toggleableRequirementChoices"
           :user="user"
           :key="requirementsKey"
           :startTour="startTour"
           @createCourse="createCourse"
           @showTourEndWindow="showTourEnd"
+          @on-toggleable-requirement-choices-change="chooseToggleableRequirementOption"
         />
       </div>
       <semesterview
@@ -116,6 +118,7 @@ import {
   firestoreCourseToAppCourse,
   firestoreSemestersToAppSemesters,
   createAppUser,
+  AppToggleableRequirementChoices,
 } from '@/user-data';
 import { RequirementMap } from '@/requirements/reqs-functions';
 
@@ -145,6 +148,7 @@ export default Vue.extend({
       semesters: [] as AppSemester[],
       firebaseSems: [] as FirestoreSemester[],
       currentClasses: [] as AppCourse[],
+      toggleableRequirementChoices: {} as AppToggleableRequirementChoices,
       user: {
         major: [],
         majorFN: [],
@@ -218,6 +222,8 @@ export default Vue.extend({
               firestoreUserData.subjectColors
             );
             this.currSemID += this.semesters.length;
+            this.toggleableRequirementChoices =
+              firestoreUserData.toggleableRequirementChoices || {};
 
             this.firebaseSems = firestoreUserData.semesters as FirestoreSemester[];
             this.user = this.parseUserData(firestoreUserData.userData, firestoreUserData.name);
@@ -249,6 +255,12 @@ export default Vue.extend({
     editSemesters(newSemesters: AppSemester[]) {
       this.semesters = newSemesters;
       this.updateRequirementsMenu();
+    },
+    chooseToggleableRequirementOption(
+      toggleableRequirementChoices: AppToggleableRequirementChoices
+    ) {
+      this.toggleableRequirementChoices = toggleableRequirementChoices;
+      this.getDocRef().update({ toggleableRequirementChoices });
     },
     resizeEventHandler(e: any) {
       this.isMobile = window.innerWidth <= 440;
@@ -538,6 +550,7 @@ export default Vue.extend({
       const data = {
         name: onboardingData.name,
         userData: onboardingData.userData,
+        toggleableRequirementChoices: this.toggleableRequirementChoices,
         semesters: this.firebaseSems,
         subjectColors: this.subjectColors,
         uniqueIncrementer: this.uniqueIncrementer,

--- a/src/components/Requirements.vue
+++ b/src/components/Requirements.vue
@@ -94,6 +94,7 @@ import {
   AppSemester,
   FirestoreSemesterCourse,
   AppCourse,
+  AppToggleableRequirementChoices,
 } from '@/user-data';
 import { getRostersFromLastTwoYears } from '@/utilities';
 import getCourseEquivalentsFromUserExams from '@/requirements/data/exams/ExamCredit';
@@ -119,8 +120,6 @@ export type ShowAllCourses = {
 
 type Data = {
   reqs: readonly SingleMenuRequirement[];
-  // map from requirement ID to option chosen
-  toggleableRequirementChoices: Readonly<Record<string, string>>;
   displayedMajorIndex: number;
   displayedMinorIndex: number;
   numOfColleges: number;
@@ -142,6 +141,7 @@ tour.setOption('exitOnOverlayClick', 'false');
 
 export default Vue.extend({
   props: {
+    toggleableRequirementChoices: Object as PropType<AppToggleableRequirementChoices>,
     semesters: Array as PropType<readonly AppSemester[]>,
     user: Object as PropType<AppUser>,
     compact: Boolean,
@@ -155,7 +155,6 @@ export default Vue.extend({
       displayedMajorIndex: 0,
       displayedMinorIndex: 0,
       reqs: [],
-      toggleableRequirementChoices: {},
       numOfColleges: 1,
       showAllCourses: { name: '', courses: [] },
       shouldShowAllCourses: false,
@@ -169,6 +168,11 @@ export default Vue.extend({
       tour.oncomplete(() => {
         this.$emit('showTourEndWindow');
       });
+    },
+    toggleableRequirementChoices: {
+      handler() {
+        this.recomputeRequirements();
+      },
     },
   },
   computed: {
@@ -258,11 +262,11 @@ export default Vue.extend({
       );
     },
     chooseToggleableRequirementOption(requirementID: string, option: string): void {
-      this.toggleableRequirementChoices = {
+      const newToggleableRequirementChoices = {
         ...this.toggleableRequirementChoices,
         [requirementID]: option,
       };
-      this.recomputeRequirements();
+      this.$emit('on-toggleable-requirement-choices-change', newToggleableRequirementChoices);
     },
     getCourseCodesArray(): readonly CourseTaken[] {
       const courses: CourseTaken[] = [];

--- a/src/user-data.ts
+++ b/src/user-data.ts
@@ -82,6 +82,7 @@ export type FirestoreNestedUserData = {
 export type FirestoreUserData = {
   readonly name: FirestoreUserName;
   readonly semesters: readonly FirestoreSemester[];
+  readonly toggleableRequirementChoices: AppToggleableRequirementChoices;
   readonly subjectColors: { readonly [subject: string]: string };
   readonly uniqueIncrementer: number;
   readonly userData: FirestoreNestedUserData;
@@ -160,6 +161,9 @@ export type AppBottomBarCourse = {
   readonly description: string;
   readonly uniqueID: number;
 };
+
+// map from requirement ID to option chosen
+export type AppToggleableRequirementChoices = Readonly<Record<string, string>>;
 
 /**
  * Creates credit range based on course


### PR DESCRIPTION
### Summary <!-- Required -->

The PR that refactors the data flow (#217) is currently blocked due to some abused functions, so I decided to go with storing toggleableRequirementChoices first without waiting for the refactor to happen.

In this PR, I lifted the state of toggleableRequirementChoices to the root Dashboard.vue, and update the user data collection whenever there is an update from requirement component.

### Test Plan <!-- Required -->

Test using A&S's biological science's general chemistry requirement. After changing your choice, reload to ensure it's remembered.