### PR TITLE
Convert NewCourse.vue to TypeScript

### DIFF
--- a/src/components/Modals/NewCourse/NewCourse.vue
+++ b/src/components/Modals/NewCourse/NewCourse.vue
@@ -84,8 +84,8 @@
   </div>
 </template>
 
-<script>
-import Vue from 'vue';
+<script lang="ts">
+import Vue, { PropType } from 'vue';
 import coursesJSON from '@/assets/courses/courses.json';
 import EditRequirement from '@/components/Modals/NewCourse/EditRequirement.vue';
 import BinaryButton from '@/components/Modals/NewCourse/BinaryButton.vue';
@@ -94,6 +94,9 @@ import fall from '@/assets/images/fallEmoji.svg';
 import spring from '@/assets/images/springEmoji.svg';
 import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
+import { FirestoreSemesterType } from '@/user-data';
+import { SingleMenuRequirement } from '@/requirements/types';
+import { CourseJson } from '@/requirements/courses-json-generator';
 
 Vue.component('editRequirement', EditRequirement);
 Vue.component('binaryButton', BinaryButton);
@@ -103,10 +106,10 @@ export default Vue.extend({
     isOnboard: Boolean,
     semesterID: String,
     placeholderText: String,
-    season: String,
+    season: String as PropType<FirestoreSemesterType>,
     year: Number,
     isCourseModelSelectingSemester: Boolean,
-    reqs: Array,
+    reqs: Array as PropType<readonly SingleMenuRequirement[]>,
   },
   data() {
     return {
@@ -117,67 +120,70 @@ export default Vue.extend({
         Summer: summer,
       },
       selected: false,
-      requirements: [],
-      potentialReqs: [],
+      requirements: [] as string[],
+      potentialReqs: [] as string[],
       binaryPotentialReqs: [],
       editMode: false,
       selectedCourse: '',
       selectedCourseID: -1,
       selectorSemesterId: '',
-      selectedReqs: [],
+      selectedReqs: [] as string[],
     };
   },
   computed: {
-    text() {
+    text(): string {
       return 'Search Course Roster';
     },
-    placeholder() {
+    placeholder(): string {
       return this.placeholderText !== 'Select one'
         ? this.placeholderText
-        : '"CS110", "Multivariable Calculus", etc';
+        : '"CS1110", "Multivariable Calculus", etc';
     },
-    potReqs() {
+    potReqs(): string {
       return this.potentialReqs.join(', ');
     },
-    relatedReqs() {
+    relatedReqs(): string {
       return this.requirements.join(', ');
     },
-    hasReqs() {
+    hasReqs(): boolean {
       return this.requirements.length !== 0;
     },
-    hasPotReqs() {
+    hasPotReqs(): boolean {
       return this.potentialReqs.length !== 0;
     },
-    editReqsText() {
+    editReqsText(): string {
       return this.potentialReqs.length !== 0 ? 'Add these Requirements' : 'Edit Requirements';
     },
   },
   mounted() {
     // Activate focus and set input to empty
-    const input = document.getElementById(`dropdown-${this.semesterID}`);
+    const input = document.getElementById(`dropdown-${this.semesterID}`) as HTMLInputElement;
     input.value = '';
     input.focus();
 
-    this.autocomplete(document.getElementById(`dropdown-${this.semesterID}`), coursesJSON);
+    this.autocomplete(
+      document.getElementById(`dropdown-${this.semesterID}`) as HTMLInputElement,
+      coursesJSON
+    );
   },
   methods: {
     closeCourseModal() {
       this.$emit('close-course-modal');
     },
-    autocomplete(inp, courses) {
+    autocomplete(inp: HTMLInputElement, courses: CourseJson) {
       /* the autocomplete function takes two arguments,
       @inp: input
       @courses: object of courses from JSON
       */
-      let currentFocus;
+      let currentFocus: number;
       const inpCopy = inp;
-      function removeActive(x) {
+      function removeActive(x: readonly HTMLDivElement[]) {
         /* a function to remove the "active" class from all autocomplete items: */
         for (let i = 0; i < x.length; i += 1) {
           x[i].classList.remove('autocomplete-active');
         }
       }
-      function addActive(x) {
+      function addActive(x?: readonly HTMLDivElement[]) {
         /* a function to classify an item as "active": */
         if (!x) return;
         /* start by removing the "active" class on all items: */
@@ -187,19 +193,18 @@ export default Vue.extend({
         /* add class "autocomplete-active": */
         x[currentFocus].classList.add('autocomplete-active');
       }
-      function closeAllLists(elmnt) {
+      function closeAllLists(elmnt?: HTMLElement) {
         /* close all autocomplete lists in the document,
         except the one passed as an argument: */
         const x = document.getElementsByClassName('autocomplete-items');
         for (let i = 0; i < x.length; i += 1) {
           if (elmnt !== x[i] && elmnt !== inp) {
-            x[i].parentNode.removeChild(x[i]);
+            x[i].parentNode!.removeChild(x[i]);
           }
         }
       }
       /* execute a function when someone writes in the text field: */
       inp.addEventListener('input', () => {
-        let a;
         const val = inp.value.toUpperCase();
         /* close any already open lists of autocompleted values */
         closeAllLists();
@@ -208,11 +213,11 @@ export default Vue.extend({
         /* create a DIV element that will contain the items (values): */
         // search after value length of 2 to reduce search times of courses
         if (val.length >= 2) {
-          a = document.createElement('DIV');
+          const a = document.createElement('DIV');
           a.setAttribute('id', `${inp.id}autocomplete-list`);
           a.setAttribute('class', 'autocomplete-items');
           /* append the DIV element as a child of the autocomplete container: */
-          inp.parentNode.appendChild(a);
+          inp.parentNode!.appendChild(a);
 
           /* code array for results that contain course code and title array for results that contain title */
           const code = [];
@@ -234,8 +239,8 @@ export default Vue.extend({
           }
 
           // Sort both results by title
-          code.sort((first, second) => first.title - second.title);
-          title.sort((first, second) => first.title - second.title);
+          code.sort((first, second) => first.title.localeCompare(second.title));
+          title.sort((first, second) => first.title.localeCompare(second.title));
 
           /* prioritize code matches over title matches */
           let match = code.concat(title);
@@ -277,37 +282,34 @@ export default Vue.extend({
       });
       /* execute a function presses a key on the keyboard: */
       inp.addEventListener('keydown', e => {
-        let x = document.getElementById(`${inp.id}autocomplete-list`);
-        if (x) x = x.getElementsByTagName('div');
+        const x = document.getElementById(`${inp.id}autocomplete-list`) as HTMLDivElement;
+        const xList: readonly HTMLDivElement[] = x ? [...x.getElementsByTagName('div')] : [];
         if (e.keyCode === 40) {
           /* If the arrow DOWN key is pressed,
             increase the currentFocus variable: */
           currentFocus += 1;
           /* and and make the current item more visible: */
-          addActive(x);
+          addActive(xList);
         } else if (e.keyCode === 38) {
           // up
           /* If the arrow UP key is pressed,
             decrease the currentFocus variable: */
           currentFocus -= 1;
           /* and and make the current item more visible: */
-          addActive(x);
+          addActive(xList);
         } else if (e.keyCode === 13) {
           /* If the ENTER key is pressed, prevent the form from being submitted, */
           e.preventDefault();
           if (currentFocus > -1) {
             /* and simulate a click on the "active" item: */
-            if (x) x[currentFocus].click();
+            if (xList) xList[currentFocus].click();
           }
         }
       });
       /* execute a function when someone clicks in the document: */
       document.addEventListener('click', e => {
-        closeAllLists(e.target);
+        closeAllLists(e.target as HTMLElement);
       });
-    },
-    checkIfLast(elem, list) {
-      return elem === list[list.length - 1];
     },
     toggleEditMode() {
       this.editMode = !this.editMode;
@@ -322,7 +324,7 @@ export default Vue.extend({
       this.requirements = [];
       this.potentialReqs = [];
     },
-    updateSemProps(season, year) {
+    updateSemProps(season: string, year: number) {
       this.$emit('updateSemProps', season, year);
     },
     getReqsRelatedToCourse() {
@@ -334,15 +336,14 @@ export default Vue.extend({
         const subreqs = this.reqs[i].ongoing;
         for (let j = 0; j < subreqs.length; j += 1) {
           // requirements
-          if (subreqs[j].fulfilledBy === 'courses') {
-            const { courses } = subreqs[j].requirement;
-            if (typeof courses !== 'undefined') {
-              for (let k = 0; k < courses.length; k += 1) {
-                for (const [, ids] of Object.entries(courses[k])) {
-                  if (ids.includes(this.selectedCourseID)) {
-                    relatedReqs.push(subreqs[j].requirement.name);
-                    break;
-                  }
+          const subRequirement = subreqs[j].requirement;
+          if (subRequirement.fulfilledBy === 'courses') {
+            const { courses } = subRequirement;
+            for (let k = 0; k < courses.length; k += 1) {
+              for (const [, ids] of Object.entries(courses[k])) {
+                if (ids.includes(this.selectedCourseID)) {
+                  relatedReqs.push(subreqs[j].requirement.name);
+                  break;
                 }
               }
             }
@@ -357,8 +358,7 @@ export default Vue.extend({
         }
       }
     },
-    editReq(data) {
-      const { name, isSelected } = data;
+    editReq({ name, isSelected }: Readonly<{ name: string; isSelected: boolean }>) {
       if (isSelected) {
         this.selectedReqs.push(name); // add to selectedReqs
       } else {
@@ -396,7 +396,7 @@ export default Vue.extend({
       } else {
         this.selected = false;
         // copied code from line 125 and 209 TODO - refactor
-        const inpCopy = document.getElementById(`dropdown-${this.semesterID}`);
+        const inpCopy = document.getElementById(`dropdown-${this.semesterID}`) as HTMLInputElement;
         inpCopy.value = '';
         this.$emit('toggle-left-button');
         this.$emit('allow-add', true);
@@ -406,9 +406,11 @@ export default Vue.extend({
       return this.selectedReqs;
     },
     addCourse() {
-      if (this.$refs[`dropdown-${this.semesterID}`].value) this.$emit('addItem', this.semesterID);
+      if ((this.$refs[`dropdown-${this.semesterID}`] as HTMLInputElement).value) {
+        this.$emit('addItem', this.semesterID);
+      }
     },
-    onboardingStyle(placeholderText, isOnboard) {
+    onboardingStyle(placeholderText: string, isOnboard: boolean) {
       if (!isOnboard) {
         return 'newCourse-dropdown';
       }

--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -31,9 +31,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
 import NewCourse from '@/components/Modals/NewCourse/NewCourse.vue';
-import { CornellCourseRosterCourse } from '@/user-data';
+import { AppSemester, CornellCourseRosterCourse } from '@/user-data';
+import { SingleMenuRequirement } from '@/requirements/types';
 
 Vue.component('newCourse', NewCourse);
 
@@ -52,10 +53,10 @@ export default Vue.extend({
   props: {
     type: String,
     semesterID: String,
-    currentSemesters: Array,
+    currentSemesters: Array as PropType<readonly AppSemester[]>,
     isOpen: Boolean,
     isCourseModelSelectingSemester: Boolean,
-    reqs: Array,
+    reqs: Array as PropType<readonly SingleMenuRequirement[]>,
   },
   methods: {
     disableButton(bool: boolean) {

--- a/src/requirements/courses-json-generator.ts
+++ b/src/requirements/courses-json-generator.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'fs';
 import filteredAllCourses from './filtered-all-courses';
 
-type CourseJson = {
+export type CourseJson = {
   [courseCode: string]: {
     i: number; // course id
     t: string; // title


### PR DESCRIPTION
### Summary <!-- Required -->

This PR converts `NewCourse.vue` to TypeScript. It doesn't attempt to make it any better. It just adds type and some type casts until things can type check. The goal is to give me some type information for this file, so that I can later more confidently get rid of all the DOM manipulations.

### Test Plan <!-- Required -->

This is mostly type-only changes. Now everything still type checks. You can still add courses.

<img width="503" alt="Screen Shot 2021-02-03 at 20 56 59" src="https://user-images.githubusercontent.com/4290500/106834044-aa9a5000-6662-11eb-87e6-0f9f28d2c50c.png">
