### PR TITLE
[easy][cleanup] Eliminate all unnecessary id from vue templates

### DIFF
--- a/src/components/BottomBar/BottomBarTabView.vue
+++ b/src/components/BottomBar/BottomBarTabView.vue
@@ -8,7 +8,6 @@
       >
         <bottombartab
           v-bind="bottomCourse"
-          :id="index"
           :subject="bottomCourse.subject"
           :number="bottomCourse.number"
           :color="bottomCourse.color"

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -67,7 +67,6 @@ export default Vue.extend({
       type: Array,
     },
     compact: Boolean,
-    id: String,
     uniqueID: Number,
     active: Boolean,
     semesterIndex: Number,

--- a/src/components/Modals/DeleteSemester.vue
+++ b/src/components/Modals/DeleteSemester.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="deleteSemesterModal">
-    <div class="deleteSemesterModal-content" id="deleteSemester">
+    <div class="deleteSemesterModal-content">
       <div class="deleteSemesterModal-top">
         <span class="deleteSemesterModal-title">{{ title }}</span>
         <img

--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="editSemesterModal">
-    <div class="editSemesterModal-content" id="deleteSemester">
+    <div class="editSemesterModal-content">
       <div class="editSemesterModal-top">
         <span class="editSemesterModal-title">{{ title }}</span>
         <img

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -33,7 +33,6 @@
               v-bind:class="{ warning: isDuplicate }"
               v-for="season in seasons"
               :key="seasonValue(season)"
-              :id="season"
               class="newSemester-dropdown-content-item"
               @click="selectSeason(season[1])"
             >
@@ -71,7 +70,6 @@
             <div
               v-for="year in years"
               :key="year"
-              :id="year"
               class="newSemester-dropdown-content-item"
               @click="selectYear(year)"
             >

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -7,11 +7,7 @@
       <div class="navbar-iconWrapper desktop" id="profileIcon" @click="editProfile"></div>
     </div>
     <div class="navbar-bottom">
-      <div
-        class="navbar-iconWrapper mobile"
-        id="requirementsBar"
-        @click="toggleRequirementsBar"
-      ></div>
+      <div class="navbar-iconWrapper mobile requirementsBar" @click="toggleRequirementsBar"></div>
       <div class="navbar-iconWrapper mobile" id="profileIcon" @click="editProfile"></div>
       <div class="navbar-iconWrapper" id="logout" @click="logout"></div>
     </div>
@@ -91,7 +87,7 @@ export default Vue.extend({
   }
 }
 
-#requirementsBar {
+.requirementsBar {
   cursor: pointer;
   background-image: url('~@/assets/images/navbar/hamburger-gray.svg');
 
@@ -164,7 +160,7 @@ export default Vue.extend({
 
 @media only screen and (max-width: 600px) {
   .navbar {
-    #requirementsBar {
+    .requirementsBar {
       cursor: pointer;
       background-image: url('~@/assets/images/navbar/hamburger-gray.svg');
 

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="completedsubreqcourse">
     <div class="completed-reqCourses-course-wrapper">
-      <div id="completedSeparator" class="separator"></div>
+      <div class="separator"></div>
       <div class="completed-reqCourses-course-heading-wrapper">
         <div class="completed-reqCourses-course-heading-course">
           <span class="completed-reqCourses-course-heading-check"
@@ -18,7 +18,6 @@
       </div>
       <div class="completed-reqCourses-course-object-wrapper">
         <reqcourse
-          :id="courseSubject + courseNumber"
           :color="color"
           :subject="courseSubject"
           :number="courseNumber"

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="incompletesubreqcourse">
     <div class="draggable-requirements-wrapper" v-if="displayDescription">
-      <div id="incompleteSeparator" class="separator"></div>
+      <div class="separator"></div>
       <div class="draggable-requirements-heading">
         <div class="draggable-requirements-heading-label">{{ addCourseLabel }}</div>
         <div
@@ -38,7 +38,6 @@
           <course
             v-bind="course"
             :courseObj="course"
-            :id="course.subject + course.number"
             :uniqueID="course.uniqueID"
             :compact="true"
             :active="false"

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -1,7 +1,6 @@
 <template v-if="semesters">
   <div class="requirements">
     <div
-      id="req-tooltip"
       class="fixed"
       data-intro-group="req-tooltip"
       :v-bind:class="{ 'd-none': !shouldShowAllCourses }"
@@ -50,7 +49,6 @@
               <course
                 v-bind="courseData"
                 :courseObj="courseData"
-                :id="courseData.subject + courseData.number"
                 :uniqueID="courseData.uniqueID"
                 :compact="false"
                 :active="false"

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -51,7 +51,6 @@
       + New Semester
     </button>
     <div
-      id="tour"
       class="semester-content"
       data-intro-group="pageTour"
       data-step="2"
@@ -84,7 +83,6 @@
               v-bind="course"
               :courseObj="course"
               :duplicatedCourseCodeList="duplicatedCourseCodeList"
-              :id="course.subject + course.number"
               :uniqueID="course.uniqueID"
               :compact="compact"
               :active="activatedCourse.uniqueID === course.uniqueID"

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -10,7 +10,6 @@
     :key="key"
   >
     <new-semester-modal
-      id="semesterModal"
       class="semester-modal"
       :class="{ 'modal--block': isSemesterModalOpen }"
       :currentSemesters="semesters"
@@ -38,13 +37,11 @@
       </div>
     </div>
     <confirmation
-      :id="'semesterConfirmation'"
       class="semesterView-confirmation"
       :class="{ 'modal--flex': isSemesterConfirmationOpen }"
       :text="confirmationText"
     />
     <semester-caution
-      :id="'semesterCaution'"
       class="semesterView-caution"
       :class="{ 'modal--flex': isCautionModalOpen }"
       :text="cautionText"

--- a/src/containers/404.vue
+++ b/src/containers/404.vue
@@ -5,7 +5,7 @@
       <div class="message-container">
         <img class="img-404" src="@/assets/images/404.svg" alt="404" />
         <div class="oops-wrapper">
-          <div id="oops" class="color_box">
+          <div class="oops color_box">
             Oops...
             <br />Page Not Found
             <img
@@ -39,7 +39,7 @@ export default Vue.extend({});
 .logo {
   width: 12rem;
 }
-#oops {
+.oops {
   text-align: left;
   display: inline-block;
   font-weight: bold;

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="dashboard" class="dashboard">
+  <div class="dashboard">
     <onboarding
       class="dashboard-onboarding"
       v-if="isOnboarding"
@@ -68,7 +68,7 @@
       v-if="showTourEndWindow"
     >
     </tourwindow>
-    <div id="dashboard-bottomView">
+    <div>
       <bottombar
         v-if="bottomCourses.length > 0 && ((!isOpeningRequirements && isTablet) || !isTablet)"
         :bottomCourses="bottomCourses"

--- a/src/containers/Login.vue
+++ b/src/containers/Login.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="login">
+  <div>
     <transition name="fade">
       <div v-if="performingRequest" class="loading">
         <p>Loading...</p>
@@ -79,8 +79,7 @@
           </div>
           <div class="col-6 col-md-6 image-wrapper women-wrapper">
             <img
-              id="hide"
-              class="women"
+              class="hide women"
               src="@/assets/images/Person_planning.svg"
               alt="women planning"
             />
@@ -93,9 +92,8 @@
         <div class="drag phonepad row no-gutters">
           <div class="col-md-6 image-wrapper image-wrapper--drag">
             <img
-              id="hide"
               style="position: relative"
-              class="preview"
+              class="hide preview"
               src="@/assets/images/drag.svg"
               alt="Dragging preview"
             />
@@ -121,7 +119,7 @@
             </p>
           </div>
           <div class="col-md-7 image-wrapper image-wrapper--semester">
-            <img id="hide" class="schedule" src="@/assets/images/schedule.svg" alt="Plan preview" />
+            <img class="hide schedule" src="@/assets/images/schedule.svg" alt="Plan preview" />
           </div>
         </div>
       </div>
@@ -546,7 +544,7 @@ p {
   max-width: 600px;
 }
 @media (max-width: 1154px) {
-  img#hide {
+  img.hide {
     display: none;
   }
   .top-bar {


### PR DESCRIPTION
### Summary <!-- Required -->

There are a lot of id declaration in the vue templates. In most cases, they shouldn't be there, because it's usually a sign of DOM manipulation. In this PR I purged almost all of them. In cases where id is used for styling, I replaced that with class names.

There are only 3 left:

1. dropdown-<id>. Sadly, it's used to retrieve values from new course component. I plan to eventually replace it with emits
2. id="app". This is required for setup vue.
3. id="onboarding-transfer-swimming-yes" and id="onboarding-transfer-swimming-no". They are there for the labels.

### Test Plan <!-- Required -->

- 404 page is fine
- login page is fine
- dashboard is fine
- modals are fine