### PR TITLE
Show next IncompleteSubReqCourse slot for One Slot SubRequirements

### DIFF
--- a/src/components/IncompleteSubReqCourse.vue
+++ b/src/components/IncompleteSubReqCourse.vue
@@ -12,10 +12,7 @@
           {{ seeAll }}
         </div>
       </div>
-      <div
-        v-if="!dataReady && crseInfoObjects.length > 0"
-        class="loading-requirements-courses"
-      >
+      <div v-if="!dataReady && crseInfoObjects.length > 0" class="loading-requirements-courses">
         <vue-skeleton-loader
           v-for="n in defaultNumberofLoadingCards"
           :key="n"

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -253,6 +253,7 @@ export default Vue.extend({
             subReqCoursesArray.push({ isCompleted: true, courses: [subReqCourse] });
           });
           // Create new IncompletedSubReqCourse slot if all credits or courses not met
+          // but only one CompletedSubReqCourse slot exists
           if (this.subReq.courses.length === 1 && !this.isCompleted) {
             const crseInfoArray = this.generateSubReqIncompleteCrseInfoArray(subReqCourses, i);
             subReqCoursesArray.push({ isCompleted: false, courses: crseInfoArray });

--- a/src/components/SubRequirement.vue
+++ b/src/components/SubRequirement.vue
@@ -249,7 +249,14 @@ export default Vue.extend({
       for (let i = 0; i < this.subReq.courses.length; i += 1) {
         const subReqCourseSlot = this.subReq.courses[i];
         if (subReqCourseSlot.length > 0) {
-          subReqCoursesArray.push({ isCompleted: true, courses: subReqCourseSlot });
+          subReqCourseSlot.forEach(subReqCourse => {
+            subReqCoursesArray.push({ isCompleted: true, courses: [subReqCourse] });
+          });
+          // Create new IncompletedSubReqCourse slot if all credits or courses not met
+          if (this.subReq.courses.length === 1 && !this.isCompleted) {
+            const crseInfoArray = this.generateSubReqIncompleteCrseInfoArray(subReqCourses, i);
+            subReqCoursesArray.push({ isCompleted: false, courses: crseInfoArray });
+          }
         } else {
           const crseInfoArray = this.generateSubReqIncompleteCrseInfoArray(subReqCourses, i);
           subReqCoursesArray.push({ isCompleted: false, courses: crseInfoArray });


### PR DESCRIPTION
### Summary

This pull request is the implementation of generating a new IncompleteSubReqCourse slot for incomplete One-Slot SubRequirements.

- [x] Show next IncompleteSubReqCourse slot for incomplete One-Slot SubRequirements
- [x] Show all courses that satisfy One-Slot SubRequirements

Refers to this Monday Item: [Split each req into Course 1, Course 2, with functionality](https://courseplan.monday.com/boards/433956786/pulses/541209935/posts/696315968)
#### Previous State
There exists "One-Slot SubRequirements" like the CS Elective subrequirement example shown below, where there are a certain number of courses or credits that must be fulfilled in order to fulfill the subrequirement but only one course slot shows. The frontend requirements bar does not handle these "One-Slot SubRequirements", as can be seen below:
![Screen Shot 2020-12-12 at 4 30 13 PM](https://user-images.githubusercontent.com/54298311/101995430-c4896900-3c97-11eb-8515-a788b90b61b0.png)
![Screen Shot 2020-12-12 at 4 30 03 PM](https://user-images.githubusercontent.com/54298311/101995434-c6ebc300-3c97-11eb-8a06-57eebd4c459d.png)
There should be another IncompleteSubReqCourse component that appears below the first CompletedSubReqCourse component for the CS Elective subrequirement.

The second course that fulfills the CS Elective is not shown:
![Screen Shot 2020-12-12 at 4 40 46 PM](https://user-images.githubusercontent.com/54298311/101995564-cd2e6f00-3c98-11eb-85e6-b98009e944ba.png)

#### Improved State
Now, an IncompleteSubReqCourse component should be generated after each course is added for a One-Slot SubRequirement until the minimum course or credit limit is met. Also, all the courses that help fulfill the One-Slot SubRequirement are shown.

![Screen Shot 2020-12-12 at 4 38 47 PM](https://user-images.githubusercontent.com/54298311/101995520-8476b600-3c98-11eb-851c-ce02ab2e1619.png)

### Test Plan 
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/54298311/101995860-2d261500-3c9b-11eb-8db2-daf5c80934bf.gif)

Slots should be generated as normal for all other types of SubRequirements (e.g. Core Courses for INFO major).

### Notes
- Dragging issues are being worked on and will be resolved in a future PR. 
- We can see every course that fulfills the Total Academic Credits and college-specific subrequirements as they are also examples of "One-Slot SubRequirements". Do we not want to treat these subrequirements like "self-check" requirements that shouldn't show any specific course info?