### PR TITLE
Split AppUser into FirestoreUsername and AppOnboardingData

### DIFF
--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -78,7 +78,7 @@
 import Vue, { PropType } from 'vue';
 import reqsData from '@/requirements/typed-requirement-json';
 import { clickOutside } from '@/utilities';
-import { AppUser } from '@/user-data';
+import { AppOnboardingData, FirestoreUserName } from '@/user-data';
 import OnboardingBasicMultiDropdown from './OnboardingBasicMultiDropdown.vue';
 import OnboardingBasicSingleDropdown from './OnboardingBasicSingleDropdown.vue';
 
@@ -87,19 +87,20 @@ const placeholderText = 'Select one';
 export default Vue.extend({
   components: { OnboardingBasicMultiDropdown, OnboardingBasicSingleDropdown },
   props: {
-    user: Object as PropType<AppUser>,
+    userName: { type: Object as PropType<FirestoreUserName>, required: true },
+    onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
   },
   data() {
-    const majorAcronyms = [...this.user.major];
-    const minorAcronyms = [...this.user.minor];
+    const majorAcronyms = [...this.onboardingData.major];
+    const minorAcronyms = [...this.onboardingData.minor];
     if (majorAcronyms.length === 0) majorAcronyms.push('');
     if (minorAcronyms.length === 0) minorAcronyms.push('');
     return {
-      firstName: this.user.firstName,
-      middleName: this.user.middleName,
-      lastName: this.user.lastName,
+      firstName: this.userName.firstName,
+      middleName: this.userName.middleName,
+      lastName: this.userName.lastName,
       placeholderText,
-      collegeAcronym: this.user.college,
+      collegeAcronym: this.onboardingData.college,
       majorAcronyms,
       minorAcronyms,
     };

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -17,19 +17,19 @@
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
             <label class="onboarding-label"><span> First Name </span></label>
             <label class="onboarding-label--review"
-              ><span> {{ user.firstName }}</span></label
+              ><span> {{ userName.firstName }}</span></label
             >
           </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
             <label class="onboarding-label"><span> Middle Name </span></label>
             <label class="onboarding-label--review"
-              ><span> {{ user.middleName }}</span></label
+              ><span> {{ userName.middleName }}</span></label
             >
           </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
             <label class="onboarding-label"><span> Last Name </span></label>
             <label class="onboarding-label--review"
-              ><span> {{ user.lastName }}</span></label
+              ><span> {{ userName.lastName }}</span></label
             >
           </div>
         </div>
@@ -45,7 +45,7 @@
           </div>
           <div class="onboarding-selectWrapper-review">
             <label class="onboarding-label">Major</label>
-            <div v-for="(major, index) in user.major" :key="index">
+            <div v-for="(major, index) in onboardingData.major" :key="index">
               <label class="onboarding-label--review">{{ getMajorFullName(major) }}</label>
             </div>
           </div>
@@ -55,7 +55,7 @@
         </div>
         <div class="onboarding-selectWrapper">
           <label class="onboarding-label">Minors:</label>
-          <div v-for="(minor, index) in user.minor" :key="index">
+          <div v-for="(minor, index) in onboardingData.minor" :key="index">
             <label class="onboarding-label--review">{{ getMinorFullName(minor) }}</label>
           </div>
         </div>
@@ -79,7 +79,7 @@
           <div class="onboarding-selectWrapper-review">
             <label class="onboarding-label">
               <img class="checkmark" src="@/assets/images/checkmark-onboarding.svg" />
-              {{ this.user.tookSwim === 'yes' ? 'Yes' : 'No' }}
+              {{ this.onboardingData.tookSwim === 'yes' ? 'Yes' : 'No' }}
             </label>
           </div>
         </div>
@@ -90,13 +90,13 @@
           <div class="onboarding-selectWrapper-reviewExam">
             <div class="alignLeft">
               <label class="onboarding-label">AP Credits</label>
-              <div v-for="(exam, index) in user.exam" :key="'AP' + index">
+              <div v-for="(exam, index) in onboardingData.exam" :key="'AP' + index">
                 <label v-if="exam.type == 'AP'" class="onboarding-label--review">{{
                   exam.subject
                 }}</label>
               </div>
               <label class="onboarding-label addSpaceTop">IB Credits</label>
-              <div v-for="(exam, index) in user.exam" :key="'IB' + index">
+              <div v-for="(exam, index) in onboardingData.exam" :key="'IB' + index">
                 <label v-if="exam.type == 'IB'" class="onboarding-label--review">{{
                   exam.subject
                 }}</label>
@@ -104,13 +104,13 @@
             </div>
             <div class="alignCenter">
               <label class="onboarding-label">Score</label>
-              <div v-for="(exam, index) in user.exam" :key="'APScore' + index">
+              <div v-for="(exam, index) in onboardingData.exam" :key="'APScore' + index">
                 <label v-if="exam.type == 'AP'" class="onboarding-label--review">{{
                   exam.score
                 }}</label>
               </div>
               <label class="onboarding-label addSpaceTop">Score</label>
-              <div v-for="(exam, index) in user.exam" :key="'IBScore' + index">
+              <div v-for="(exam, index) in onboardingData.exam" :key="'IBScore' + index">
                 <label v-if="exam.type == 'IB'" class="onboarding-label--review">{{
                   exam.score
                 }}</label>
@@ -118,13 +118,13 @@
             </div>
             <div class="alignCenter">
               <label class="onboarding-label">Credit</label>
-              <div v-for="(exam, index) in user.exam" :key="'APCredit' + index">
+              <div v-for="(exam, index) in onboardingData.exam" :key="'APCredit' + index">
                 <label v-if="exam.type == 'AP'" class="onboarding-label--review">{{
                   getExamCredit(exam)
                 }}</label>
               </div>
               <label class="onboarding-label addSpaceTop">Credit</label>
-              <div v-for="(exam, index) in user.exam" :key="'IBCredit' + index">
+              <div v-for="(exam, index) in onboardingData.exam" :key="'IBCredit' + index">
                 <label v-if="exam.type == 'IB'" class="onboarding-label--review">{{
                   getExamCredit(exam)
                 }}</label>
@@ -138,12 +138,12 @@
         <div class="onboarding-selectWrapper">
           <div class="onboarding-selectWrapper-reviewExam">
             <div>
-              <div v-for="(course, index) in user.transferCourse" :key="index">
+              <div v-for="(course, index) in onboardingData.transferCourse" :key="index">
                 <label class="onboarding-label--review">{{ course.class }}</label>
               </div>
             </div>
             <div class="alignEnd">
-              <div v-for="(course, index) in user.transferCourse" :key="index">
+              <div v-for="(course, index) in onboardingData.transferCourse" :key="index">
                 <label class="onboarding-label--review"> {{ course.credits }} Credits </label>
               </div>
             </div>
@@ -164,23 +164,28 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { getExamCredit } from '@/components/Modals/Onboarding/OnboardingTransfer.vue';
-import { AppUser } from '@/user-data';
+import { AppOnboardingData, FirestoreUserName } from '@/user-data';
 import { getCollegeFullName, getMajorFullName, getMinorFullName } from '@/utilities';
 
 const placeholderText = 'Select one';
 
 export default Vue.extend({
-  props: { user: Object as PropType<AppUser> },
+  props: {
+    userName: { type: Object as PropType<FirestoreUserName>, required: true },
+    onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
+  },
   computed: {
     collegeText(): string {
-      return this.user.college !== '' ? getCollegeFullName(this.user.college) : placeholderText;
+      return this.onboardingData.college !== ''
+        ? getCollegeFullName(this.onboardingData.college)
+        : placeholderText;
     },
     totalCredits(): number {
       let count = 0;
-      this.user.exam.forEach(exam => {
+      this.onboardingData.exam.forEach(exam => {
         count += getExamCredit(exam);
       });
-      this.user.transferCourse.forEach(clas => {
+      this.onboardingData.transferCourse.forEach(clas => {
         count += clas.credits;
       });
       return count;

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -166,7 +166,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { examData as reqsData } from '@/requirements/data/exams/ExamCredit';
-import { AppUser, FirestoreAPIBExam, CornellCourseRosterCourse } from '@/user-data';
+import { FirestoreAPIBExam, CornellCourseRosterCourse, AppOnboardingData } from '@/user-data';
 import OnboardingTransferSwimming from './OnboardingTransferSwimming.vue';
 import OnboardingTransferExamPropertyDropdown from './OnboardingTransferExamPropertyDropdown.vue';
 import CourseSelector, { MatchingCourseSearchResult } from '../NewCourse/CourseSelector.vue';
@@ -210,23 +210,24 @@ export default Vue.extend({
     OnboardingTransferExamPropertyDropdown,
   },
   props: {
-    user: Object as PropType<AppUser>,
+    onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
   },
   data(): Data {
     const examsAP: FirestoreAPIBExam[] = [];
     const examsIB: FirestoreAPIBExam[] = [];
-    this.user.exam.forEach(exam => {
+    this.onboardingData.exam.forEach(exam => {
       (exam.type === 'AP' ? examsAP : examsIB).push(exam);
     });
     examsAP.push({ type: 'AP', subject: placeholderText, score: 0 });
     examsIB.push({ type: 'IB', subject: placeholderText, score: 0 });
     const transferClasses: TransferClassWithOptionalCourse[] = [];
-    this.user.transferCourse.forEach(course => {
+    this.onboardingData.transferCourse.forEach(course => {
       transferClasses.push(course);
     });
     transferClasses.push({ class: placeholderText, credits: 0 });
     return {
-      tookSwimTest: typeof this.user.tookSwim !== 'undefined' ? this.user.tookSwim : 'no',
+      tookSwimTest:
+        typeof this.onboardingData.tookSwim !== 'undefined' ? this.onboardingData.tookSwim : 'no',
       scoresAP,
       scoresIB,
       subjectsAP,

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -2,7 +2,7 @@
   <div class="requirementheader">
     <!-- TODO change for multiple colleges -->
     <div
-      v-if="reqIndex <= numOfColleges || reqIndex == numOfColleges + user.major.length"
+      v-if="reqIndex <= numOfColleges || reqIndex == numOfColleges + onboardingData.major.length"
       class="row top"
     >
       <p class="name col p-0">{{ req.name }}</p>
@@ -16,7 +16,7 @@
         }"
         @click="activateMajor(id)"
         class="major-title"
-        v-for="(major, id) in user.major"
+        v-for="(major, id) in onboardingData.major"
         :key="id"
         :class="{ pointer: multipleMajors }"
       >
@@ -33,11 +33,11 @@
           :style="{ color: id === displayedMajorIndex ? `#${reqGroupColorMap[req.group][0]}` : '' }"
           class="major-title-bottom"
         >
-          ({{ getCollegeFullName(user.college) }})
+          ({{ getCollegeFullName(onboardingData.college) }})
         </p>
       </div>
     </div>
-    <div v-if="reqIndex == numOfColleges + user.major.length" class="minor">
+    <div v-if="reqIndex == numOfColleges + onboardingData.major.length" class="minor">
       <div
         :style="{
           'border-bottom':
@@ -45,7 +45,7 @@
         }"
         @click="activateMinor(id)"
         class="major-title"
-        v-for="(minor, id) in user.minor"
+        v-for="(minor, id) in onboardingData.minor"
         :key="id"
         :class="{ pointer: multipleMinors }"
       >
@@ -117,7 +117,7 @@
 import Vue, { PropType } from 'vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 import { SingleMenuRequirement } from '@/requirements/types';
-import { AppUser } from '@/user-data';
+import { AppOnboardingData } from '@/user-data';
 import { getCollegeFullName, getMajorFullName, getMinorFullName } from '@/utilities';
 
 Vue.component('dropdownarrow', DropDownArrow);
@@ -130,16 +130,16 @@ export default Vue.extend({
     displayedMinorIndex: Number,
     req: Object as PropType<SingleMenuRequirement>,
     reqGroupColorMap: Object as PropType<Readonly<Record<string, string[]>>>,
-    user: Object as PropType<AppUser>,
+    onboardingData: Object as PropType<AppOnboardingData>,
     showMajorOrMinorRequirements: Boolean,
     numOfColleges: Number,
   },
   computed: {
     multipleMajors() {
-      return this.user.major.length > 1;
+      return this.onboardingData.major.length > 1;
     },
     multipleMinors() {
-      return this.user.minor.length > 1;
+      return this.onboardingData.minor.length > 1;
     },
     progressWidth() {
       if (this.req.fulfilled != null && this.req.required != null) {

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -7,7 +7,7 @@
       :displayedMinorIndex="displayedMinorIndex"
       :req="req"
       :reqGroupColorMap="reqGroupColorMap"
-      :user="user"
+      :onboardingData="onboardingData"
       :showMajorOrMinorRequirements="showMajorOrMinorRequirements"
       :numOfColleges="numOfColleges"
       @activateMajor="activateMajor"
@@ -85,7 +85,7 @@ import RequirementHeader from '@/components/Requirements/RequirementHeader.vue';
 import SubRequirement from '@/components/Requirements/SubRequirement.vue';
 
 import { SingleMenuRequirement } from '@/requirements/types';
-import { AppUser, AppCourse, AppSemester } from '@/user-data';
+import { AppCourse, AppOnboardingData, AppSemester } from '@/user-data';
 
 Vue.component('requirementheader', RequirementHeader);
 Vue.component('subrequirement', SubRequirement);
@@ -105,7 +105,7 @@ export default Vue.extend({
     toggleableRequirementChoices: Object as PropType<Readonly<Record<string, string>>>,
     displayedMajorIndex: Number,
     displayedMinorIndex: Number,
-    user: Object as PropType<AppUser>,
+    onboardingData: Object as PropType<AppOnboardingData>,
     showMajorOrMinorRequirements: Boolean,
     numOfColleges: Number,
     rostersFromLastTwoYears: Array as PropType<readonly string[]>,

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -18,7 +18,7 @@
           :toggleableRequirementChoices="toggleableRequirementChoices"
           :displayedMajorIndex="displayedMajorIndex"
           :displayedMinorIndex="displayedMinorIndex"
-          :user="user"
+          :onboardingData="onboardingData"
           :showMajorOrMinorRequirements="showMajorOrMinorRequirements(index, req.group)"
           :rostersFromLastTwoYears="rostersFromLastTwoYears"
           :numOfColleges="numOfColleges"
@@ -72,11 +72,11 @@ import RequirementView from '@/components/Requirements/RequirementView.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 import { SingleMenuRequirement, SubReqCourseSlot, CrseInfo } from '@/requirements/types';
 import {
-  AppUser,
   AppSemester,
   AppCourse,
   CornellCourseRosterCourse,
   AppToggleableRequirementChoices,
+  AppOnboardingData,
 } from '@/user-data';
 import { getRostersFromLastTwoYears } from '@/utilities';
 // emoji for clipboard
@@ -118,7 +118,7 @@ tour.setOption('exitOnOverlayClick', 'false');
 export default Vue.extend({
   props: {
     semesters: Array as PropType<readonly AppSemester[]>,
-    user: Object as PropType<AppUser>,
+    onboardingData: Object as PropType<AppOnboardingData>,
     compact: Boolean,
     startTour: Boolean,
     reqs: Array as PropType<readonly SingleMenuRequirement[]>,
@@ -151,14 +151,14 @@ export default Vue.extend({
     },
   },
   methods: {
-    showMajorOrMinorRequirements(id: number, group: string) {
+    showMajorOrMinorRequirements(id: number, group: string): boolean {
       if (group === 'MAJOR') {
         return id === this.displayedMajorIndex + this.numOfColleges;
       }
       // TODO CHANGE FOR MULTIPLE COLLEGES & UNIVERISTIES
       return (
         id < this.numOfColleges ||
-        id === this.displayedMinorIndex + this.numOfColleges + this.user.major.length
+        id === this.displayedMinorIndex + this.numOfColleges + this.onboardingData.major.length
       );
     },
     chooseToggleableRequirementOption(requirementID: string, option: string): void {

--- a/src/requirements/data/exams/ExamCredit.ts
+++ b/src/requirements/data/exams/ExamCredit.ts
@@ -1,4 +1,4 @@
-import { AppUser, FirestoreAPIBExam } from '../../../user-data';
+import { AppOnboardingData, FirestoreAPIBExam } from '../../../user-data';
 import { CourseTaken } from '../../types';
 
 export type ExamRequirements = {
@@ -469,7 +469,9 @@ function getCourseEquivalentsFromOneMajor(
   return APCourseEquivalents.concat(IBCourseEquivalents);
 }
 
-export default function getCourseEquivalentsFromUserExams(user: AppUser): readonly CourseTaken[] {
+export default function getCourseEquivalentsFromUserExams(
+  user: AppOnboardingData
+): readonly CourseTaken[] {
   const courses: CourseTaken[] = [];
   const examCourseCodeSet = new Set<string>();
   const userExamData: ExamsTaken = { AP: [], IB: [] };

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -1,13 +1,12 @@
 import { getOrAllocateSubjectColor, incrementUniqueID } from './global-firestore-data';
 import {
   AppCourse,
+  AppOnboardingData,
   AppSemester,
-  AppUser,
   CornellCourseRosterCourse,
   FirestoreOnboardingUserData,
   FirestoreSemester,
   FirestoreSemesterCourse,
-  FirestoreUserName,
 } from './user-data';
 
 /**
@@ -170,21 +169,12 @@ export const firestoreSemestersToAppSemesters = (
   firestoreSemesters: readonly FirestoreSemester[]
 ): AppSemester[] => firestoreSemesters.map(firestoreSemesterToAppSemester);
 
-export const createAppUser = (
-  data: FirestoreOnboardingUserData,
-  name: FirestoreUserName
-): AppUser => {
-  const user: AppUser = {
-    // TODO: take into account multiple colleges
-    college: data.colleges[0].acronym,
-    firstName: name.firstName,
-    middleName: name.middleName,
-    lastName: name.lastName,
-    major: data.majors.map(({ acronym }) => acronym),
-    minor: data.minors.map(({ acronym }) => acronym),
-    exam: 'exam' in data ? [...data.exam] : [],
-    transferCourse: 'class' in data ? [...data.class] : [],
-    tookSwim: data.tookSwim,
-  };
-  return user;
-};
+export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
+  // TODO: take into account multiple colleges
+  college: data.colleges[0].acronym,
+  major: data.majors.map(({ acronym }) => acronym),
+  minor: data.minors.map(({ acronym }) => acronym),
+  exam: 'exam' in data ? [...data.exam] : [],
+  transferCourse: 'class' in data ? [...data.class] : [],
+  tookSwim: data.tookSwim,
+});

--- a/src/user-data.ts
+++ b/src/user-data.ts
@@ -91,7 +91,7 @@ export type CornellCourseRosterCourse = {
   readonly roster: string;
 };
 
-export type AppUser = FirestoreUserName & {
+export type AppOnboardingData = {
   readonly college: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];


### PR DESCRIPTION
Depends on #273.

### Summary <!-- Required -->

In an effort to make the format of the app data and firestore data more consistent with each other, this diff splits the AppUser into `FirestoreUsername` and `AppOnboardingData`, which is very close to the firestore data.

After this diff, we will be able to integrate the onboarding data into the global data store.

### Test Plan <!-- Required -->

- go through onboarding to ensure full names are displayed correctly.
- check the requirement menu to see full names are displayed correctly.