### PR TITLE
Avoid storing semester id in AppSemester

### DIFF
--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -29,7 +29,7 @@
     </div>
     <coursemenu
       v-if="menuOpen"
-      :semId="semId"
+      :semesterIndex="semesterIndex"
       :isCompact="compact"
       class="course-menu"
       @delete-course="deleteCourse"
@@ -70,7 +70,7 @@ export default Vue.extend({
     id: String,
     uniqueID: Number,
     active: Boolean,
-    semId: Number,
+    semesterIndex: Number,
     isReqCourse: Boolean,
   },
   data() {

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -89,12 +89,14 @@ import { coursesColorSet } from '@/assets/constants/colors';
 export default Vue.extend({
   props: {
     getCreditRange: (Array as PropType<readonly number[]>) as PropType<readonly [number, number]>,
-    semId: Number,
+    semesterIndex: Number,
     isCompact: Boolean,
   },
   data() {
     return {
-      isLeft: (this.semId % 2 === 0 && !this.isCompact) || (this.semId % 4 === 0 && this.isCompact),
+      isLeft:
+        (this.semesterIndex % 2 === 0 && !this.isCompact) ||
+        (this.semesterIndex % 4 === 0 && this.isCompact),
       // TODO: better version for all breakpoints
       // isLeft: this.semId % numPerRow() === 0,
       colors: coursesColorSet,

--- a/src/components/Modals/DeleteSemester.vue
+++ b/src/components/Modals/DeleteSemester.vue
@@ -39,7 +39,6 @@ Vue.component('newCourse', NewCourse);
 
 export default Vue.extend({
   props: {
-    deleteSemID: Number,
     deleteSemType: String,
     deleteSemYear: Number,
   },

--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -13,7 +13,6 @@
         <newSemester
           class="modal-body"
           :currentSemesters="semesters"
-          :id="deleteSemID"
           :isEdit="true"
           :year="deleteSemYear"
           :type="deleteSemType"
@@ -51,7 +50,6 @@ Vue.component('newSemester', NewSemester);
 export default Vue.extend({
   props: {
     semesters: Array as PropType<readonly AppSemester[]>,
-    deleteSemID: Number,
     deleteSemType: String,
     deleteSemYear: Number,
   },

--- a/src/components/Modals/Modal.vue
+++ b/src/components/Modals/Modal.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
   },
   props: {
     type: String,
-    semesterID: Number,
+    semesterID: String,
     currentSemesters: Array,
     isOpen: Boolean,
     isCourseModelSelectingSemester: Boolean,

--- a/src/components/Modals/NewCourse/NewCourse.vue
+++ b/src/components/Modals/NewCourse/NewCourse.vue
@@ -101,7 +101,7 @@ const summer = require('@/assets/images/summerEmoji.svg');
 export default Vue.extend({
   props: {
     isOnboard: Boolean,
-    semesterID: Number,
+    semesterID: String,
     placeholderText: String,
     season: String,
     year: Number,

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -7,7 +7,6 @@
         >
         <div
           v-bind:class="[{ duplicate: isDuplicate() }, { 'newSemester-select': !isDuplicate() }]"
-          id="season"
           class="position-relative"
           v-click-outside="closeSeasonDropdownIfOpen"
         >
@@ -16,30 +15,18 @@
             @click="showHideSeasonContent"
           >
             <div
-              v-if="isEdit"
               class="newSemester-dropdown-placeholder season-placeholder"
-              :id="'season-placeholder-' + id"
-              :style="{ color: displayOptions.season.placeholderColor }"
-            >
-              {{ seasonPlaceholder }}
-            </div>
-            <div
-              v-else
-              class="newSemester-dropdown-placeholder season-placeholder"
-              id="season-placeholder"
               :style="{ color: displayOptions.season.placeholderColor }"
             >
               {{ seasonPlaceholder }}
             </div>
             <div
               class="newSemester-dropdown-placeholder season-arrow"
-              id="season-arrow"
               :style="{ borderTopColor: displayOptions.season.arrowColor }"
             ></div>
           </div>
           <div
             class="newSemester-dropdown-content season-content position-absolute w-100"
-            id="season-content"
             v-if="displayOptions.season.shown"
           >
             <div
@@ -62,36 +49,23 @@
         >
         <div
           v-bind:class="[{ duplicate: isDuplicate() }, { 'newSemester-select': !isDuplicate() }]"
-          id="year"
           class="position-relative"
           v-click-outside="closeYearDropdownIfOpen"
         >
           <div class="newSemester-dropdown-placeholder year-wrapper" @click="showHideYearContent">
             <div
-              v-if="isEdit"
               class="newSemester-dropdown-placeholder year-placeholder"
-              :id="'year-placeholder-' + id"
-              :style="{ color: displayOptions.year.placeholderColor }"
-            >
-              {{ yearPlaceholder }}
-            </div>
-            <div
-              v-else
-              class="newSemester-dropdown-placeholder year-placeholder"
-              id="year-placeholder"
               :style="{ color: displayOptions.year.placeholderColor }"
             >
               {{ yearPlaceholder }}
             </div>
             <div
               class="newSemester-dropdown-placeholder year-arrow"
-              id="year-arrow"
               :style="{ borderTopColor: displayOptions.year.arrowColor }"
             ></div>
           </div>
           <div
             class="newSemester-dropdown-content year-content position-absolute"
-            id="year-content"
             v-if="displayOptions.year.shown"
           >
             <div
@@ -325,7 +299,11 @@ export default Vue.extend({
       if (semesters != null) {
         semesters.forEach(semester => {
           if (semester.year === this.yearPlaceholder && semester.type === this.seasonPlaceholder) {
-            if (!this.isEdit || (this.isEdit && this.id !== semester.id)) {
+            if (
+              !this.isEdit ||
+              (this.isEdit &&
+                (this.yearPlaceholder !== this.year || this.seasonPlaceholder !== this.type))
+            ) {
               isDup = true;
             }
           }

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -39,13 +39,11 @@
         :isBottomBarExpanded="bottomBar.isExpanded"
         :isBottomBar="bottomCourses.length > 0"
         :isMobile="isMobile"
-        :currSemID="currSemID"
         :reqs="reqs"
         @compact-updated="compactVal = $event"
         @edit-semesters="editSemesters"
         @updateBar="updateBar"
         @close-bar="closeBar"
-        @increment-semID="incrementSemID"
       />
     </div>
     <tourwindow
@@ -149,7 +147,6 @@ export default Vue.extend({
     return {
       loaded: false,
       compactVal: false,
-      currSemID: 1,
       semesters: [] as readonly AppSemester[],
       currentClasses: [] as AppCourse[],
       toggleableRequirementChoices: {} as AppToggleableRequirementChoices,
@@ -223,7 +220,6 @@ export default Vue.extend({
           if (doc.exists) {
             const firestoreUserData = doc.data() as FirestoreUserData;
             this.semesters = firestoreSemestersToAppSemesters(firestoreUserData.semesters);
-            this.currSemID += this.semesters.length;
             this.toggleableRequirementChoices =
               firestoreUserData.toggleableRequirementChoices || {};
 
@@ -233,10 +229,7 @@ export default Vue.extend({
             this.loaded = true;
             this.recomputeRequirements();
           } else {
-            this.semesters = [
-              { id: this.currSemID, type: getCurrentSeason(), year: getCurrentYear(), courses: [] },
-            ];
-            this.currSemID += 1;
+            this.semesters = [{ type: getCurrentSeason(), year: getCurrentYear(), courses: [] }];
             this.startOnboarding();
           }
         })
@@ -371,9 +364,6 @@ export default Vue.extend({
 
       // Return randomly generated color
       return randomColor;
-    },
-    incrementSemID() {
-      this.currSemID += 1;
     },
     showTourEnd() {
       if (!this.isMobile) {

--- a/src/user-data.ts
+++ b/src/user-data.ts
@@ -142,7 +142,6 @@ export type AppCourse = {
 
 export type AppSemester = {
   readonly courses: readonly AppCourse[];
-  id: number;
   readonly type: FirestoreSemesterType;
   readonly year: number;
 };
@@ -319,12 +318,12 @@ export const firestoreCourseToAppCourse = (
   };
 };
 
-const firestoreSemesterToAppSemester = (
-  { courses, type, year }: FirestoreSemester,
-  semesterID: number
-): AppSemester => {
+const firestoreSemesterToAppSemester = ({
+  courses,
+  type,
+  year,
+}: FirestoreSemester): AppSemester => {
   return {
-    id: semesterID,
     courses: courses.map(course => firestoreCourseToAppCourse(course, false)),
     type,
     year,
@@ -334,9 +333,7 @@ const firestoreSemesterToAppSemester = (
 export const firestoreSemestersToAppSemesters = (
   firestoreSemesters: readonly FirestoreSemester[]
 ): AppSemester[] => {
-  return firestoreSemesters.map((firebaseSem, index) => {
-    return firestoreSemesterToAppSemester(firebaseSem, index + 1);
-  });
+  return firestoreSemesters.map(firestoreSemesterToAppSemester);
 };
 
 export const createAppUser = (data: FirestoreNestedUserData, name: FirestoreUserName): AppUser => {


### PR DESCRIPTION
## Summary

Right now the semester id is only used in two different ways:

- Use as a unique id for the semester for updating/editing, which can be replaced by a combination of year + season(type)
- Use as an array index like thing, which can be used to decide whether the edit color menu appear on the left or right. This can be replaced by an actual array index.

Keeping the id makes semester stuff tightly coupled with the root Dashboard.vue, so it's better to replace it.

## Test Plan

- Test semester creating, editing, deleting works
- Test edit semester and create semester still have correct duplication error warning
- Test edit color menu still appears on the correct side.