### PR TITLE
Split firestoreCourseToAppCourse into cornellCourseRosterCourseToAppCourse and firestoreCourseToAppCourse

### DIFF
--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -96,8 +96,8 @@ import {
   AppMajor,
   AppMinor,
   AppSemester,
-  FirestoreSemesterCourse,
   AppCourse,
+  CornellCourseRosterCourse,
   AppToggleableRequirementChoices,
 } from '@/user-data';
 import { getRostersFromLastTwoYears } from '@/utilities';
@@ -211,9 +211,6 @@ export default Vue.extend({
     activateMinor(id: number) {
       this.displayedMinorIndex = id;
     },
-    createCourse(course: FirestoreSemesterCourse, isRequirementsCourse: boolean) {
-      this.$emit('createCourse', course, isRequirementsCourse);
-    },
     getRequirementsTooltipText() {
       return `<b>This is your Requirements Bar <img src="${clipboard}"class = "newSemester-emoji-text"></b><br>
           <div class = "introjs-bodytext">To ease your journey, we’ve collected a list of course
@@ -253,9 +250,12 @@ export default Vue.extend({
           allowSameCourseForDifferentRosters: false,
         })
           .then(result => {
-            result.data.courses.forEach((course: FirestoreSemesterCourse) => {
+            result.data.courses.forEach((course: CornellCourseRosterCourse) => {
               // @ts-ignore [We should resolve this later]
-              const createdCourse = this.$parent.createCourse(course, true);
+              const createdCourse = this.$parent.createAppCourseFromCornellRosterCourse(
+                course,
+                true
+              );
               createdCourse.compact = true;
               fetchedCourses.push(createdCourse);
             });

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -121,12 +121,7 @@ import {
 } from '@/requirements/types';
 import { clickOutside } from '@/utilities';
 
-import {
-  FirestoreSemesterCourse,
-  AppCourse,
-  firestoreCourseToAppCourse,
-  AppSemester,
-} from '@/user-data';
+import { CornellCourseRosterCourse, AppCourse, AppSemester } from '@/user-data';
 
 Vue.component('completedsubreqcourse', CompletedSubReqCourse);
 Vue.component('incompletesubreqcourse', IncompleteSubReqCourse);
@@ -218,9 +213,6 @@ export default Vue.extend({
     },
     isDataReady() {
       this.dataReady = true;
-    },
-    createCourse(course: FirestoreSemesterCourse, isRequirementsCourse: boolean) {
-      this.$emit('createCourse', course, isRequirementsCourse);
     },
     closeMenuIfOpen() {
       this.showFulfillmentOptionsDropdown = false;
@@ -329,9 +321,12 @@ export default Vue.extend({
       })
         .then(result => {
           fetchedCourses = result.data.courses;
-          fetchedCourses.forEach((course: FirestoreSemesterCourse) => {
+          fetchedCourses.forEach((course: CornellCourseRosterCourse) => {
             // @ts-ignore
-            const createdCourse = this.$parent.$parent.$parent.createCourse(course, true);
+            const createdCourse = this.$parent.$parent.$parent.createAppCourseFromCornellRosterCourse(
+              course,
+              true
+            );
             createdCourse.compact = true;
             this.subReqFetchedCourseObjectsNotTakenArray.push(createdCourse);
           });

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -129,7 +129,7 @@ import EditSemester from '@/components/Modals/EditSemester.vue';
 import AddCourseButton from '@/components/AddCourseButton.vue';
 
 import { clickOutside } from '@/utilities';
-import { AppCourse, AppSemester } from '@/user-data';
+import { AppCourse, AppSemester, CornellCourseRosterCourse } from '@/user-data';
 
 Vue.component('course', Course);
 Vue.component('modal', Modal);
@@ -306,11 +306,13 @@ export default Vue.extend({
     closeConfirmationModal() {
       this.isConfirmationOpen = false;
     },
-    // TODO: give better type on data
-    addCourse(data: any, season: string | null = null, year: number | null = null) {
+    addCourse(
+      data: CornellCourseRosterCourse,
+      season: string | null = null,
+      year: number | null = null
+    ) {
       // @ts-ignore
-      const newCourse = this.$parent.$parent.createCourse(data, false);
-      // TODO: stop mutating this data directly
+      const newCourse = this.$parent.$parent.createAppCourseFromCornellRosterCourse(data, false);
       const courseCode = `${data.subject} ${data.catalogNbr}`;
       let confirmationMsg;
       if (season !== '' || year !== 0) {

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -342,7 +342,7 @@ export default Vue.extend({
      * Works in conjunction with addCourse()
      * CHANGE WILL ALTER DATA STRUCTURE
      */
-    toFirebaseCourse(course: AppCourse) {
+    toFirebaseCourse(course: AppCourse): FirestoreSemesterCourse {
       return {
         crseId: course.crseId,
         code: `${course.subject} ${course.number}`,
@@ -359,7 +359,7 @@ export default Vue.extend({
         lastRoster: course.lastRoster,
         color: course.color,
         uniqueID: course.uniqueID,
-      } as FirestoreSemesterCourse;
+      };
     },
     /**
      * Updates semester user data

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -25,7 +25,6 @@
           :user="user"
           :key="requirementsKey"
           :startTour="startTour"
-          @createCourse="createCourse"
           @showTourEndWindow="showTourEnd"
           @on-toggleable-requirement-choices-change="chooseToggleableRequirementOption"
           @deleteCourseFromSemesters="deleteCourseFromSemesters"
@@ -112,11 +111,12 @@ import {
   FirestoreTransferClass,
   FirestoreNestedUserData,
   FirestoreUserData,
+  CornellCourseRosterCourse,
   AppUser,
   AppCourse,
   AppSemester,
   AppBottomBarCourse,
-  firestoreCourseToAppCourse,
+  cornellCourseRosterCourseToAppCourse,
   firestoreSemestersToAppSemesters,
   createAppUser,
   AppToggleableRequirementChoices,
@@ -221,10 +221,7 @@ export default Vue.extend({
         .then(doc => {
           if (doc.exists) {
             const firestoreUserData = doc.data() as FirestoreUserData;
-            this.semesters = firestoreSemestersToAppSemesters(
-              firestoreUserData.semesters,
-              firestoreUserData.subjectColors
-            );
+            this.semesters = firestoreSemestersToAppSemesters(firestoreUserData.semesters);
             this.currSemID += this.semesters.length;
             this.toggleableRequirementChoices =
               firestoreUserData.toggleableRequirementChoices || {};
@@ -301,11 +298,14 @@ export default Vue.extend({
     /**
      * Creates a course on frontend with either user or API data
      */
-    createCourse(course: FirestoreSemesterCourse, isRequirementsCourse: boolean): AppCourse {
+    createAppCourseFromCornellRosterCourse(
+      course: CornellCourseRosterCourse,
+      isRequirementsCourse: boolean
+    ): AppCourse {
       if (!isRequirementsCourse) {
         this.recomputeRequirements();
       }
-      return firestoreCourseToAppCourse(
+      return cornellCourseRosterCourseToAppCourse(
         course,
         isRequirementsCourse,
         () => this.incrementID(),
@@ -588,7 +588,7 @@ export default Vue.extend({
         }
       });
       user.transferCourse.forEach(course => {
-        const courseInfo = firestoreCourseToAppCourse(
+        const courseInfo = cornellCourseRosterCourseToAppCourse(
           course.course,
           false,
           () => this.incrementID(),


### PR DESCRIPTION
### Summary <!-- Required -->

For quite a long time, the `createCourse` function inside `Dashboard.vue` is doing two things at once: converting course data from firestore to `AppCourse` and converting course roster course data into `AppCourse`. When I did some cleanup earlier, such code structure is preserved to keep the diff small. However, now it's the time to cleanup these data, so that we have a better idea what we store in the db.

This diff first splits the type `FirestoreSemesterCourse` into `FirestoreSemesterCourse` and `CornellCourseRosterCourse`, and then splitted their converter functions. As a result of the split, the converter function becomes much cleaner and much safer.

With this refactors, it becomes clear that all the calls to `createCourse` via `this.$parent....createCourse(...)` is for the purpose of converting `CornellCourseRosterCourse` to `AppCourse`, so I renamed the function to reflect that.

### Test Plan <!-- Required -->

Check that fetching course information in the requirement bar and add course still works.

### Notes <!-- Optional -->

In a future diff, I plan to move the `createCourse` function out of the Dashboard component, and make the function and related state available globally.