### PR TITLE
Fix two easy @ts-expect-error

### DIFF
--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -32,7 +32,7 @@
             <div
               v-bind:class="{ warning: isDuplicate }"
               v-for="season in seasons"
-              :key="seasonValue(season)"
+              :key="season[1]"
               class="newSemester-dropdown-content-item"
               @click="selectSeason(season[1])"
             >
@@ -93,14 +93,6 @@ import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
 import { inactiveGray, yuxuanBlue, darkPlaceholderGray } from '@/assets/scss/_variables.scss';
 import { FirestoreSemesterType, AppSemester } from '@/user-data';
-
-// enum to define seasons as integers in season order
-const SeasonsEnum = Object.freeze({
-  winter: 0,
-  spring: 1,
-  summer: 2,
-  fall: 3,
-});
 
 type DisplayOption = {
   shown: boolean;
@@ -187,10 +179,6 @@ export default Vue.extend({
     this.$emit('updateSemProps', this.seasonPlaceholder, this.yearPlaceholder);
   },
   methods: {
-    seasonValue(season: readonly [string, string]): number {
-      // @ts-expect-error: TS cannot understand lowercasing the string produces the right field name.
-      return SeasonsEnum[season[1].toLowerCase()];
-    },
     getCurrentSeason(): FirestoreSemesterType {
       let currentSeason: FirestoreSemesterType;
       const currentMonth = new Date().getMonth();

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -123,10 +123,10 @@ Vue.component('editsemester', EditSemester);
 
 // enum to define seasons as integers in season order
 const SeasonsEnum = Object.freeze({
-  winter: 0,
-  spring: 1,
-  summer: 2,
-  fall: 3,
+  Winter: 0,
+  Spring: 1,
+  Summer: 2,
+  Fall: 3,
 });
 
 export default Vue.extend({
@@ -297,8 +297,7 @@ export default Vue.extend({
       if (a.year < b.year) {
         return 1;
       }
-      // @ts-expect-error: typescript cannot understand Fall -> fall conversion by .toLowerCase()
-      if (SeasonsEnum[a.type.toLowerCase()] < SeasonsEnum[b.type.toLowerCase()]) {
+      if (SeasonsEnum[a.type] < SeasonsEnum[b.type]) {
         return 1;
       }
       return -1;


### PR DESCRIPTION
### Summary <!-- Required -->

- NewSemester.vue: we can use string as key, so no need to convert to number.
- Semester.vue: we can just make the object field upper case, so we don't need to do the lower case conversion which TS doesn't understand.

### Test Plan <!-- Required -->

- Check the console to see no key collision warning in NewSemester modal.
- Check semesters are still correctly ordered.