### PR TITLE
Hoist requirement data to the root Dashboard.vue

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -19,6 +19,7 @@
         <requirements
           class="dashboard-reqs"
           v-if="loaded && (!isTablet || (isOpeningRequirements && isTablet))"
+          :reqs="reqs"
           :semesters="semesters"
           :toggleableRequirementChoices="toggleableRequirementChoices"
           :user="user"
@@ -44,7 +45,6 @@
         @edit-semesters="editSemesters"
         @updateBar="updateBar"
         @close-bar="closeBar"
-        @updateRequirementsMenu="updateRequirementsMenu"
         @increment-semID="incrementSemID"
       />
     </div>
@@ -121,7 +121,9 @@ import {
   createAppUser,
   AppToggleableRequirementChoices,
 } from '@/user-data';
-import { RequirementMap } from '@/requirements/reqs-functions';
+import { RequirementMap, computeRequirements } from '@/requirements/reqs-functions';
+import { CourseTaken, SingleMenuRequirement } from '@/requirements/types';
+import getCourseEquivalentsFromUserExams from '@/requirements/data/exams/ExamCredit';
 
 Vue.component('course', Course);
 Vue.component('semesterview', SemesterView);
@@ -190,6 +192,7 @@ export default Vue.extend({
         class = "emoji-text" alt = "surf">`,
       congratsExit: '',
       congratsButtonText: 'Start Planning',
+      reqs: [] as readonly SingleMenuRequirement[],
     };
   },
   created() {
@@ -231,7 +234,7 @@ export default Vue.extend({
             this.subjectColors = firestoreUserData.subjectColors;
             this.uniqueIncrementer = firestoreUserData.uniqueIncrementer;
             this.loaded = true;
-            this.updateRequirementsMenu();
+            this.recomputeRequirements();
           } else {
             this.semesters.push({
               id: this.currSemID,
@@ -255,13 +258,14 @@ export default Vue.extend({
 
     editSemesters(newSemesters: AppSemester[]) {
       this.semesters = newSemesters;
-      this.updateRequirementsMenu();
+      this.recomputeRequirements();
     },
     chooseToggleableRequirementOption(
       toggleableRequirementChoices: AppToggleableRequirementChoices
     ) {
       this.toggleableRequirementChoices = toggleableRequirementChoices;
       this.getDocRef().update({ toggleableRequirementChoices });
+      this.recomputeRequirements();
     },
     resizeEventHandler(e: any) {
       this.isMobile = window.innerWidth <= 440;
@@ -299,7 +303,7 @@ export default Vue.extend({
      */
     createCourse(course: FirestoreSemesterCourse, isRequirementsCourse: boolean): AppCourse {
       if (!isRequirementsCourse) {
-        this.updateRequirementsMenu();
+        this.recomputeRequirements();
       }
       return firestoreCourseToAppCourse(
         course,
@@ -402,9 +406,6 @@ export default Vue.extend({
     },
     incrementSemID() {
       this.currSemID += 1;
-    },
-    updateRequirementsMenu() {
-      this.requirementsKey += 1;
     },
     showTourEnd() {
       if (!this.isMobile) {
@@ -566,7 +567,7 @@ export default Vue.extend({
           }
           docRef.set(data);
           this.cancelOnboarding();
-          this.updateRequirementsMenu();
+          this.recomputeRequirements();
         })
         .catch(error => {
           console.log('Error getting document:', error);
@@ -598,7 +599,6 @@ export default Vue.extend({
       });
       this.currentClasses = transferClasses;
 
-      this.updateRequirementsMenu();
       return user;
     },
 
@@ -637,6 +637,77 @@ export default Vue.extend({
       return arr && arr.length !== 0 && arr[0] !== '' ? arr : ['N/A'];
     },
 
+    getCourseCodesArray(): readonly CourseTaken[] {
+      const courses: CourseTaken[] = [];
+      this.semesters.forEach(semester => {
+        semester.courses.forEach(course => {
+          courses.push({
+            code: `${course.lastRoster}: ${course.subject} ${course.number}`,
+            subject: course.subject,
+            courseId: course.crseId,
+            number: course.number,
+            credits: course.credits,
+            roster: course.lastRoster,
+          });
+        });
+      });
+      courses.push(...getCourseEquivalentsFromUserExams(this.user));
+      return courses;
+    },
+
+    getRequirementTypeDisplayName(type: string): string {
+      return type.charAt(0).toUpperCase() + type.substring(1);
+    },
+
+    recomputeRequirements(): void {
+      const groups = computeRequirements(
+        this.getCourseCodesArray(),
+        this.toggleableRequirementChoices,
+        this.user.college,
+        this.user.major,
+        this.user.minor
+      );
+      // Turn result into data readable by requirements menu
+      const singleMenuRequirements = groups.map(group => {
+        const singleMenuRequirement: SingleMenuRequirement = {
+          ongoing: [],
+          completed: [],
+          name: `${
+            group.groupName.charAt(0) + group.groupName.substring(1).toLowerCase()
+          } Requirements`,
+          group: group.groupName.toUpperCase() as 'COLLEGE' | 'MAJOR' | 'MINOR',
+          specific: group.specific,
+        };
+        group.reqs.forEach(req => {
+          // Create progress bar with requirement with progressBar = true
+          if (req.requirement.progressBar) {
+            singleMenuRequirement.type = this.getRequirementTypeDisplayName(
+              req.requirement.fulfilledBy
+            );
+            singleMenuRequirement.fulfilled = req.totalCountFulfilled || req.minCountFulfilled;
+            singleMenuRequirement.required =
+              (req.requirement.fulfilledBy !== 'self-check' && req.totalCountRequired) ||
+              req.minCountRequired;
+          }
+          // Default display value of false for all requirement lists
+          const displayableRequirementFulfillment = { ...req, displayDescription: false };
+          if (!req.minCountFulfilled || req.minCountFulfilled < req.minCountRequired) {
+            singleMenuRequirement.ongoing.push(displayableRequirementFulfillment);
+          } else {
+            singleMenuRequirement.completed.push(displayableRequirementFulfillment);
+          }
+        });
+        // Make number of requirements items progress bar in absense of identified progress metric
+        if (!singleMenuRequirement.type) {
+          singleMenuRequirement.type = 'Requirements';
+          singleMenuRequirement.fulfilled = singleMenuRequirement.completed.length;
+          singleMenuRequirement.required =
+            singleMenuRequirement.ongoing.length + singleMenuRequirement.completed.length;
+        }
+        return singleMenuRequirement;
+      });
+      this.reqs = singleMenuRequirements;
+    },
     deleteCourseFromSemesters(uniqueID: number) {
       const updatedSemesters = this.semesters.map(semester => {
         const coursesWithoutDeleted = semester.courses.filter(course => {

--- a/src/components/SemesterView.vue
+++ b/src/components/SemesterView.vue
@@ -70,7 +70,6 @@
           @new-semester="openSemesterModal"
           @delete-semester="deleteSemester"
           @edit-semester="editSemester"
-          @update-requirements-menu="updateRequirementsMenu"
           @open-caution-modal="openCautionModal"
           @add-course-to-semester="addCourseToSemester"
         />
@@ -296,9 +295,6 @@ export default Vue.extend({
         const newSemesters = [...this.semesters, newSem].sort(this.compare);
         this.$emit('edit-semesters', newSemesters);
       }
-    },
-    updateRequirementsMenu() {
-      this.$emit('updateRequirementsMenu');
     },
     compare(a: AppSemester, b: AppSemester): number {
       if (a.type === b.type && a.year === b.year) {


### PR DESCRIPTION
### Summary <!-- Required -->

I need to implement warnings that are coming from requirement computation, so I need to hoist the data up to the root so that relevant information can be computed higher up and passed down to semesters and classes components.

Since now the requirements are already in the root, there is no need for the `updateRequirementsMenu` hack that only changes the key. We can call the `recomputeRequirements` functions directly instead. As a result, I removed all the `updateRequirementsMenu` and some dead code associated with it. 

### Test Plan <!-- Required -->

All the requirements are correctly updated when classes and toggleable requirement changes.

### Notes

I keep this diff small so that @hahnbeelee can easily merge this into her branch once it's in master. There is only one merge conflicts that needs to be fixed:

<img width="809" alt="Screen Shot 2020-12-09 at 13 56 45" src="https://user-images.githubusercontent.com/4290500/101674722-dadcbe00-3a26-11eb-986a-f5bb10a81bdb.png">

which you should remove the line that calls `updateRequirementsMenu`.