### PR TITLE
Unify AppCourse & FirestoreSemesterCourse, AppSemester & FirestoreSemester

### DIFF
--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -41,13 +41,13 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
-import { AppSemester } from '@/user-data';
+import { FirestoreSemester } from '@/user-data';
 
 Vue.component('newSemester', NewSemester);
 
 export default Vue.extend({
   props: {
-    semesters: Array as PropType<readonly AppSemester[]>,
+    semesters: Array as PropType<readonly FirestoreSemester[]>,
     deleteSemType: String,
     deleteSemYear: Number,
   },

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -92,7 +92,7 @@ import spring from '@/assets/images/springEmoji.svg';
 import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
 import { inactiveGray, yuxuanBlue, darkPlaceholderGray } from '@/assets/scss/_variables.scss';
-import { FirestoreSemesterType, AppSemester } from '@/user-data';
+import { FirestoreSemesterType, FirestoreSemester } from '@/user-data';
 
 type DisplayOption = {
   shown: boolean;
@@ -115,7 +115,7 @@ type Data = {
 
 export default Vue.extend({
   props: {
-    currentSemesters: Array as PropType<readonly AppSemester[] | null>,
+    currentSemesters: Array as PropType<readonly FirestoreSemester[] | null>,
     id: Number,
     isEdit: Boolean,
     year: Number,

--- a/src/components/Modals/NewSemesterModal.vue
+++ b/src/components/Modals/NewSemesterModal.vue
@@ -24,7 +24,7 @@
 import Vue, { PropType } from 'vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
 import FlexibleModal from '@/components/Modals/FlexibleModal.vue';
-import { AppSemester } from '@/user-data';
+import { FirestoreSemester } from '@/user-data';
 
 Vue.component('flexible-modal', FlexibleModal);
 Vue.component('new-semester', NewSemester);
@@ -34,7 +34,7 @@ export default Vue.extend({
     return { isDisabled: false, season: '', year: 0 };
   },
   props: {
-    currentSemesters: { type: Array as PropType<readonly AppSemester[]>, required: true },
+    currentSemesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
   },
   methods: {
     disableButton(disabled: boolean) {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -37,7 +37,7 @@
 import Vue, { PropType } from 'vue';
 import ReqCourse from '@/components/Requirements/ReqCourse.vue';
 import { DisplayableRequirementFulfillment, CourseTaken } from '@/requirements/types';
-import { AppSemester, FirestoreSemesterType } from '@/user-data';
+import { FirestoreSemester, FirestoreSemesterType } from '@/user-data';
 
 Vue.component('reqcourse', ReqCourse);
 
@@ -57,7 +57,7 @@ export default Vue.extend({
     subReq: Object as PropType<DisplayableRequirementFulfillment>,
     subReqCourseId: Number,
     crsesTaken: Array as PropType<readonly CourseTaken[]>,
-    semesters: Array as PropType<readonly AppSemester[]>,
+    semesters: Array as PropType<readonly FirestoreSemester[]>,
   },
   data(): CompletedSubReq {
     return {
@@ -100,19 +100,18 @@ export default Vue.extend({
       if (!this.$data.scrollable) event.preventDefault();
     },
     setCourseAndSemesterForNonTransferCredits(crseTaken: CourseTaken) {
+      const courseTakenCode = `${crseTaken.subject} ${crseTaken.number}`;
       for (let i = 0; i < this.semesters.length; i += 1) {
         const semester = this.semesters[i];
         const filteredSemesterCourses = semester.courses.filter(
-          course =>
-            course.crseId === crseTaken.courseId &&
-            course.subject === crseTaken.subject &&
-            course.number === crseTaken.number
+          course => course.crseId === crseTaken.courseId && course.code === courseTakenCode
         );
         if (filteredSemesterCourses.length > 0) {
           const course = filteredSemesterCourses[0];
+          const [subject, number] = course.code.split(' ');
           this.color = course.color;
-          this.courseSubject = course.subject;
-          this.courseNumber = course.number;
+          this.courseSubject = subject;
+          this.courseNumber = number;
           this.courseUniqueId = course.uniqueID;
           this.semesterType = semester.type;
           this.semesterYear = semester.year;

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -38,7 +38,7 @@
           <course
             v-bind="course"
             :courseObj="course"
-            :uniqueID="course.uniqueID"
+            :isReqCourse="true"
             :compact="true"
             :active="false"
             class="requirements-course"
@@ -62,14 +62,14 @@ import {
   SubReqCourseSlot,
   CrseInfo,
 } from '@/requirements/types';
-import { AppCourse } from '@/user-data';
+import { FirestoreSemesterCourse } from '@/user-data';
 
 Vue.component('vue-skeleton-loader', VueSkeletonLoader);
 Vue.component('course', Course);
 Vue.component('addcoursebutton', AddCourseButton);
 
 type Data = {
-  courseObjects: AppCourse[];
+  courseObjects: FirestoreSemesterCourse[];
   scrollable: boolean;
   displayCourses: boolean;
 };
@@ -99,7 +99,7 @@ export default Vue.extend({
     subReq: Object as PropType<DisplayableRequirementFulfillment>,
     subReqCourseId: Number,
     crseInfoObjects: Array as PropType<CrseInfo[]>,
-    subReqFetchedCourseObjectsNotTakenArray: Array as PropType<AppCourse[]>,
+    subReqFetchedCourseObjectsNotTakenArray: Array as PropType<FirestoreSemesterCourse[]>,
     subReqCoursesArray: Array as PropType<SubReqCourseSlot[]>,
     dataReady: Boolean,
     displayDescription: Boolean,
@@ -147,14 +147,14 @@ export default Vue.extend({
       if (!this.$data.scrollable) event.preventDefault();
     },
     getFirstFourCourseObjects() {
-      const firstFourCourseObjects: AppCourse[] = [];
+      const firstFourCourseObjects: FirestoreSemesterCourse[] = [];
       for (
         let i = 0;
         firstFourCourseObjects.length < 4 && i < this.crseInfoObjects.length;
         i += 1
       ) {
         const crseInfoObject = this.crseInfoObjects[i];
-        const filteredCourses: AppCourse[] = this.subReqFetchedCourseObjectsNotTakenArray.filter(
+        const filteredCourses: FirestoreSemesterCourse[] = this.subReqFetchedCourseObjectsNotTakenArray.filter(
           course => crseInfoObject.crseIds.includes(course.crseId)
         );
         const numRemainingCourses = Math.min(

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -85,7 +85,7 @@ import RequirementHeader from '@/components/Requirements/RequirementHeader.vue';
 import SubRequirement from '@/components/Requirements/SubRequirement.vue';
 
 import { SingleMenuRequirement } from '@/requirements/types';
-import { AppCourse, AppOnboardingData, AppSemester } from '@/user-data';
+import { AppOnboardingData, FirestoreSemester, FirestoreSemesterCourse } from '@/user-data';
 
 Vue.component('requirementheader', RequirementHeader);
 Vue.component('subrequirement', SubRequirement);
@@ -110,7 +110,7 @@ export default Vue.extend({
     numOfColleges: Number,
     rostersFromLastTwoYears: Array as PropType<readonly string[]>,
     lastLoadedShowAllCourseId: Number,
-    semesters: Array as PropType<readonly AppSemester[]>,
+    semesters: Array as PropType<readonly FirestoreSemester[]>,
   },
   data() {
     return {
@@ -130,7 +130,7 @@ export default Vue.extend({
     activateMinor(id: number) {
       this.$emit('activateMinor', id);
     },
-    onShowAllCourses(courses: AppCourse[]) {
+    onShowAllCourses(courses: FirestoreSemesterCourse[]) {
       this.$emit('onShowAllCourses', courses);
     },
     changeToggleableRequirementChoice(requirementID: string, option: string) {

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -1,11 +1,8 @@
 import { getOrAllocateSubjectColor, incrementUniqueID } from './global-firestore-data';
 import {
-  AppCourse,
   AppOnboardingData,
-  AppSemester,
   CornellCourseRosterCourse,
   FirestoreOnboardingUserData,
-  FirestoreSemester,
   FirestoreSemesterCourse,
 } from './user-data';
 
@@ -22,10 +19,9 @@ const createCourseCreditRange = (course: CornellCourseRosterCourse): readonly [n
   return [Math.min(...courseCreditRange), Math.max(...courseCreditRange)];
 };
 
-export const cornellCourseRosterCourseToAppCourse = (
-  course: CornellCourseRosterCourse,
-  isRequirementsCourse: boolean
-): AppCourse => {
+export const cornellCourseRosterCourseToFirebaseSemesterCourse = (
+  course: CornellCourseRosterCourse
+): FirestoreSemesterCourse => {
   const uniqueID = incrementUniqueID();
 
   const { subject, catalogNbr: number, titleLong: name, description, roster: lastRoster } = course;
@@ -86,12 +82,9 @@ export const cornellCourseRosterCourseToAppCourse = (
   // Create course from saved color. Otherwise, create course from subject color group
   const color = getOrAllocateSubjectColor(subject);
 
-  const isReqCourse = isRequirementsCourse;
-
   return {
     crseId: course.crseId,
-    subject,
-    number,
+    code: `${subject} ${number}`,
     name,
     description,
     credits,
@@ -104,70 +97,9 @@ export const cornellCourseRosterCourseToAppCourse = (
     distributions,
     lastRoster,
     color,
-    check: true,
     uniqueID,
-    isReqCourse,
   };
 };
-
-export const firestoreCourseToAppCourse = (
-  course: FirestoreSemesterCourse,
-  isRequirementsCourse: boolean
-): AppCourse => {
-  const {
-    uniqueID,
-    code,
-    name,
-    description,
-    credits,
-    creditRange,
-    semesters,
-    prereqs,
-    enrollment,
-    lectureTimes,
-    instructors,
-    distributions,
-    lastRoster,
-    color,
-  } = course;
-
-  const [subject, number] = code.split(' ');
-
-  return {
-    crseId: course.crseId,
-    subject,
-    number,
-    name,
-    description,
-    credits,
-    creditRange,
-    semesters,
-    prereqs,
-    enrollment,
-    lectureTimes,
-    instructors,
-    distributions,
-    lastRoster,
-    color,
-    check: true,
-    uniqueID,
-    isReqCourse: isRequirementsCourse,
-  };
-};
-
-const firestoreSemesterToAppSemester = ({
-  courses,
-  type,
-  year,
-}: FirestoreSemester): AppSemester => ({
-  courses: courses.map(course => firestoreCourseToAppCourse(course, false)),
-  type,
-  year,
-});
-
-export const firestoreSemestersToAppSemesters = (
-  firestoreSemesters: readonly FirestoreSemester[]
-): AppSemester[] => firestoreSemesters.map(firestoreSemesterToAppSemester);
 
 export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
   // TODO: take into account multiple colleges

--- a/src/user-data.ts
+++ b/src/user-data.ts
@@ -100,33 +100,6 @@ export type AppOnboardingData = {
   readonly tookSwim: 'yes' | 'no';
 };
 
-export type AppCourse = {
-  readonly crseId: number;
-  readonly subject: string;
-  readonly number: string;
-  readonly name: string;
-  readonly description: string;
-  readonly credits: number;
-  readonly creditRange: readonly [number, number];
-  readonly semesters: readonly string[];
-  readonly prereqs: string;
-  readonly enrollment: readonly string[];
-  readonly lectureTimes: readonly string[];
-  readonly instructors: readonly string[];
-  readonly distributions: readonly string[];
-  readonly lastRoster: string;
-  readonly color: string;
-  readonly check: boolean;
-  uniqueID: number;
-  isReqCourse: boolean;
-};
-
-export type AppSemester = {
-  readonly courses: readonly AppCourse[];
-  readonly type: FirestoreSemesterType;
-  readonly year: number;
-};
-
 export type AppBottomBarCourse = {
   readonly subject: string;
   readonly number: string;


### PR DESCRIPTION
### Summary <!-- Required -->

In the push to store some important data globally, we want the data in firestore to be consistent with the data used in the app, so that we don't have to do tricky transformations all the time. Semester and course data is such important global data.

`AppCourse` and `FirestoreSemesterCourse` are very similar to each other, except a few fields.  `AppSemester` and `FirestoreSemester` are almost identical, except that one contains `AppCourse` and the other contains `FirestoreSemesterCourse`.

This diff unifies them into the same type. In particular, it abandons AppCourse and AppSemester and switches them to the firestore version throughout the app. The `AppCourse` data has these fields that are different from `FirestoreSemesterCourse`:

- `check: boolean`. Unused field, so i removed it.
- `isReqCourse: boolean`. This is not necessary to the course, but would be more appropriate if it's a parameter passed into the course component, so I removed it.
- `subject, number` instead of `code`. In the places where we need subject and number, we split from the code.

After the above changes are done, `AppCourse` and `FirestoreSemesterCourse` are completely identical and we can only keep one type!

There was also a leftover from previous PR when I found that we are doing `course.compact = true;`. It turns out it's unnecessary, since the relevant field is passed into the course component already.

### Test Plan <!-- Required -->

- add/edit/delete course still works.
- course drag and drop still works
- courses in the requirement menu still correctly show up

### Notes <!-- Optional -->

In this PR, I also want to get rid of the `v-bind="course"` on the course component, but failed to do so. It turns out that the sad drag and drop library depends on it :(