### PR TITLE
Cleanup Onboarding components (wave 4/n)

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -491,6 +491,7 @@ select option[disabled]:first-child {
   align-self: center;
 }
 .checkmark {
+  cursor: pointer;
   margin-right: 5px;
 }
 .addSpaceTop {

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -138,11 +138,6 @@ export default Vue.extend({
   },
   methods: {
     updateBasic() {
-      const name = {
-        firstName: this.firstName,
-        middleName: this.middleName,
-        lastName: this.lastName,
-      };
       this.$emit(
         'updateBasic',
         { acronym: this.collegeAcronym, text: this.colleges[this.collegeAcronym] },
@@ -154,7 +149,11 @@ export default Vue.extend({
           acronym,
           text: this.minors[acronym] || placeholderText,
         })),
-        name
+        {
+          firstName: this.firstName,
+          middleName: this.middleName,
+          lastName: this.lastName,
+        }
       );
     },
     // Clear a major if a new college is selected and the major is not in it
@@ -174,40 +173,36 @@ export default Vue.extend({
         }
       }
     },
-    onSelectDropdown(
-      dropdowns: readonly DropdownSlot[],
-      acronym: string,
-      text: string,
-      index: number
-    ): void {
-      const dropdown = dropdowns[index];
-      dropdown.acronym = acronym;
-      dropdown.text = text;
-    },
     selectCollege(acronym: string) {
       this.collegeAcronym = acronym;
+      this.clearMajorIfNotInCollege();
+      this.updateBasic();
     },
     selectMajor(acronym: string, i: number) {
       this.majorAcronyms = this.majorAcronyms.map((dropdown, index) =>
         index === i ? acronym : dropdown
       );
+      this.updateBasic();
     },
     selectMinor(acronym: string, i: number) {
       this.minorAcronyms = this.minorAcronyms.map((dropdown, index) =>
         index === i ? acronym : dropdown
       );
+      this.updateBasic();
     },
     removeMajor(index: number) {
       this.majorAcronyms.splice(index, 1);
       if (this.majorAcronyms.length === 0) {
         this.addMajor();
       }
+      this.updateBasic();
     },
     removeMinor(index: number) {
       this.minorAcronyms.splice(index, 1);
       if (this.minorAcronyms.length === 0) {
         this.addMinor();
       }
+      this.updateBasic();
     },
     addMajor() {
       this.majorAcronyms.push('');

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -90,57 +90,44 @@
           <div class="onboarding-selectWrapper-reviewExam">
             <div class="alignLeft">
               <label class="onboarding-label">AP Credits</label>
-              <div v-for="(options, index) in displayOptions.exam" :key="'AP' + index">
-                <label
-                  v-if="typeof options.type != undefined && options.type.placeholder == 'AP'"
-                  class="onboarding-label--review"
-                  >{{ options.subject.placeholder }}</label
-                >
+              <div v-for="(exam, index) in user.exam" :key="'AP' + index">
+                <label v-if="exam.type == 'AP'" class="onboarding-label--review">{{
+                  exam.subject
+                }}</label>
               </div>
               <label class="onboarding-label addSpaceTop">IB Credits</label>
-              <div v-for="(options, index) in displayOptions.exam" :key="'IB' + index">
-                <label
-                  v-if="typeof options.type != undefined && options.type.placeholder == 'IB'"
-                  class="onboarding-label--review"
-                  >{{ options.subject.placeholder }}</label
-                >
+              <div v-for="(exam, index) in user.exam" :key="'IB' + index">
+                <label v-if="exam.type == 'IB'" class="onboarding-label--review">{{
+                  exam.subject
+                }}</label>
               </div>
             </div>
             <div class="alignCenter">
               <label class="onboarding-label">Score</label>
-              <div v-for="(options, index) in displayOptions.exam" :key="'APScore' + index">
-                <label
-                  v-if="typeof options.type != undefined && options.type.placeholder == 'AP'"
-                  class="onboarding-label--review"
-                  >{{ options.score.placeholder }}</label
-                >
+              <div v-for="(exam, index) in user.exam" :key="'APScore' + index">
+                <label v-if="exam.type == 'AP'" class="onboarding-label--review">{{
+                  exam.score
+                }}</label>
               </div>
               <label class="onboarding-label addSpaceTop">Score</label>
-              <div v-for="(options, index) in displayOptions.exam" :key="'IBScore' + index">
-                <label
-                  v-if="typeof options.type != undefined && options.type.placeholder == 'IB'"
-                  class="onboarding-label--review"
-                  >{{ options.score.placeholder }}</label
-                >
+              <div v-for="(exam, index) in user.exam" :key="'IBScore' + index">
+                <label v-if="exam.type == 'IB'" class="onboarding-label--review">{{
+                  exam.score
+                }}</label>
               </div>
             </div>
             <div class="alignCenter">
               <label class="onboarding-label">Credit</label>
-              <div v-for="(options, index) in displayOptions.exam" :key="'APCredit' + index">
-                <!-- TODO replace credit with true value rather than dummy json value, or remove credit from showing -->
-                <label
-                  v-if="typeof options.type != undefined && options.type.placeholder == 'AP'"
-                  class="onboarding-label--review"
-                  >{{ getExamCredit(options) }}</label
-                >
+              <div v-for="(exam, index) in user.exam" :key="'APCredit' + index">
+                <label v-if="exam.type == 'AP'" class="onboarding-label--review">{{
+                  getExamCredit(exam)
+                }}</label>
               </div>
               <label class="onboarding-label addSpaceTop">Credit</label>
-              <div v-for="(options, index) in displayOptions.exam" :key="'IBCredit' + index">
-                <label
-                  v-if="typeof options.type != undefined && options.type.placeholder == 'IB'"
-                  class="onboarding-label--review"
-                  >{{ getExamCredit(options) }}</label
-                >
+              <div v-for="(exam, index) in user.exam" :key="'IBCredit' + index">
+                <label v-if="exam.type == 'IB'" class="onboarding-label--review">{{
+                  getExamCredit(exam)
+                }}</label>
               </div>
             </div>
           </div>
@@ -151,17 +138,13 @@
         <div class="onboarding-selectWrapper">
           <div class="onboarding-selectWrapper-reviewExam">
             <div>
-              <div v-for="(options, index) in displayOptions.class" :key="index">
-                <label v-if="options.class !== 'Select one'" class="onboarding-label--review">
-                  {{ options.class }}
-                </label>
+              <div v-for="(course, index) in user.transferCourse" :key="index">
+                <label class="onboarding-label--review">{{ course.class }}</label>
               </div>
             </div>
             <div class="alignEnd">
-              <div v-for="(options, index) in displayOptions.class" :key="index">
-                <label v-if="options.class !== 'Select one'" class="onboarding-label--review">
-                  {{ options.credits }} Credits
-                </label>
+              <div v-for="(course, index) in user.transferCourse" :key="index">
+                <label class="onboarding-label--review"> {{ course.credits }} Credits </label>
               </div>
             </div>
           </div>
@@ -178,127 +161,33 @@
   </div>
 </template>
 
-<script>
-// TODO: move repeated functions in all onboarding pages to a separate file
-import Vue from 'vue';
-import { examData } from '@/requirements/data/exams/ExamCredit';
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import { getExamCredit } from '@/components/Modals/Onboarding/OnboardingTransfer.vue';
+import { AppUser } from '@/user-data';
 
 const placeholderText = 'Select one';
 
 export default Vue.extend({
-  props: { user: Object },
+  props: { user: Object as PropType<AppUser> },
   computed: {
-    collegeText() {
+    collegeText(): string {
       return this.user.college !== '' ? this.user.collegeFN : placeholderText;
     },
-  },
-  data() {
-    return {
-      placeholderText,
-      totalCredits: 0,
-      transferJSON: {},
-      displayOptions: {
-        exam: [
-          {
-            // unnecessary but required for type check, as this is not ts file yet, whats a better way to deal with this?
-            placeholder: placeholderText,
-            type: { placeholder: '' },
-            subject: { placeholder: '' },
-            score: { placeholder: '' },
-          },
-        ],
-        class: [
-          // unnecessary but required for type check, as this is not ts file yet
-          { class: placeholderText, credits: 0 },
-        ],
-      },
-    };
-  },
-  mounted() {
-    this.getClasses();
-    this.getTransferMap();
-    this.getCredits();
-  },
-  methods: {
-    getClasses() {
-      const exams = [];
-      const sections = ['type', 'subject', 'score'];
-      if ('exam' in this.user && this.user.exam.length > 0) {
-        for (let x = 0; x < this.user.exam.length; x += 1) {
-          const exam = {};
-          for (const sec of sections) {
-            exam[sec] = { placeholder: this.user.exam[x][sec] };
-          }
-          if (typeof this.user.exam[x].subject !== 'undefined') {
-            exams.push(exam);
-            exam.equivCourse = this.user.exam[x].equivCourse;
-          }
-        }
-      }
-      const exam = {};
-      for (const sec of sections) {
-        exam[sec] = { placeholder: placeholderText };
-      }
-      exams.push(exam);
-      this.displayOptions.exam = exams;
-      const swim = typeof this.user.tookSwim !== 'undefined' ? this.user.tookSwim : 'no';
-      this.tookSwimTest = swim;
-      const transferClass = [];
-      this.user.transferCourse.forEach(course => {
-        transferClass.push(course);
-      });
-      transferClass.push({ class: placeholderText, credits: 0 });
-      this.displayOptions.class = transferClass;
-    },
-    getCredits() {
+    totalCredits(): number {
       let count = 0;
-      this.displayOptions.exam.forEach(exam => {
-        if (this.transferJSON !== null) {
-          const name = exam.subject.placeholder;
-          if (name in this.transferJSON) {
-            count += this.transferJSON[name].credits;
-          }
-        }
+      this.user.exam.forEach(exam => {
+        count += getExamCredit(exam);
       });
-      this.displayOptions.class.forEach(clas => {
+      this.user.transferCourse.forEach(clas => {
         count += clas.credits;
       });
-      this.totalCredits = count;
+      return count;
     },
-    getExamCredit(exam) {
-      const name = exam.subject.placeholder;
-      if (this.transferJSON !== null) {
-        if (name in this.transferJSON) {
-          return this.transferJSON[name].credits;
-        }
-      }
-      return 0;
-    },
-    getTransferMap() {
-      const TransferJSON = {};
-      examData.AP.forEach(sub => {
-        TransferJSON[sub.name] = {
-          credits: sub.fulfillment.credits,
-          type: 'AP',
-        };
-      });
-      examData.IB.forEach(sub => {
-        TransferJSON[sub.name] = {
-          credits: sub.fulfillment.credits,
-          type: 'IB',
-        };
-      });
-      this.transferJSON = TransferJSON;
-      if (typeof this.displayOptions !== 'undefined') {
-        this.$emit(
-          'updateTransfer',
-          this.displayOptions.exam,
-          this.displayOptions.class,
-          this.tookSwimTest
-        );
-      }
-    },
-    setPage(page) {
+  },
+  methods: {
+    getExamCredit,
+    setPage(page: number): void {
       this.$emit('setPage', page);
     },
   },

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -1,41 +1,9 @@
 <template>
   <div class="onboarding">
-    <div class="onboarding-section">
-      <div class="onboarding-subHeader">
-        <span class="onboarding-subHeader--font">Cornell Swimming Test </span>
-      </div>
-      <div class="onboarding-inputs onboarding-inputs--name">
-        <div class="onboarding-inputWrapper">
-          <label class="onboarding-label"
-            >Have you taken the Swim Test? (Choose yes if you are a transfer)</label
-          >
-          <div class="onboarding-inputs--radioWrapper">
-            <label class="onboarding-inputs--radio--radioText" for="yes">
-              <input
-                class="onboarding-inputs--radio"
-                type="radio"
-                v-on:click="updateSwimYes"
-                v-model="tookSwimTest"
-                value="yes"
-              />
-              <img class="checkmark" :src="swimYesImage" alt="checkmark" />
-              Yes
-            </label>
-            <label class="onboarding-inputs--radio--radioText" for="no">
-              <input
-                class="onboarding-inputs--radio"
-                type="radio"
-                v-on:click="updateSwimNo"
-                v-model="tookSwimTest"
-                value="no"
-              />
-              <img class="checkmark" :src="swimNoImage" alt="checkmark" />
-              No
-            </label>
-          </div>
-        </div>
-      </div>
-    </div>
+    <onboarding-transfer-swimming
+      :tookSwimTest="tookSwimTest === 'yes'"
+      @update-swim="updateSwim"
+    />
     <div class="onboarding-section">
       <div class="onboarding-subHeader">
         <span class="onboarding-subHeader--font"> Transfer Credits (Optional)</span>
@@ -46,94 +14,33 @@
             <span class="onboarding-subHeader--font">AP Credits</span>
           </div>
           <div class="onboarding-subsection">
-            <div
-              class="onboarding-section"
-              v-for="(options, index) in displayOptions.exam"
-              :key="index"
-              :style="{ borderColor: options.type.boxBorder }"
-              v-click-outside:[index]="closeAPDropdownIfOpen"
-            >
-              <div v-if="options.type.placeholder != 'IB'" class="onboarding-selectWrapperRow">
-                <div class="onboarding-select--columnWide">
-                  <label class="onboarding-label">Subject</label>
-                  <div class="onboarding-select onboarding-input">
-                    <div
-                      class="onboarding-dropdown-placeholder college-major-minor-wrapper"
-                      @click="showHideSubjectContent(index)"
-                    >
-                      <div
-                        class="onboarding-dropdown-placeholder college-major-minor-placeholder"
-                        :style="{ color: options.subject.placeholderColor }"
-                      >
-                        {{ options.subject.placeholder }}
-                      </div>
-                      <div
-                        class="onboarding-dropdown-placeholder college-arrow"
-                        :style="{ borderTopColor: options.subject.arrowColor }"
-                      ></div>
-                    </div>
-                    <div
-                      class="onboarding-dropdown-content college-content"
-                      v-if="options.subject.shown"
-                    >
-                      <div
-                        v-for="(subject, acronym) in subjects[index]"
-                        :key="acronym"
-                        class="onboarding-dropdown-content-item"
-                        @click="selectSubject(subject, acronym, index)"
-                      >
-                        {{ subject }}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="onboarding-select--column">
-                  <label class="onboarding-label">Score</label>
-                  <div class="onboarding-select onboarding-input">
-                    <div
-                      class="onboarding-dropdown-placeholder college-major-minor-wrapper"
-                      @click="showHideScoreContent(index)"
-                    >
-                      <div
-                        class="onboarding-dropdown-placeholder college-major-minor-placeholder"
-                        :style="{ color: options.score.placeholderColor }"
-                      >
-                        {{ options.score.placeholder }}
-                      </div>
-                      <div
-                        class="onboarding-dropdown-placeholder college-arrow"
-                        :style="{ borderTopColor: options.score.arrowColor }"
-                      ></div>
-                    </div>
-                    <div
-                      class="onboarding-dropdown-content college-content"
-                      v-if="options.score.shown"
-                    >
-                      <div
-                        v-for="(score, acronym) in scoresAP"
-                        :key="acronym"
-                        class="onboarding-dropdown-content-item"
-                        @click="selectScore(score, acronym, index)"
-                      >
-                        {{ score }}
-                      </div>
-                    </div>
-                  </div>
-                </div>
+            <div class="onboarding-section" v-for="(exam, index) in examsAP" :key="index">
+              <div class="onboarding-selectWrapperRow">
+                <onboarding-transfer-exam-property-dropdown
+                  property-name="Subject"
+                  :columnWide="true"
+                  :availableOptions="subjectsAP"
+                  :choice="exam.subject"
+                  @on-select="subject => selectAPSubject(subject, index)"
+                />
+                <onboarding-transfer-exam-property-dropdown
+                  property-name="Score"
+                  :columnWide="false"
+                  :availableOptions="scoresAP"
+                  :choice="exam.score"
+                  @on-select="score => selectAPScore(score, index)"
+                />
                 <div class="onboarding-select--columnCenter">
                   <label class="onboarding-label">Credits</label>
-                  <label class="college-major-minor-placeholder">{{
-                    getExamCredit(options)
-                  }}</label>
+                  <label class="college-major-minor-placeholder">{{ getExamCredit(exam) }}</label>
                 </div>
                 <div class="onboarding-select--column-removeExam">
                   <div
                     class="onboarding-remove"
-                    @click="removeExam(index)"
+                    @click="removeExam('AP', index)"
                     :class="{
                       'onboarding--hidden':
-                        countExamType(displayOptions.exam, 'AP') === 1 &&
-                        options.subject.placeholder == placeholderText,
+                        examsAP.length === 1 && exam.subject === placeholderText,
                     }"
                   >
                     <img src="@/assets/images/x-green.svg" alt="x" />
@@ -149,95 +56,33 @@
             <span class="onboarding-subHeader--font">IB Credits</span>
           </div>
           <div class="onboarding-inputs">
-            <div
-              class="onboarding-section"
-              v-for="(options, index) in displayOptions.exam"
-              :key="index"
-              :style="{ borderColor: options.type.boxBorder }"
-              v-click-outside:[index]="closeIBDropdownIfOpen"
-            >
-              <div v-if="options.type.placeholder != 'AP'" class="onboarding-selectWrapperRow">
-                <div class="onboarding-select--columnWide">
-                  <label class="onboarding-label">Subject</label>
-                  <div class="onboarding-select onboarding-input">
-                    <div
-                      class="onboarding-dropdown-placeholder college-major-minor-wrapper"
-                      @click="showHideSubjectContent(index)"
-                    >
-                      <div
-                        class="onboarding-dropdown-placeholder college-major-minor-placeholder"
-                        :style="{ color: options.subject.placeholderColor }"
-                      >
-                        {{ options.subject.placeholder }}
-                      </div>
-                      <div
-                        class="onboarding-dropdown-placeholder college-arrow"
-                        :style="{ borderTopColor: options.subject.arrowColor }"
-                      ></div>
-                    </div>
-                    <div
-                      class="onboarding-dropdown-content college-content"
-                      v-if="options.subject.shown"
-                    >
-                      <div
-                        v-for="(subject, acronym) in subjects[index]"
-                        :key="acronym"
-                        :id="subject"
-                        class="onboarding-dropdown-content-item"
-                        @click="selectSubject(subject, acronym, index)"
-                      >
-                        {{ subject }}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="onboarding-select--column">
-                  <label class="onboarding-label">Score</label>
-                  <div class="onboarding-select onboarding-input">
-                    <div
-                      class="onboarding-dropdown-placeholder college-major-minor-wrapper"
-                      @click="showHideScoreContent(index)"
-                    >
-                      <div
-                        class="onboarding-dropdown-placeholder college-major-minor-placeholder"
-                        :style="{ color: options.score.placeholderColor }"
-                      >
-                        {{ options.score.placeholder }}
-                      </div>
-                      <div
-                        class="onboarding-dropdown-placeholder college-arrow"
-                        :style="{ borderTopColor: options.score.arrowColor }"
-                      ></div>
-                    </div>
-                    <div
-                      class="onboarding-dropdown-content college-content"
-                      v-if="options.score.shown"
-                    >
-                      <div
-                        v-for="(score, acronym) in scoresIB"
-                        :key="acronym"
-                        class="onboarding-dropdown-content-item"
-                        @click="selectScore(score, acronym, index)"
-                      >
-                        {{ score }}
-                      </div>
-                    </div>
-                  </div>
-                </div>
+            <div class="onboarding-section" v-for="(exam, index) in examsIB" :key="index">
+              <div class="onboarding-selectWrapperRow">
+                <onboarding-transfer-exam-property-dropdown
+                  property-name="Subject"
+                  :columnWide="true"
+                  :availableOptions="subjectsIB"
+                  :choice="exam.subject"
+                  @on-select="subject => selectIBSubject(subject, index)"
+                />
+                <onboarding-transfer-exam-property-dropdown
+                  property-name="Score"
+                  :columnWide="false"
+                  :availableOptions="scoresIB"
+                  :choice="exam.score"
+                  @on-select="score => selectIBScore(score, index)"
+                />
                 <div class="onboarding-select--columnCenter">
                   <label class="onboarding-label">Credits</label>
-                  <label class="college-major-minor-placeholder">{{
-                    getExamCredit(options)
-                  }}</label>
+                  <label class="college-major-minor-placeholder">{{ getExamCredit(exam) }}</label>
                 </div>
                 <div class="onboarding-select--column-removeExam">
                   <div
                     class="onboarding-remove"
-                    @click="removeExam(index)"
+                    @click="removeExam('IB', index)"
                     :class="{
                       'onboarding--hidden':
-                        countExamType(displayOptions.exam, 'IB') === 1 &&
-                        options.subject.placeholder == placeholderText,
+                        examsIB.length === 1 && exam.subject === placeholderText,
                     }"
                   >
                     <img src="@/assets/images/x-green.svg" alt="x" />
@@ -257,16 +102,16 @@
           <div class="onboarding-inputs">
             <label class="onboarding-label">Equivalent Cornell Class</label>
             <div
-              v-for="(options, index) in displayOptions.class"
+              v-for="(options, index) in classes"
               :key="index"
               class="onboarding-selectWrapperRow"
             >
               <div class="onboarding-select--columnFill">
                 <newCourse
-                  :semesterID="index"
+                  :semesterID="String(index)"
                   :isOnboard="true"
                   :placeholderText="options.class"
-                  :key="displayOptions.class.length"
+                  :key="classes.length"
                   @addItem="addItem"
                 >
                 </newCourse>
@@ -277,7 +122,7 @@
                   @click="removeTransfer(index)"
                   :class="{
                     'onboarding--hidden':
-                      displayOptions.class.length === 1 &&
+                      classes.length === 1 &&
                       (options.class == placeholderText || options.class == null),
                   }"
                 >
@@ -323,446 +168,134 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { examData as reqsData } from '@/requirements/data/exams/ExamCredit';
-import checkmarkSelected from '@/assets/images/checkmark-onboarding.svg';
-import checkmarkUnselected from '@/assets/images/checkmark-empty.svg';
 import NewCourse from '@/components/Modals/NewCourse/NewCourse.vue';
-import { clickOutside } from '@/utilities';
-import { AppUser, CornellCourseRosterCourse, FirestoreTransferClass } from '@/user-data';
-// @ts-expect-error: typescript cannot understand scss variable imports.
-import { inactiveGray, yuxuanBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
+import { AppUser, FirestoreAPIBExam, CornellCourseRosterCourse } from '@/user-data';
+import OnboardingTransferSwimming from './OnboardingTransferSwimming.vue';
+import OnboardingTransferExamPropertyDropdown from './OnboardingTransferExamPropertyDropdown.vue';
 
 Vue.component('newCourse', NewCourse);
 
 const placeholderText = 'Select one';
 
-type Section = 'type' | 'subject' | 'score';
-
-type DisplayOption = {
-  shown: boolean;
-  stopClose: boolean;
-  boxBorder: string;
-  arrowColor: string;
-  placeholderColor: string;
-  placeholder: string;
-  acronym: string;
+type TransferClassWithOptionalCourse = {
+  class: string;
+  credits: number;
+  course?: CornellCourseRosterCourse;
 };
 
 type Data = {
-  tookSwimTest: string;
-  scoresAP: number[];
-  scoresIB: number[];
-  classes: [];
-  exams: string[];
+  tookSwimTest: 'yes' | 'no';
+  scoresAP: readonly number[];
+  scoresIB: readonly number[];
+  subjectsAP: readonly string[];
+  subjectsIB: readonly string[];
   placeholderText: string;
-  subjects: string[][];
-  firstName: string;
-  middleName?: string;
-  lastName: string;
-  displayOptions: {
-    exam: Record<'type' | 'subject' | 'score', DisplayOption>[];
-    class: FirestoreTransferClass[];
-  };
-  key: number;
-  transferJSON: any;
-  isError: boolean;
-  totalCredits: number;
-  swimYesImage: string;
-  swimNoImage: string;
+  examsAP: FirestoreAPIBExam[];
+  examsIB: FirestoreAPIBExam[];
+  classes: TransferClassWithOptionalCourse[];
+};
+
+const scoresAP = [1, 2, 3, 4, 5];
+const scoresIB = [1, 2, 3, 4, 5, 6, 7];
+const subjectsAP = reqsData.AP.map(it => it.name);
+const subjectsIB = reqsData.IB.map(it => it.name);
+
+export const getExamCredit = (exam: FirestoreAPIBExam): number => {
+  const relevantExamFromExamData = reqsData[exam.type].find(it => it.name === exam.subject);
+  if (relevantExamFromExamData == null) return 0;
+  const { fulfillment } = relevantExamFromExamData;
+  return exam.score < fulfillment.minimumScore ? 0 : fulfillment.credits;
 };
 
 export default Vue.extend({
+  components: { OnboardingTransferSwimming, OnboardingTransferExamPropertyDropdown },
   props: {
     user: Object as PropType<AppUser>,
   },
   data(): Data {
+    const examsAP: FirestoreAPIBExam[] = [];
+    const examsIB: FirestoreAPIBExam[] = [];
+    this.user.exam.forEach(exam => {
+      (exam.type === 'AP' ? examsAP : examsIB).push(exam);
+    });
+    examsAP.push({ type: 'AP', subject: placeholderText, score: 0 });
+    examsIB.push({ type: 'IB', subject: placeholderText, score: 0 });
+    const transferClasses: TransferClassWithOptionalCourse[] = [];
+    this.user.transferCourse.forEach(course => {
+      transferClasses.push(course);
+    });
+    transferClasses.push({ class: placeholderText, credits: 0 });
     return {
-      tookSwimTest: '',
-      scoresAP: [1, 2, 3, 4, 5],
-      scoresIB: [1, 2, 3, 4, 5, 6, 7],
-      classes: [],
-      exams: [],
+      tookSwimTest: typeof this.user.tookSwim !== 'undefined' ? this.user.tookSwim : 'no',
+      scoresAP,
+      scoresIB,
+      subjectsAP,
+      subjectsIB,
+      examsAP,
+      examsIB,
+      classes: transferClasses,
       placeholderText,
-      subjects: [[]],
-      firstName: this.user.firstName,
-      middleName: this.user.middleName,
-      lastName: this.user.lastName,
-      displayOptions: {
-        exam: [],
-        class: [],
-      },
-      key: 0,
-      transferJSON: {},
-      isError: false,
-      totalCredits: 0,
-      swimYesImage: '',
-      swimNoImage: '',
     };
   },
-  directives: {
-    'click-outside': clickOutside,
-  },
-  mounted() {
-    this.getClasses();
-    this.setExamsMap();
-    this.setSubjectList();
-    this.getCredits();
-    this.setSwimImages();
-  },
-  methods: {
-    getClasses() {
-      const exams: Record<Section, DisplayOption>[] = [];
-      const sections = ['type', 'subject', 'score'] as const;
-      if ('exam' in this.user && this.user.exam.length > 0) {
-        for (let x = 0; x < this.user.exam.length; x += 1) {
-          // @ts-ignore
-          const exam: Record<'type' | 'subject' | 'score', DisplayOption> = {};
-          for (const sec of sections) {
-            exam[sec] = {
-              shown: false,
-              stopClose: false,
-              boxBorder: '',
-              arrowColor: '',
-              placeholderColor: lightPlaceholderGray,
-              placeholder: String(this.user.exam[x][sec]),
-              acronym: '',
-            };
-          }
-          if (typeof this.user.exam[x].subject !== 'undefined') {
-            exams.push(exam);
-            // @ts-ignore
-            exam.equivCourse = this.user.exam[x].equivCourse;
-          }
-        }
-      }
-      // @ts-ignore
-      const examAP: Record<Section, DisplayOption> = {};
-      for (const sect of sections) {
-        let placeholderSect = placeholderText;
-        if (sect === 'type') {
-          placeholderSect = 'AP';
-        } else if (sect === 'score') {
-          placeholderSect = '0';
-        }
-        examAP[sect] = {
-          shown: false,
-          stopClose: false,
-          boxBorder: '',
-          arrowColor: '',
-          placeholderColor: '',
-          placeholder: placeholderSect,
-          acronym: '',
-        };
-      }
-      exams.push(examAP);
-      // @ts-ignore
-      const examIB: Record<Section, DisplayOption> = {};
-      for (const sect of sections) {
-        let placeholderSect = placeholderText;
-        if (sect === 'type') {
-          placeholderSect = 'IB';
-        } else if (sect === 'score') {
-          placeholderSect = '0';
-        }
-        examIB[sect] = {
-          shown: false,
-          stopClose: false,
-          boxBorder: '',
-          arrowColor: '',
-          placeholderColor: '',
-          placeholder: placeholderSect,
-          acronym: '',
-        };
-      }
-      exams.push(examIB);
-      this.displayOptions.exam = exams;
-      const swim = typeof this.user.tookSwim !== 'undefined' ? this.user.tookSwim : 'no';
-      this.tookSwimTest = swim;
-      const transferClass: FirestoreTransferClass[] = [];
-      this.user.transferCourse.forEach(course => {
-        transferClass.push(course);
-      });
-      // @ts-ignore
-      transferClass.push({ class: placeholderText, credits: 0 });
-      this.displayOptions.class = transferClass;
-    },
-    getCredits() {
+  computed: {
+    totalCredits(): number {
       let count = 0;
-      this.displayOptions.exam.forEach(exam => {
-        if (this.transferJSON !== null) {
-          const name = exam.subject.placeholder;
-          if (name in this.transferJSON) {
-            count += this.transferJSON[name].credits;
-          }
-        }
+      [...this.examsAP, ...this.examsIB].forEach(exam => {
+        count += this.getExamCredit(exam);
       });
-      this.displayOptions.class.forEach(clas => {
+      this.classes.forEach(clas => {
         count += clas.credits;
       });
-      this.totalCredits = count;
+      return count;
     },
-    getExamCredit(exam: Record<'type' | 'subject' | 'score', DisplayOption>) {
-      const name = exam.subject.placeholder;
-      if (this.transferJSON !== null) {
-        if (name in this.transferJSON) {
-          return this.transferJSON[name].credits;
-        }
-      }
-      return 0;
+  },
+  methods: {
+    getExamCredit,
+    updateSwim(tookSwimTest: boolean) {
+      this.tookSwimTest = tookSwimTest ? 'yes' : 'no';
+      this.updateTransfer();
     },
-    getTransferMap() {
-      const TransferJSON: Record<string, { credits: number; type: 'AP' | 'IB' }> = {};
-      reqsData.AP.forEach(sub => {
-        TransferJSON[sub.name] = {
-          credits: sub.fulfillment.credits,
-          type: 'AP',
-        };
-      });
-      reqsData.IB.forEach(sub => {
-        TransferJSON[sub.name] = {
-          credits: sub.fulfillment.credits,
-          type: 'IB',
-        };
-      });
-      this.transferJSON = TransferJSON;
-      if (typeof this.displayOptions !== 'undefined') {
-        this.$emit(
-          'updateTransfer',
-          this.displayOptions.exam,
-          this.displayOptions.class,
-          this.tookSwimTest
-        );
-      }
+    selectAPSubject(subject: string, i: number) {
+      this.examsAP = this.examsAP.map((exam, index) => (index === i ? { ...exam, subject } : exam));
+      this.updateTransfer();
     },
-    showHideContent(type: 'exam' | 'class', section: Section, i: number) {
-      let displayOptions: any = this.displayOptions[type][i];
-      if (type === 'exam') {
-        displayOptions = displayOptions[section];
-      }
-      const contentShown = displayOptions.shown;
-      displayOptions.shown = !contentShown;
-      if (contentShown) {
-        displayOptions.boxBorder = inactiveGray;
-        displayOptions.arrowColor = inactiveGray;
-      } else {
-        displayOptions.boxBorder = yuxuanBlue;
-        displayOptions.arrowColor = yuxuanBlue;
-      }
+    selectIBSubject(subject: string, i: number) {
+      this.examsIB = this.examsIB.map((exam, index) => (index === i ? { ...exam, subject } : exam));
+      this.updateTransfer();
     },
-    showHideExamContent(i: number) {
-      this.showHideContent('exam', 'type', i);
+    selectAPScore(score: number, i: number) {
+      this.examsAP = this.examsAP.map((exam, index) => (index === i ? { ...exam, score } : exam));
+      this.updateTransfer();
     },
-    showHideSubjectContent(i: number) {
-      this.showHideContent('exam', 'subject', i);
-    },
-    showHideScoreContent(i: number) {
-      this.showHideContent('exam', 'score', i);
-    },
-    showHideClassContent(i: number) {
-      // @ts-ignore
-      this.showHideContent('class', '', i);
-    },
-    closeDropdownIfOpen(section: 'exam' | 'class', type: 'AP' | 'IB' | null, i: number) {
-      const displayOptions: any = this.displayOptions[section][i];
-      if (section === 'exam') {
-        Object.keys(displayOptions).forEach(key => {
-          if (key !== 'equivCourse' && displayOptions[key].stopClose) {
-            displayOptions[key].stopClose = false;
-          } else if (
-            key !== 'equivCourse' &&
-            displayOptions[key].shown &&
-            displayOptions.type.placeholder === type
-          ) {
-            displayOptions[key].shown = false;
-            displayOptions[key].boxBorder = inactiveGray;
-            displayOptions[key].arrowColor = inactiveGray;
-          }
-        });
-      } else if (displayOptions.stopClose) {
-        displayOptions.stopClose = false;
-      } else if ('equivCourse' && displayOptions.shown) {
-        displayOptions.shown = false;
-        displayOptions.boxBorder = inactiveGray;
-        displayOptions.arrowColor = inactiveGray;
-      }
-    },
-    closeIBDropdownIfOpen(event: unknown, i: number) {
-      this.closeDropdownIfOpen('exam', 'IB', i);
-    },
-    closeAPDropdownIfOpen(event: unknown, i: number) {
-      this.closeDropdownIfOpen('exam', 'AP', i);
-    },
-    closeClassDropdownIfOpen(event: unknown, i: number) {
-      this.closeDropdownIfOpen('class', null, i);
-    },
-    // Set the exam map to with acronym keys and full name values
-    setExamsMap() {
-      const exams: string[] = [];
-      Object.keys(reqsData).forEach(key => {
-        exams.push(key);
-      });
-      this.exams = exams;
-    },
-    // Set the subject map to with acronym keys and full name values
-    setSubjectList() {
-      /** @type {Object.<string, string>} */
-      const totalSubjects: string[][] = [];
-      this.displayOptions.exam.forEach(exam => {
-        if (exam.type.placeholder !== placeholderText) {
-          // @ts-ignore
-          const examType: 'AP' | 'IB' = exam.type.placeholder;
-          const subjects: string[] = [];
-          if (examType in reqsData && examType !== null) {
-            reqsData[examType].forEach(sub => {
-              subjects.push(sub.name);
-            });
-            totalSubjects.push(subjects);
-          }
-        }
-      });
-      this.subjects = totalSubjects;
-    },
-    // Didn't want to seperate into two functions but v-model wouldn't work unless clicked twice?
-    updateSwimYes() {
-      this.tookSwimTest = 'yes';
-      this.swimYesImage = checkmarkSelected;
-      this.swimNoImage = checkmarkUnselected;
-      this.$emit(
-        'updateTransfer',
-        this.displayOptions.exam,
-        this.displayOptions.class,
-        this.tookSwimTest
-      );
-    },
-    updateSwimNo() {
-      this.tookSwimTest = 'no';
-      this.swimNoImage = checkmarkSelected;
-      this.swimYesImage = checkmarkUnselected;
-      this.$emit(
-        'updateTransfer',
-        this.displayOptions.exam,
-        this.displayOptions.class,
-        this.tookSwimTest
-      );
-    },
-    setSwimImages() {
-      this.swimYesImage = this.tookSwimTest === 'yes' ? checkmarkSelected : checkmarkUnselected;
-      this.swimNoImage = this.tookSwimTest === 'no' ? checkmarkSelected : checkmarkUnselected;
-    },
-    selectOption(
-      type: 'exam' | 'class',
-      section: Section,
-      text: string,
-      acronym: string | number,
-      i: number
-    ) {
-      let displayOptions: any = this.displayOptions[type][i];
-      if (type === 'exam') {
-        displayOptions = displayOptions[section];
-      }
-      displayOptions.placeholder = text;
-      displayOptions.shown = false;
-      displayOptions.arrowColor = inactiveGray;
-      displayOptions.boxBorder = inactiveGray;
-      displayOptions.placeholderColor = lightPlaceholderGray;
-    },
-    selectExam(text: string, acronym: string | number, i: number) {
-      this.selectOption('exam', 'type', text, acronym, i);
-      this.setSubjectList();
-    },
-    selectScore(text: number, acronym: string | number, i: number) {
-      this.selectOption('exam', 'score', String(text), acronym, i);
-    },
-    selectSubject(text: string, acronym: string | number, i: number) {
-      // @ts-ignore
-      const type: 'AP' | 'IB' = this.displayOptions.exam[i].type.placeholder;
-      this.selectOption('exam', 'subject', text, acronym, i);
-    },
-    selectClass(text: string, acronym: string | number, i: number) {
-      // @ts-ignore
-      this.selectOption('class', 'placholder', text, acronym, i);
+    selectIBScore(score: number, i: number) {
+      this.examsIB = this.examsIB.map((exam, index) => (index === i ? { ...exam, score } : exam));
+      this.updateTransfer();
     },
     addExam(type: 'AP' | 'IB') {
-      const exam = {
-        type: {
-          shown: false,
-          stopClose: false,
-          boxBorder: '',
-          arrowColor: '',
-          placeholderColor: '',
-          placeholder: type,
-          acronym: '',
-        },
-        subject: {
-          shown: false,
-          stopClose: false,
-          boxBorder: '',
-          arrowColor: '',
-          placeholderColor: placeholderText,
-          placeholder: placeholderText,
-          acronym: '',
-        },
-        score: {
-          shown: false,
-          stopClose: false,
-          boxBorder: '',
-          arrowColor: '',
-          placeholderColor: '',
-          placeholder: '0',
-          acronym: '',
-        },
-      };
-      this.displayOptions.exam.push(exam);
-      this.setSubjectList();
-      this.getCredits();
+      const exam = { type, subject: placeholderText, score: 0 };
+      (type === 'AP' ? this.examsAP : this.examsIB).push(exam);
     },
-    getCourseFromExam(type: 'AP' | 'IB', subject: string) {
-      let courses: Record<string, number[]> | undefined;
-      for (const exam of reqsData[type]) {
-        if (exam.name === subject) {
-          courses = exam.fulfillment.courseEquivalents;
-          // as a default takes the first equivalent course
-          // TODO will need to add requirements menu if editiable.
-          break;
-        }
-      }
-      return courses;
-    },
-    removeExam(index: number) {
-      this.displayOptions.exam.splice(index, 1);
-      if (this.countExamType(this.displayOptions.exam, 'AP') === 0) {
-        this.addExam('AP');
-      }
-      if (this.countExamType(this.displayOptions.exam, 'IB') === 0) {
-        this.addExam('IB');
-      }
-      this.getCredits();
-      this.key += 1;
+    removeExam(type: 'AP' | 'IB', index: number) {
+      const exams = type === 'AP' ? this.examsAP : this.examsIB;
+      exams.splice(index, 1);
+      if (exams.length === 0) this.addExam(type);
+      this.updateTransfer();
     },
     removeTransfer(index: number) {
-      this.displayOptions.class.splice(index, 1);
-      if (this.displayOptions.class.length === 0) {
+      this.classes.splice(index, 1);
+      if (this.classes.length === 0) {
         this.addTransfer();
       }
-      this.getCredits();
+      this.updateTransfer();
     },
     addTransfer() {
-      // @ts-ignore
-      this.displayOptions.class.push({ class: placeholderText, credits: 0 });
-    },
-    countExamType(exams: Record<'type' | 'subject' | 'score', DisplayOption>[], type: 'AP' | 'IB') {
-      let counter = 0;
-      for (let i = 0; i < exams.length; i += 1) {
-        if (exams[i].type.placeholder === type) {
-          counter += 1;
-        }
-      }
-      return counter;
+      this.classes.push({ class: placeholderText, credits: 0 });
     },
     updateTransfer() {
       this.$emit(
         'updateTransfer',
-        this.displayOptions.exam,
-        this.displayOptions.class,
+        [...this.examsAP, ...this.examsIB],
+        this.classes,
         this.tookSwimTest
       );
     },
@@ -782,12 +315,7 @@ export default Vue.extend({
             if (resultJSONclass.catalogNbr === number) {
               const course = resultJSONclass;
               const creditsC = course.enrollGroups[0].unitsMaximum;
-              this.displayOptions.class[id] = {
-                class: courseCode,
-                course,
-                credits: creditsC,
-              };
-              this.getCredits();
+              this.classes[id] = { class: courseCode, course, credits: creditsC };
             }
           });
         });

--- a/src/components/Modals/Onboarding/OnboardingTransferExamPropertyDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransferExamPropertyDropdown.vue
@@ -1,0 +1,99 @@
+<template>
+  <div
+    :class="columnWide ? 'onboarding-select--columnWide' : 'onboarding-select--column'"
+    :style="{ borderColor: boxBorder }"
+    v-click-outside="closeDropdownIfOpen"
+  >
+    <label class="onboarding-label">{{ propertyName }}</label>
+    <div class="onboarding-select onboarding-input">
+      <div
+        class="onboarding-dropdown-placeholder college-major-minor-wrapper"
+        @click="showHideContent()"
+      >
+        <div
+          class="onboarding-dropdown-placeholder college-major-minor-placeholder"
+          :style="{ color: placeholderColor }"
+        >
+          {{ choice }}
+        </div>
+        <div
+          class="onboarding-dropdown-placeholder college-arrow"
+          :style="{ borderTopColor: arrowColor }"
+        ></div>
+      </div>
+      <div class="onboarding-dropdown-content college-content" v-if="shown">
+        <div
+          v-for="(choice, index) in availableOptions"
+          :key="index"
+          class="onboarding-dropdown-content-item"
+          @click="selectChoice(choice)"
+        >
+          {{ choice }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import { clickOutside } from '@/utilities';
+// @ts-expect-error: typescript cannot understand scss variable imports.
+import { inactiveGray, yuxuanBlue, lightPlaceholderGray } from '@/assets/scss/_variables.scss';
+
+const placeholderText = 'Select one';
+
+export default Vue.extend({
+  props: {
+    propertyName: { type: String, required: true },
+    columnWide: { type: Boolean, required: true },
+    availableOptions: { type: Array as PropType<readonly unknown[]>, required: true },
+    choice: { type: [String, Number], required: true },
+  },
+  data() {
+    return {
+      shown: false,
+      stopClose: false,
+      boxBorder: '',
+      arrowColor: '',
+      placeholderColor: this.choice && this.choice !== placeholderText ? lightPlaceholderGray : '',
+    };
+  },
+  directives: {
+    'click-outside': clickOutside,
+  },
+  methods: {
+    showHideContent() {
+      const contentShown = this.shown;
+      this.shown = !contentShown;
+      if (contentShown) {
+        this.boxBorder = inactiveGray;
+        this.arrowColor = inactiveGray;
+      } else {
+        this.boxBorder = yuxuanBlue;
+        this.arrowColor = yuxuanBlue;
+      }
+    },
+    closeDropdownIfOpen() {
+      if (this.stopClose) {
+        this.stopClose = false;
+      } else if (this.shown) {
+        this.shown = false;
+        this.boxBorder = inactiveGray;
+        this.arrowColor = inactiveGray;
+      }
+    },
+    selectChoice(choice: unknown) {
+      this.$emit('on-select', choice);
+      this.shown = false;
+      this.arrowColor = inactiveGray;
+      this.boxBorder = inactiveGray;
+      this.placeholderColor = lightPlaceholderGray;
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/components/Modals/Onboarding/Onboarding.scss';
+</style>

--- a/src/components/Modals/Onboarding/OnboardingTransferSwimming.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransferSwimming.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="onboarding-section">
+    <div class="onboarding-subHeader">
+      <span class="onboarding-subHeader--font">Cornell Swimming Test </span>
+    </div>
+    <div class="onboarding-inputs onboarding-inputs--name">
+      <div class="onboarding-inputWrapper">
+        <label class="onboarding-label"
+          >Have you taken the Swim Test? (Choose yes if you are a transfer)</label
+        >
+        <div class="onboarding-inputs--radioWrapper">
+          <label class="onboarding-inputs--radio--radioText" for="onboarding-transfer-swimming-yes">
+            <input
+              class="onboarding-inputs--radio"
+              id="onboarding-transfer-swimming-yes"
+              type="radio"
+              v-model="radioValue"
+              value="true"
+            />
+            <img class="checkmark" :src="swimYesImage" alt="checkmark" />
+            Yes
+          </label>
+          <label class="onboarding-inputs--radio--radioText" for="onboarding-transfer-swimming-no">
+            <input
+              class="onboarding-inputs--radio"
+              id="onboarding-transfer-swimming-no"
+              type="radio"
+              v-model="radioValue"
+              value="false"
+            />
+            <img class="checkmark" :src="swimNoImage" alt="checkmark" />
+            No
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import checkmarkSelected from '@/assets/images/checkmark-onboarding.svg';
+import checkmarkUnselected from '@/assets/images/checkmark-empty.svg';
+
+export default Vue.extend({
+  props: { tookSwimTest: { type: Boolean, required: true } },
+  data() {
+    return { radioValue: String(this.tookSwimTest) };
+  },
+  watch: {
+    radioValue(tookSwimTest: string): void {
+      this.$emit('update-swim', tookSwimTest === 'true');
+    },
+  },
+  computed: {
+    swimYesImage(): string {
+      return this.radioValue === 'true' ? checkmarkSelected : checkmarkUnselected;
+    },
+    swimNoImage(): string {
+      return this.radioValue === 'false' ? checkmarkSelected : checkmarkUnselected;
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/components/Modals/Onboarding/Onboarding.scss';
+</style>

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -149,7 +149,6 @@ export default Vue.extend({
       loaded: false,
       compactVal: false,
       semesters: [] as readonly AppSemester[],
-      currentClasses: [] as AppCourse[],
       toggleableRequirementChoices: {} as AppToggleableRequirementChoices,
       user: {
         major: [],
@@ -230,7 +229,7 @@ export default Vue.extend({
           const uniqueIncrementerData = uniqueIncrementerDoc.data();
           const onboardingData = onboardingDataDoc.data();
           if (usernameData != null && onboardingData != null) {
-            this.user = this.parseUserData(onboardingData, usernameData);
+            this.user = createAppUser(onboardingData, usernameData);
           }
           if (semestersData != null) {
             this.semesters = firestoreSemestersToAppSemesters(semestersData.semesters);
@@ -479,7 +478,7 @@ export default Vue.extend({
       userData: FirestoreOnboardingUserData;
       name: FirestoreUserName;
     }) {
-      const user = this.parseUserData(onboardingData.userData, onboardingData.name);
+      const user = createAppUser(onboardingData.userData, onboardingData.name);
 
       this.user = user;
       this.loaded = true;
@@ -501,29 +500,6 @@ export default Vue.extend({
 
     cancelOnboarding() {
       this.isOnboarding = false;
-    },
-    parseUserData(data: FirestoreOnboardingUserData, name: FirestoreUserName): AppUser {
-      const user = createAppUser(data, name);
-
-      const transferClasses: any[] = [];
-      user.exam.forEach(exam => {
-        if ('equivCourse' in exam) {
-          transferClasses.push(exam.equivCourse[0]);
-        }
-      });
-      user.transferCourse.forEach(course => {
-        const courseInfo = cornellCourseRosterCourseToAppCourse(
-          course.course,
-          false,
-          () => this.incrementID(),
-          subject => this.addColor(subject)
-        );
-        transferClasses.push(courseInfo);
-        // ; // TODO for user to pick which req a class goes for
-      });
-      this.currentClasses = transferClasses;
-
-      return user;
     },
 
     editProfile() {


### PR DESCRIPTION
### Summary <!-- Required -->

Depends on #253.

This diff cleans up the `OnboardingTransfer` component by creating the following components:

- `OnboardingTransferExamPropertyDropdown.vue`, which serves as an editor for exam subject and score,
- `OnboardingTransferSwimming.vue`, which serves as an editor as `tookSwimTest`

Using the above components allow us to move all the display props down to those children components, and greatly simplified the state of the `OnboardingTransfer` component. Now the `OnboardingTransfer` component only serves as a container for states.

### Test Plan <!-- Required -->

Check that transfer credits and AP/IB exam data editor are working fine and data are stored.