### PR TITLE
Cleanup NewCourse component by eliminating DOM manipulation

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -8,6 +8,7 @@ $white: #fff;
 $black: #000;
 
 $offWhite: #f8f8f8;
+$searchBoxWhite: #f1f1f1;
 $medGray: #737373;
 $darkGray: #3c3c3c;
 $darkGray2: #404040;
@@ -24,6 +25,8 @@ $primaryGray: #3d3d3d;
 $secondaryGray: #858585;
 $activeGray: #5b676d;
 $disabledGray: #cccccc;
+$searchBoxBorderGray: #d4d4d4;
+$searchBoxHoverGray: #e9e9e9;
 
 $lightPlaceholderGray: #757575;
 $darkPlaceholderGray: #b6b6b6;

--- a/src/components/Modals/DeleteSemester.vue
+++ b/src/components/Modals/DeleteSemester.vue
@@ -33,9 +33,6 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import NewCourse from '@/components/Modals/NewCourse/NewCourse.vue';
-
-Vue.component('newCourse', NewCourse);
 
 export default Vue.extend({
   props: {

--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -40,11 +40,9 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import NewCourse from '@/components/Modals/NewCourse/NewCourse.vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
 import { AppSemester } from '@/user-data';
 
-Vue.component('newCourse', NewCourse);
 Vue.component('newSemester', NewSemester);
 
 export default Vue.extend({

--- a/src/components/Modals/NewCourse/CourseSelector.vue
+++ b/src/components/Modals/NewCourse/CourseSelector.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="autocomplete">
+    <input
+      v-bind:class="['search-box', searchBoxClassName]"
+      ref="dropdownInput"
+      v-model="searchText"
+      :placeholder="placeholder"
+      @keyup.esc="onEscape"
+      @keyup.enter="onEnter"
+      @keyup.up="changeFocus(currentFocus - 1)"
+      @keyup.down="changeFocus(currentFocus + 1)"
+    />
+    <div v-if="matches.length > 0" class="autocomplete-items">
+      <div
+        v-for="(matchingCourse, index) in matches"
+        :key="matchingCourse.id"
+        v-bind:class="['search-result', currentFocus === index ? 'autocomplete-active' : '']"
+        @click="selectCourse(matchingCourse)"
+      >
+        {{ matchingCourse.title }}
+        <input type="hidden" :value="matchingCourse.title" :name="matchingCourse.roster" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import coursesJSON from '@/assets/courses/courses.json';
+
+import { CourseJson } from '@/requirements/courses-json-generator';
+
+export type MatchingCourseSearchResult = {
+  readonly title: string;
+  readonly roster: string;
+  readonly id: number;
+};
+
+const getMatchingCourses = (
+  searchText: string,
+  courses: CourseJson
+): readonly MatchingCourseSearchResult[] => {
+  // search after value length of 2 to reduce search times of courses
+  if (!searchText || searchText.length < 2) return [];
+  /* code array for results that contain course code and title array for results that contain title */
+  const code: MatchingCourseSearchResult[] = [];
+  const title: MatchingCourseSearchResult[] = [];
+
+  for (const attr in courses) {
+    if (courses[attr]) {
+      const result = {
+        title: `${attr}: ${courses[attr].t}`,
+        roster: courses[attr].r,
+        id: courses[attr].i,
+      };
+      if (attr.toUpperCase().includes(searchText) && attr !== 'lastScanned') {
+        code.push(result);
+      } else if (courses[attr].t && courses[attr].t.toUpperCase().includes(searchText)) {
+        title.push(result);
+      }
+    }
+  }
+
+  // Sort both results by title
+  code.sort((first, second) => first.title.localeCompare(second.title));
+  title.sort((first, second) => first.title.localeCompare(second.title));
+
+  /* prioritize code matches over title matches */
+  // limit the number of results to 10
+  return code.concat(title).slice(0, 10);
+};
+
+export default Vue.extend({
+  props: { searchBoxClassName: String, placeholder: String, autoFocus: Boolean },
+  data() {
+    return {
+      searchText: '',
+      currentFocus: -1,
+    };
+  },
+  computed: {
+    matches(): readonly MatchingCourseSearchResult[] {
+      return getMatchingCourses(this.searchText.toUpperCase(), coursesJSON);
+    },
+  },
+  mounted() {
+    // Activate focus and set input to empty
+    const input = this.dropdownInputRef();
+    if (this.autoFocus) input.focus();
+  },
+  methods: {
+    dropdownInputRef(): HTMLInputElement {
+      return this.$refs.dropdownInput as HTMLInputElement;
+    },
+    onEscape() {
+      this.$emit('on-escape');
+    },
+    changeFocus(newFocusIndex: number) {
+      const wraparoundLimit = this.matches.length;
+      this.currentFocus = ((newFocusIndex % wraparoundLimit) + wraparoundLimit) % wraparoundLimit;
+    },
+    selectCourse(result: MatchingCourseSearchResult) {
+      this.$emit('on-select', result);
+      this.searchText = result.title;
+      this.currentFocus = -1;
+    },
+    onEnter() {
+      const result = this.matches[this.currentFocus];
+      if (result != null) this.selectCourse(result);
+    },
+  },
+});
+</script>
+
+<style lang="scss">
+@import '@/assets/scss/_variables.scss';
+
+.search-box {
+  border: 1px solid transparent;
+  background-color: $searchBoxWhite;
+  padding: 10px;
+  font-size: 16px;
+}
+.autocomplete {
+  /*the container must be positioned relative:*/
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  margin-top: 0.5rem;
+  padding-bottom: 12px;
+}
+.autocomplete-items {
+  position: absolute;
+  border: 1px solid $searchBoxBorderGray;
+  border-bottom: none;
+  border-top: none;
+  z-index: 99;
+  /*position the autocomplete items to be the same width as the container:*/
+  top: 100%;
+  left: 0;
+  right: 0;
+  box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.25);
+  border-radius: 7px;
+
+  .search-result {
+    padding: 10px;
+    cursor: pointer;
+    background-color: $white;
+
+    &:hover {
+      background-color: $searchBoxHoverGray;
+    }
+  }
+}
+.autocomplete-active {
+  /*when navigating through the items using the arrow keys:*/
+  background-color: DodgerBlue !important;
+  color: $white;
+}
+</style>

--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -16,10 +16,11 @@
       :isCourseModelSelectingSemester="isCourseModelSelectingSemester"
       placeholderText='"CS 1110", "Multivariable Calculus", etc.'
       @duplicateSemester="disableButton"
-      @close-current-model="closeCourseModal"
+      @close-course-modal="closeCourseModal"
       @updateSemProps="updateSemProps"
       @toggle-left-button="toggleLeftButton"
       @allow-add="disableButton"
+      @on-course-select="selectCourse"
       @edit-mode="editMode"
       ref="modalBodyComponent"
       :season="season"
@@ -35,12 +36,14 @@ import Vue, { PropType } from 'vue';
 import NewCourse from '@/components/Modals/NewCourse/NewCourse.vue';
 import { AppSemester, CornellCourseRosterCourse } from '@/user-data';
 import { SingleMenuRequirement } from '@/requirements/types';
+import { MatchingCourseSearchResult } from './CourseSelector.vue';
 
 Vue.component('newCourse', NewCourse);
 
 export default Vue.extend({
   data() {
     return {
+      selectedCourse: null as MatchingCourseSearchResult | null,
       courseIsAddable: true,
       isDisabled: true,
       leftButtonText: 'CANCEL',
@@ -59,6 +62,9 @@ export default Vue.extend({
     reqs: Array as PropType<readonly SingleMenuRequirement[]>,
   },
   methods: {
+    selectCourse(result: MatchingCourseSearchResult) {
+      this.selectedCourse = result;
+    },
     disableButton(bool: boolean) {
       this.isDisabled = bool;
     },
@@ -85,10 +91,8 @@ export default Vue.extend({
       }
     },
     addCourse() {
-      const dropdown = document.getElementById(`dropdown-${this.semesterID}`) as HTMLInputElement;
-      const title = dropdown.value;
-      // name used to transmit roster information
-      const roster = dropdown.name;
+      if (this.selectedCourse == null) return;
+      const { roster, title } = this.selectedCourse;
 
       const courseCode = title.substring(0, title.indexOf(':'));
       const subject = courseCode.split(' ')[0];
@@ -110,8 +114,8 @@ export default Vue.extend({
           });
         });
 
-      // clear input and close modal when complete
-      dropdown.value = '';
+      // @ts-expect-error: TS cannot understand $ref's component.
+      this.$refs.modalBodyComponent.reset();
       this.closeCurrentModal();
     },
     toggleLeftButton() {

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -85,8 +85,6 @@ export default Vue.extend({
   data() {
     return {
       currentPage: 1,
-      majorDropdowns: [] as readonly DropdownSlot[],
-      minorDropdowns: [] as readonly DropdownSlot[],
       isError: false,
       user: this.userData,
     };
@@ -109,8 +107,12 @@ export default Vue.extend({
           },
           userData: {
             colleges: [{ acronym: this.user.college, fullName: this.user.collegeFN }],
-            majors: this.notPlaceholderOptions(this.majorDropdowns),
-            minors: this.notPlaceholderOptions(this.minorDropdowns),
+            majors: this.notPlaceholderOptions(
+              this.user.major.map((acronym, i) => ({ acronym, text: this.user.majorFN[i] }))
+            ),
+            minors: this.notPlaceholderOptions(
+              this.user.minor.map((acronym, i) => ({ acronym, text: this.user.minorFN[i] }))
+            ),
             exam: this.user.exam.filter(exam => exam.subject !== placeholderText),
             class: this.user.transferCourse.filter(
               oneClass => oneClass.class !== placeholderText && oneClass.class !== null
@@ -166,8 +168,6 @@ export default Vue.extend({
         userMinorsAcronym: minor,
         userMinorsFN: minorFN,
       } = this.basicOptionsToUser(newMajor, newMinor);
-      this.majorDropdowns = newMajor;
-      this.minorDropdowns = newMinor;
       this.user = {
         ...this.user,
         firstName,

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -350,7 +350,7 @@ export default Vue.extend({
     border-radius: 0px;
     background-color: $white;
     &::placeholder {
-      color: $black;
+      color: $lightPlaceholderGray;
     }
   }
   &-onboarding-empty {


### PR DESCRIPTION
## Summary

Depends on #258.

The NewCourse component is also a mess. It's used in two different places:

- NewCourseModal for supporting the main functionality.
- OnboardingTransfer for selecting equivalent classes.

I first cleaned up the DOM manipulation by replacing that with standard vue state based approach. It turns out it's much simpler to write code in this way.

After the above cleanup, it becomes clear that OnboardingTransfer component is only using the new course component for selecting a course. All the extra requirement functionality are not needed. Therefore, I replaced the use of `newCourse` component to be `course-selector`. This change also unbreaks the functionality of adding transfer classes.

Then we are able to clean up a lot of if-else just to make the new-course component work for onboarding transfer.

## Test Plan

- check that OnboardingTransfer works. Try to add a transfer class.
- check that NewCourseModal works. Try to add a class inside a semester.

<img width="472" alt="Screen Shot 2021-02-03 at 23 22 02" src="https://user-images.githubusercontent.com/4290500/106844504-b859d080-6676-11eb-901a-0131c94f54fd.png">
<img width="503" alt="Screen Shot 2021-02-03 at 23 22 13" src="https://user-images.githubusercontent.com/4290500/106844505-b859d080-6676-11eb-8a1d-57da1767c2a9.png">
<img width="657" alt="Screen Shot 2021-02-03 at 23 22 31" src="https://user-images.githubusercontent.com/4290500/106844506-b859d080-6676-11eb-9907-662a8df25a58.png">
