### PR TITLE
Setup global data listeners for all data except semesters

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -73,10 +73,11 @@ import OnboardingReview from '@/components/Modals/Onboarding/OnboardingReview.vu
 import {
   AppOnboardingData,
   FirestoreAPIBExam,
-  FirestoreOnboardingUserData,
   FirestoreTransferClass,
   FirestoreUserName,
 } from '@/user-data';
+import { db, onboardingDataCollection, usernameCollection } from '@/firebaseConfig';
+import store from '@/store';
 
 Vue.component('onboardingBasic', OnboardingBasic);
 Vue.component('onboardingTransfer', OnboardingTransfer);
@@ -109,22 +110,22 @@ export default Vue.extend({
       ) {
         this.isError = true;
       } else {
-        const onboardingData: { name: FirestoreUserName; userData: FirestoreOnboardingUserData } = {
-          name: {
+        db.batch()
+          .set(usernameCollection.doc(store.state.currentFirebaseUser.email), {
             firstName: this.name.firstName,
             middleName: this.name.middleName,
             lastName: this.name.lastName,
-          },
-          userData: {
+          })
+          .set(onboardingDataCollection.doc(store.state.currentFirebaseUser.email), {
             colleges: [{ acronym: this.onboarding.college }],
             majors: this.onboarding.major.map(acronym => ({ acronym })),
             minors: this.onboarding.minor.map(acronym => ({ acronym })),
             exam: this.onboarding.exam,
             class: this.onboarding.transferCourse,
             tookSwim: this.onboarding.tookSwim,
-          },
-        };
-        this.$emit('onboard', onboardingData);
+          })
+          .commit();
+        this.$emit('onboard');
       }
     },
     goBack() {

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -1,10 +1,5 @@
 import { getOrAllocateSubjectColor, incrementUniqueID } from './global-firestore-data';
-import {
-  AppOnboardingData,
-  CornellCourseRosterCourse,
-  FirestoreOnboardingUserData,
-  FirestoreSemesterCourse,
-} from './user-data';
+import { CornellCourseRosterCourse, FirestoreSemesterCourse } from './user-data';
 
 /**
  * Creates credit range based on course
@@ -101,12 +96,4 @@ export const cornellCourseRosterCourseToFirebaseSemesterCourse = (
   };
 };
 
-export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
-  // TODO: take into account multiple colleges
-  college: data.colleges[0].acronym,
-  major: data.majors.map(({ acronym }) => acronym),
-  minor: data.minors.map(({ acronym }) => acronym),
-  exam: 'exam' in data ? [...data.exam] : [],
-  transferCourse: 'class' in data ? [...data.class] : [],
-  tookSwim: data.tookSwim,
-});
+export default cornellCourseRosterCourseToFirebaseSemesterCourse;


### PR DESCRIPTION
Depends on #275.

### Summary <!-- Required -->

This PR setups up all firestore listeners except semesters and then connect them to the root Dashboard. Semester data is hard to setup listener due to drag and drop mess.

For all the listeners I set up, when all of the listeners finish the first `onSnapshot`, it will call the onLoad callback to inform the application that the first batch of data has been loaded (so that the application has full data to work with, like requirement computation). Dashboard turns this into a promise and combines this with the promise of semester data loading, and then wait on these promises before declaring the page is loaded.

### Test Plan <!-- Required -->

- add/edit/delete course still works.
- course drag and drop still works
- courses in the requirement menu still correctly show up

### Notes

To integrate semester into this, we need to replace the drag and drop library first.