### PR TITLE
Factor out requirement graph builder code into its own file

### DIFF
--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -122,7 +122,7 @@ import {
   createAppUser,
   AppToggleableRequirementChoices,
 } from '@/user-data';
-import { computeRequirements } from '@/requirements/reqs-functions';
+import computeRequirements from '@/requirements/reqs-functions';
 import { CourseTaken, SingleMenuRequirement } from '@/requirements/types';
 import getCourseEquivalentsFromUserExams from '@/requirements/data/exams/ExamCredit';
 import getCurrentSeason, { checkNotNull, getCurrentYear, getSubjectColor } from '@/utilities';

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -1,5 +1,4 @@
-import buildRequirementFulfillmentGraph from './requirement-graph-builder';
-import requirementJson from './typed-requirement-json';
+import buildRequirementFulfillmentGraphFromUserData from './requirement-graph-builder-from-user-data';
 import {
   CourseTaken,
   EligibleCourses,
@@ -7,9 +6,6 @@ import {
   RequirementFulfillmentStatistics,
   GroupedRequirementFulfillmentReport,
 } from './types';
-
-export type RequirementMap = { readonly [code: string]: readonly string[] };
-type MutableRequirementMapWithMutableChildren = { [code: string]: string[] };
 
 function computeFulfillmentStatisticsFromCourses(
   coursesThatFulfilledRequirement: readonly (readonly CourseTaken[])[],
@@ -147,24 +143,6 @@ function computeFulfillmentCoursesAndStatistics(
 }
 
 /**
- * Removes all AP/IB equivalent course credit if it's a duplicate crseId.
- * In the future, we may need to implement a more fleshed-out system.
- * Eg. "A student taking CHEM 1560, CHEM 2070, or 2090 will forfeit AP [CHEM] credit."
- *
- * @param coursesTaken a list of classes taken by the user, with some metadata (e.g. no. of credits)
- * helping to compute requirement progress.
- */
-function forfeitTransferCredit(coursesTaken: readonly CourseTaken[]): readonly CourseTaken[] {
-  const equivalentCourses = coursesTaken.filter(course => course.subject !== 'CREDITS');
-  const equivalentCourseIds = new Set(equivalentCourses.map(({ courseId }) => courseId));
-  let transferCreditCourses = coursesTaken.filter(course => course.subject === 'CREDITS');
-  transferCreditCourses = transferCreditCourses.filter(
-    ({ courseId }) => !equivalentCourseIds.has(courseId)
-  );
-  return equivalentCourses.concat(transferCreditCourses);
-}
-
-/**
  * @param coursesTaken a list of classes taken by the user, with some metadata (e.g. no. of credits)
  * helping to compute requirement progress.
  * @param toggleableRequirementChoices an object map from toggleable requirement IDs to choices
@@ -173,167 +151,20 @@ function forfeitTransferCredit(coursesTaken: readonly CourseTaken[]): readonly C
  * @param minors user's list of minors.
  * @returns all requirements fulfillments, grouped by University, College, Major.
  */
-export function computeRequirements(
+export default function computeRequirements(
   coursesTaken: readonly CourseTaken[],
   toggleableRequirementChoices: Readonly<Record<string, string>>,
   college: string,
   majors: readonly string[] | null,
   minors: readonly string[] | null
 ): readonly GroupedRequirementFulfillmentReport[] {
-  // prepare grouped fulfillment summary
-  const groups: GroupedRequirementFulfillmentReport[] = [];
-
-  // check university & college & major & minor requirements
-  if (!(college in requirementJson.college)) throw new Error('College not found.');
-
-  const universityReqs = requirementJson.university.UNI;
-  const collegeReqs = requirementJson.college[college];
-
-  const requirementsToBeConsideredInGraph: readonly RequirementWithIDSourceType[] = [
-    ...universityReqs.requirements.map(
-      it =>
-        ({
-          ...it,
-          id: `College-UNI-${it.name}`,
-          sourceType: 'College',
-          sourceSpecificName: college,
-        } as const)
-    ),
-    ...collegeReqs.requirements.map(
-      it =>
-        ({
-          ...it,
-          id: `College-${college}-${it.name}`,
-          sourceType: 'College',
-          sourceSpecificName: college,
-        } as const)
-    ),
-    ...(majors || [])
-      .map(major => {
-        const majorRequirement = requirementJson.major[major];
-        if (majorRequirement == null) return [];
-        return majorRequirement.requirements.map(
-          it =>
-            ({
-              ...it,
-              id: `Major-${major}-${it.name}`,
-              sourceType: 'Major',
-              sourceSpecificName: major,
-            } as const)
-        );
-      })
-      .flat(),
-    ...(minors || [])
-      .map(minor => {
-        const minorRequirement = requirementJson.minor[minor];
-        if (minorRequirement == null) return [];
-        return minorRequirement.requirements.map(
-          it =>
-            ({
-              ...it,
-              id: `Minor-${minor}-${it.name}`,
-              sourceType: 'Minor',
-              sourceSpecificName: minor,
-            } as const)
-        );
-      })
-      .flat(),
-  ];
-  type UserChoiceOnFulfillmentStrategy = {
-    readonly correspondingRequirement: RequirementWithIDSourceType;
-    readonly coursesOfChosenFulfillmentStrategy: readonly CourseTaken[];
-  };
-  const userChoiceOnFulfillmentStrategy = requirementsToBeConsideredInGraph
-    .map((requirement): UserChoiceOnFulfillmentStrategy | null => {
-      if (requirement.fulfilledBy !== 'toggleable') {
-        return null;
-      }
-      const optionName =
-        toggleableRequirementChoices[requirement.id] ||
-        Object.keys(requirement.fulfillmentOptions)[0];
-
-      const courses: CourseTaken[] = [];
-      requirement.fulfillmentOptions[optionName].courses.forEach(eligibleCourses => {
-        Object.entries(eligibleCourses).forEach(([roster, courseIds]) => {
-          courseIds.forEach(courseId =>
-            courses.push({
-              roster,
-              courseId,
-              // Only roster and courseId are used for equality comparison,
-              // so other dummy values doesn't matter.
-              code: 'DUMMY',
-              subject: 'DUMMY',
-              number: 'DUMMY',
-              credits: 0,
-            })
-          );
-        });
-      });
-      return { correspondingRequirement: requirement, coursesOfChosenFulfillmentStrategy: courses };
-    })
-    .filter((it): it is UserChoiceOnFulfillmentStrategy => it != null);
-
-  const { requirementFulfillmentGraph } = buildRequirementFulfillmentGraph<
-    RequirementWithIDSourceType,
-    CourseTaken,
-    UserChoiceOnFulfillmentStrategy
-  >({
-    requirements: requirementsToBeConsideredInGraph,
-    userCourses: forfeitTransferCredit(coursesTaken),
-    userChoiceOnFulfillmentStrategy,
-    userChoiceOnDoubleCountingElimiation: [],
-    getRequirementUniqueID: requirement => requirement.id,
-    getCourseUniqueID: course => `${course.roster} ${course.courseId}`,
-    getAllCoursesThatCanPotentiallySatisfyRequirement: requirement => {
-      let eligibleCoursesList: readonly EligibleCourses[];
-      switch (requirement.fulfilledBy) {
-        case 'self-check':
-          return [];
-        case 'courses':
-        case 'credits':
-          eligibleCoursesList = requirement.courses;
-          break;
-        case 'toggleable':
-          eligibleCoursesList = Object.values(requirement.fulfillmentOptions)
-            .map(it => it.courses)
-            .flat();
-          break;
-        default:
-          throw new Error();
-      }
-      return eligibleCoursesList
-        .map((eligibleCourses): readonly CourseTaken[] => {
-          const courses: CourseTaken[] = [];
-          Object.entries(eligibleCourses).forEach(([roster, courseIds]) => {
-            courseIds.forEach(courseId =>
-              courses.push({
-                roster,
-                courseId,
-                // Only roster and courseId are used for equality comparison,
-                // so other dummy values doesn't matter.
-                code: 'DUMMY',
-                subject: 'DUMMY',
-                number: 'DUMMY',
-                credits: 0,
-              })
-            );
-          });
-          return courses;
-        })
-        .flat();
-    },
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy: it => it,
-    allowDoubleCounting: requirement => {
-      // All minor requirements are automatically double-countable.
-      if (requirement.sourceType === 'Minor') return true;
-      if (requirement.sourceType === 'Major') {
-        if (majors == null) throw new Error("shouldn't get here since we have major requirements!");
-        // If it's not the first major, then it's double countable.
-        if (requirement.sourceSpecificName !== majors[0]) return true;
-      }
-      return requirement.allowCourseDoubleCounting || false;
-    },
-  });
+  const { requirementFulfillmentGraph } = buildRequirementFulfillmentGraphFromUserData(
+    coursesTaken,
+    toggleableRequirementChoices,
+    college,
+    majors,
+    minors
+  );
 
   type FulfillmentStatistics = {
     readonly id: string;
@@ -382,42 +213,15 @@ export function computeRequirements(
     }
   });
 
-  groups.push({
-    groupName: 'College',
-    specific: college,
-    reqs: collegeFulfillmentStatistics,
-  });
-
-  majorFulfillmentStatisticsMap.forEach((fulfillmentStatistics, majorName) => {
-    groups.push({ groupName: 'Major', specific: majorName, reqs: fulfillmentStatistics });
-  });
-  minorFulfillmentStatisticsMap.forEach((fulfillmentStatistics, minorName) => {
-    groups.push({ groupName: 'Minor', specific: minorName, reqs: fulfillmentStatistics });
-  });
-
-  return groups;
-}
-
-/**
- * @param groups all requirements fulfillments, grouped by University, College, Major.
- * @returns a object where keys are course code and values are a list of requirement a class fulfills.
- */
-export function computeRequirementMap(
-  groups: readonly GroupedRequirementFulfillmentReport[]
-): RequirementMap {
-  const requirementsMap: MutableRequirementMapWithMutableChildren = {};
-  groups.forEach(group => {
-    group.reqs.forEach(
-      ({ requirement: { name: requirementName }, courses: coursesThatFulfilledRequirement }) => {
-        coursesThatFulfilledRequirement.forEach(coursesThatFulfilledSubRequirement => {
-          coursesThatFulfilledSubRequirement.forEach(({ code }) => {
-            // Add course to dictionary with name
-            if (code in requirementsMap) requirementsMap[code].push(requirementName);
-            else requirementsMap[code] = [requirementName];
-          });
-        });
-      }
-    );
-  });
-  return requirementsMap;
+  return [
+    { groupName: 'College', specific: college, reqs: collegeFulfillmentStatistics },
+    ...Array.from(majorFulfillmentStatisticsMap.entries()).map(
+      ([majorName, fulfillmentStatistics]) =>
+        ({ groupName: 'Major', specific: majorName, reqs: fulfillmentStatistics } as const)
+    ),
+    ...Array.from(minorFulfillmentStatisticsMap.entries()).map(
+      ([minorName, fulfillmentStatistics]) =>
+        ({ groupName: 'Minor', specific: minorName, reqs: fulfillmentStatistics } as const)
+    ),
+  ];
 }

--- a/src/requirements/requirement-graph-builder-from-user-data.ts
+++ b/src/requirements/requirement-graph-builder-from-user-data.ts
@@ -1,0 +1,194 @@
+import RequirementFulfillmentGraph from './requirement-graph';
+import buildRequirementFulfillmentGraph from './requirement-graph-builder';
+import requirementJson from './typed-requirement-json';
+import { CourseTaken, DecoratedCollegeOrMajorRequirement, EligibleCourses } from './types';
+
+export type RequirementWithIDSourceType = DecoratedCollegeOrMajorRequirement & {
+  readonly id: string;
+  readonly sourceType: 'College' | 'Major' | 'Minor';
+  readonly sourceSpecificName: string;
+};
+
+/**
+ * Removes all AP/IB equivalent course credit if it's a duplicate crseId.
+ * In the future, we may need to implement a more fleshed-out system.
+ * Eg. "A student taking CHEM 1560, CHEM 2070, or 2090 will forfeit AP [CHEM] credit."
+ *
+ * @param coursesTaken a list of classes taken by the user, with some metadata (e.g. no. of credits)
+ * helping to compute requirement progress.
+ */
+function forfeitTransferCredit(coursesTaken: readonly CourseTaken[]): readonly CourseTaken[] {
+  const equivalentCourses = coursesTaken.filter(course => course.subject !== 'CREDITS');
+  const equivalentCourseIds = new Set(equivalentCourses.map(({ courseId }) => courseId));
+  let transferCreditCourses = coursesTaken.filter(course => course.subject === 'CREDITS');
+  transferCreditCourses = transferCreditCourses.filter(
+    ({ courseId }) => !equivalentCourseIds.has(courseId)
+  );
+  return equivalentCourses.concat(transferCreditCourses);
+}
+
+export default function buildRequirementFulfillmentGraphFromUserData(
+  coursesTaken: readonly CourseTaken[],
+  toggleableRequirementChoices: Readonly<Record<string, string>>,
+  college: string,
+  majors: readonly string[] | null,
+  minors: readonly string[] | null
+): {
+  readonly requirementFulfillmentGraph: RequirementFulfillmentGraph<
+    RequirementWithIDSourceType,
+    CourseTaken
+  >;
+  readonly illegallyDoubleCountedCourses: readonly CourseTaken[];
+} {
+  // check university & college & major & minor requirements
+  if (!(college in requirementJson.college)) throw new Error('College not found.');
+
+  const universityReqs = requirementJson.university.UNI;
+  const collegeReqs = requirementJson.college[college];
+
+  const requirementsToBeConsideredInGraph: readonly RequirementWithIDSourceType[] = [
+    ...universityReqs.requirements.map(
+      it =>
+        ({
+          ...it,
+          id: `College-UNI-${it.name}`,
+          sourceType: 'College',
+          sourceSpecificName: college,
+        } as const)
+    ),
+    ...collegeReqs.requirements.map(
+      it =>
+        ({
+          ...it,
+          id: `College-${college}-${it.name}`,
+          sourceType: 'College',
+          sourceSpecificName: college,
+        } as const)
+    ),
+    ...(majors || [])
+      .map(major => {
+        const majorRequirement = requirementJson.major[major];
+        if (majorRequirement == null) return [];
+        return majorRequirement.requirements.map(
+          it =>
+            ({
+              ...it,
+              id: `Major-${major}-${it.name}`,
+              sourceType: 'Major',
+              sourceSpecificName: major,
+            } as const)
+        );
+      })
+      .flat(),
+    ...(minors || [])
+      .map(minor => {
+        const minorRequirement = requirementJson.minor[minor];
+        if (minorRequirement == null) return [];
+        return minorRequirement.requirements.map(
+          it =>
+            ({
+              ...it,
+              id: `Minor-${minor}-${it.name}`,
+              sourceType: 'Minor',
+              sourceSpecificName: minor,
+            } as const)
+        );
+      })
+      .flat(),
+  ];
+  type UserChoiceOnFulfillmentStrategy = {
+    readonly correspondingRequirement: RequirementWithIDSourceType;
+    readonly coursesOfChosenFulfillmentStrategy: readonly CourseTaken[];
+  };
+  const userChoiceOnFulfillmentStrategy = requirementsToBeConsideredInGraph
+    .map((requirement): UserChoiceOnFulfillmentStrategy | null => {
+      if (requirement.fulfilledBy !== 'toggleable') {
+        return null;
+      }
+      const optionName =
+        toggleableRequirementChoices[requirement.id] ||
+        Object.keys(requirement.fulfillmentOptions)[0];
+
+      const courses: CourseTaken[] = [];
+      requirement.fulfillmentOptions[optionName].courses.forEach(eligibleCourses => {
+        Object.entries(eligibleCourses).forEach(([roster, courseIds]) => {
+          courseIds.forEach(courseId =>
+            courses.push({
+              roster,
+              courseId,
+              // Only roster and courseId are used for equality comparison,
+              // so other dummy values doesn't matter.
+              code: 'DUMMY',
+              subject: 'DUMMY',
+              number: 'DUMMY',
+              credits: 0,
+            })
+          );
+        });
+      });
+      return { correspondingRequirement: requirement, coursesOfChosenFulfillmentStrategy: courses };
+    })
+    .filter((it): it is UserChoiceOnFulfillmentStrategy => it != null);
+
+  return buildRequirementFulfillmentGraph<
+    RequirementWithIDSourceType,
+    CourseTaken,
+    UserChoiceOnFulfillmentStrategy
+  >({
+    requirements: requirementsToBeConsideredInGraph,
+    userCourses: forfeitTransferCredit(coursesTaken),
+    userChoiceOnFulfillmentStrategy,
+    userChoiceOnDoubleCountingElimiation: [],
+    getRequirementUniqueID: requirement => requirement.id,
+    getCourseUniqueID: course => `${course.roster} ${course.courseId}`,
+    getAllCoursesThatCanPotentiallySatisfyRequirement: requirement => {
+      let eligibleCoursesList: readonly EligibleCourses[];
+      switch (requirement.fulfilledBy) {
+        case 'self-check':
+          return [];
+        case 'courses':
+        case 'credits':
+          eligibleCoursesList = requirement.courses;
+          break;
+        case 'toggleable':
+          eligibleCoursesList = Object.values(requirement.fulfillmentOptions)
+            .map(it => it.courses)
+            .flat();
+          break;
+        default:
+          throw new Error();
+      }
+      return eligibleCoursesList
+        .map((eligibleCourses): readonly CourseTaken[] => {
+          const courses: CourseTaken[] = [];
+          Object.entries(eligibleCourses).forEach(([roster, courseIds]) => {
+            courseIds.forEach(courseId =>
+              courses.push({
+                roster,
+                courseId,
+                // Only roster and courseId are used for equality comparison,
+                // so other dummy values doesn't matter.
+                code: 'DUMMY',
+                subject: 'DUMMY',
+                number: 'DUMMY',
+                credits: 0,
+              })
+            );
+          });
+          return courses;
+        })
+        .flat();
+    },
+    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy: it => it,
+    allowDoubleCounting: requirement => {
+      // All minor requirements are automatically double-countable.
+      if (requirement.sourceType === 'Minor') return true;
+      if (requirement.sourceType === 'Major') {
+        if (majors == null) throw new Error("shouldn't get here since we have major requirements!");
+        // If it's not the first major, then it's double countable.
+        if (requirement.sourceSpecificName !== majors[0]) return true;
+      }
+      return requirement.allowCourseDoubleCounting || false;
+    },
+  });
+}


### PR DESCRIPTION
### Summary <!-- Required -->

We will need the requirement graph not just as a helper structure to compute progress but also as a store for some other purposes. For example, to accurately decide the requirement choices for `NewCourseModal`, we need to inspect the graph. Therefore, the code that computes the graph must be extracted out so that we can build the graph independently of the progress report.

This PR factors out the relevant code into `requirement-graph-builder-from-user-data.ts`. In the process, I found that `computeRequirementMap` is no longer used, so I deleted it.

### Test Plan <!-- Required -->

Should have no change on requirement progress. Check the requirement progress to verify nothing changed.