### PR TITLE
Cleanup Vue components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,8 @@ module.exports = {
       },
     ],
     'max-classes-per-file': ['off'],
+    // TypeScript will handle it. It also doesn't work with typescript global types.
+    'no-undef': ['off'],
     'no-unused-vars': ['off'],
     'no-use-before-define': ['off'],
     'vue/no-mutating-props': ['warn'],

--- a/src/components/AddCourseButton.vue
+++ b/src/components/AddCourseButton.vue
@@ -24,9 +24,9 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    compact: Boolean,
-    shouldClearPadding: Boolean,
-    shouldShowWalkthrough: Boolean,
+    compact: { type: Boolean, required: true },
+    shouldClearPadding: { type: Boolean, default: false },
+    shouldShowWalkthrough: { type: Boolean, default: false },
   },
   computed: {
     addCourseText() {

--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -2,7 +2,7 @@
   <div class="bottombar">
     <div class="bottombar-tabviewTitleWrapper">
       <div class="bottombar-tabview" v-bind:class="{ expandedTabView: isExpanded }">
-        <bottombartabview
+        <bottom-bar-tab-view
           :bottomCourses="bottomCourses"
           :seeMoreCourses="seeMoreCourses"
           :bottomCourseFocus="bottomCourseFocus"
@@ -13,7 +13,7 @@
         />
       </div>
       <div class="bottombar-title" @click="toggle()">
-        <bottombartitle
+        <bottom-bar-title
           :color="bottomCourses[bottomCourseFocus].color"
           :name="bottomCourses[bottomCourseFocus].name"
           :isExpanded="isExpanded"
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div v-if="isExpanded" class="bottombar-course">
-      <bottombarcourse :courseObj="bottomCourses[bottomCourseFocus]" />
+      <bottom-bar-course :courseObj="bottomCourses[bottomCourseFocus]" />
     </div>
   </div>
 </template>
@@ -31,13 +31,9 @@ import Vue, { PropType } from 'vue';
 import BottomBarCourse from '@/components/BottomBar/BottomBarCourse.vue';
 import BottomBarTabView from '@/components/BottomBar/BottomBarTabView.vue';
 import BottomBarTitle from '@/components/BottomBar/BottomBarTitle.vue';
-import { AppBottomBarCourse } from '@/user-data';
-
-Vue.component('bottombarcourse', BottomBarCourse);
-Vue.component('bottombartabview', BottomBarTabView);
-Vue.component('bottombartitle', BottomBarTitle);
 
 export default Vue.extend({
+  components: { BottomBarCourse, BottomBarTabView, BottomBarTitle },
   props: {
     bottomCourses: Array as PropType<AppBottomBarCourse[]>,
     seeMoreCourses: Array as PropType<AppBottomBarCourse[]>,

--- a/src/components/BottomBar/BottomBarCourse.vue
+++ b/src/components/BottomBar/BottomBarCourse.vue
@@ -284,7 +284,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { reviewColors } from '@/assets/constants/colors';
-import { AppBottomBarCourse } from '@/user-data';
 
 export default Vue.extend({
   data() {
@@ -293,8 +292,7 @@ export default Vue.extend({
     };
   },
   props: {
-    courseObj: Object as PropType<AppBottomBarCourse>,
-    id: Number,
+    courseObj: { type: Object as PropType<AppBottomBarCourse>, required: true },
   },
   created() {
     window.addEventListener('resize', this.isSmallerWidthEventHandler);

--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -19,18 +19,16 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import { AppBottomBarCourse } from '@/user-data';
 
 export default Vue.extend({
   props: {
-    subject: String,
-    number: String,
-    color: String,
-    id: Number,
-    courseObj: Object as PropType<AppBottomBarCourse>,
-    tabIndex: Number,
-    bottomCourseFocus: Number,
-    isExpanded: Boolean,
+    subject: { type: String, required: true },
+    number: { type: String, required: true },
+    color: { type: String, required: true },
+    courseObj: { type: Object as PropType<AppBottomBarCourse>, required: true },
+    tabIndex: { type: Number, required: true },
+    bottomCourseFocus: { type: Number, required: true },
+    isExpanded: { type: Boolean, required: true },
   },
 
   methods: {

--- a/src/components/BottomBar/BottomBarTabView.vue
+++ b/src/components/BottomBar/BottomBarTabView.vue
@@ -6,8 +6,7 @@
         :key="index"
         class="bottombartabview-courseWrapper"
       >
-        <bottombartab
-          v-bind="bottomCourse"
+        <bottom-bar-tab
           :subject="bottomCourse.subject"
           :number="bottomCourse.number"
           :color="bottomCourse.color"
@@ -64,22 +63,20 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import BottomBarTab from '@/components/BottomBar/BottomBarTab.vue';
-import { AppBottomBarCourse } from '@/user-data';
-
-Vue.component('bottombartab', BottomBarTab);
 
 export default Vue.extend({
+  components: { BottomBarTab },
   data() {
     return {
       seeMoreOpen: false,
     };
   },
   props: {
-    bottomCourses: Array as PropType<AppBottomBarCourse[]>,
-    seeMoreCourses: Array as PropType<AppBottomBarCourse[]>,
-    bottomCourseFocus: Number,
-    isExpanded: Boolean,
-    maxBottomBarTabs: Number,
+    bottomCourses: { type: Array as PropType<AppBottomBarCourse[]>, required: true },
+    seeMoreCourses: { type: Array as PropType<AppBottomBarCourse[]>, required: true },
+    bottomCourseFocus: { type: Number, required: true },
+    isExpanded: { type: Boolean, required: true },
+    maxBottomBarTabs: { type: Number, required: true },
   },
 
   computed: {

--- a/src/components/BottomBar/BottomBarTitle.vue
+++ b/src/components/BottomBar/BottomBarTitle.vue
@@ -25,9 +25,9 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    color: String,
-    name: String,
-    isExpanded: Boolean,
+    color: { type: String, required: true },
+    name: { type: String, required: true },
+    isExpanded: { type: Boolean, required: true },
   },
 });
 </script>

--- a/src/components/Confirmation.vue
+++ b/src/components/Confirmation.vue
@@ -12,7 +12,7 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    text: String,
+    text: { type: String, required: true },
   },
 });
 </script>

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -27,7 +27,7 @@
         </div>
       </div>
     </div>
-    <coursemenu
+    <course-menu
       v-if="menuOpen"
       :semesterIndex="semesterIndex"
       :isCompact="compact"
@@ -46,12 +46,9 @@ import Vue, { PropType } from 'vue';
 import CourseMenu from '@/components/Modals/CourseMenu.vue';
 import CourseCaution from '@/components/CourseCaution.vue';
 import { clickOutside } from '@/utilities';
-import { FirestoreSemesterCourse } from '@/user-data';
-
-Vue.component('coursemenu', CourseMenu);
-Vue.component('course-caution', CourseCaution);
 
 export default Vue.extend({
+  components: { CourseCaution, CourseMenu },
   props: {
     courseObj: { type: Object as PropType<FirestoreSemesterCourse>, required: true },
     duplicatedCourseCodeList: { type: Array, required: false },

--- a/src/components/CourseCaution.vue
+++ b/src/components/CourseCaution.vue
@@ -16,11 +16,8 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    compact: Boolean,
-    cautionString: {
-      type: String,
-      required: true,
-    },
+    compact: { type: Boolean, required: true },
+    cautionString: { type: String, required: true },
   },
 });
 </script>

--- a/src/components/DropDownArrow.vue
+++ b/src/components/DropDownArrow.vue
@@ -15,9 +15,9 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    fillColor: String,
-    isFlipped: Boolean,
-    isPointingLeft: Boolean,
+    fillColor: { type: String, required: true },
+    isFlipped: { type: Boolean, default: false },
+    isPointingLeft: { type: Boolean, default: false },
   },
 });
 </script>

--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -2,7 +2,7 @@
   <div class="editSemesterModal">
     <div class="editSemesterModal-content">
       <div class="editSemesterModal-top">
-        <span class="editSemesterModal-title">{{ title }}</span>
+        <span class="editSemesterModal-title">Edit Semester</span>
         <img
           class="editSemesterModal-exit"
           src="@/assets/images/x.png"
@@ -10,7 +10,7 @@
         />
       </div>
       <div class="editSemesterModal-body">
-        <newSemester
+        <new-semester
           class="modal-body"
           :currentSemesters="semesters"
           :isEdit="true"
@@ -19,11 +19,10 @@
           @duplicateSemester="disableButton"
           @updateSemProps="updateSemProps"
           ref="modalBodyComponent"
-        >
-        </newSemester>
+        />
       </div>
       <div class="editSemesterModal-buttonWrapper">
-        <button class="editSemesterModal-button" @click="closeCurrentModal">{{ cancel }}</button>
+        <button class="editSemesterModal-button" @click="closeCurrentModal">Cancel</button>
         <div
           class="editSemesterModal-button editSemesterModal-button--delete"
           :class="{ 'editSemesterModal-button--disabled': isDisabled }"
@@ -41,15 +40,13 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
-import { FirestoreSemester } from '@/user-data';
-
-Vue.component('newSemester', NewSemester);
 
 export default Vue.extend({
+  components: { NewSemester },
   props: {
     semesters: Array as PropType<readonly FirestoreSemester[]>,
-    deleteSemType: String,
-    deleteSemYear: Number,
+    deleteSemType: { type: String as PropType<FirestoreSemesterType>, required: true },
+    deleteSemYear: { type: Number, required: true },
   },
   data() {
     return {
@@ -57,17 +54,6 @@ export default Vue.extend({
       season: '',
       year: '',
     };
-  },
-  computed: {
-    text() {
-      return 'Are you sure you want to edit this semester?';
-    },
-    cancel() {
-      return 'Cancel';
-    },
-    title() {
-      return 'Edit Semester';
-    },
   },
   methods: {
     closeCurrentModal() {

--- a/src/components/Modals/NewCourse/CourseSelector.vue
+++ b/src/components/Modals/NewCourse/CourseSelector.vue
@@ -71,7 +71,11 @@ const getMatchingCourses = (
 };
 
 export default Vue.extend({
-  props: { searchBoxClassName: String, placeholder: String, autoFocus: Boolean },
+  props: {
+    searchBoxClassName: { type: String, required: true },
+    placeholder: { type: String, required: true },
+    autoFocus: { type: Boolean, required: true },
+  },
   data() {
     return {
       searchText: '',

--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -1,7 +1,7 @@
 <template>
   <flexible-modal
     title="Add Course"
-    contentClass="content-course"
+    content-class="content-course"
     :leftButtonText="leftButtonText"
     :rightButtonText="rightButtonText"
     :rightButtonIsDisabled="selectedCourse == null"
@@ -21,12 +21,12 @@
     <div v-if="isCourseModelSelectingSemester && selectedCourse == null">
       <div class="newCourse-title">Add this class to the following semester</div>
       <div class="newCourse-semester-edit">
-        <newSemester
+        <new-semester
           :type="season"
           :year="year"
           :isCourseModelSelectingSemester="isCourseModelSelectingSemester"
           @updateSemProps="updateSemProps"
-        ></newSemester>
+        />
       </div>
     </div>
     <div v-if="selectedCourse != null">
@@ -60,8 +60,9 @@ import Vue, { PropType } from 'vue';
 import SelectedRequirementEditor, {
   RequirementWithID,
 } from '@/components/Modals/NewCourse/SelectedRequirementEditor.vue';
-import { FirestoreSemesterType, CornellCourseRosterCourse } from '@/user-data';
 import { SingleMenuRequirement } from '@/requirements/types';
+import FlexibleModal from '@/components/Modals/FlexibleModal.vue';
+import NewSemester from '@/components/Modals/NewSemester.vue';
 import CourseSelector, {
   MatchingCourseSearchResult,
 } from '@/components/Modals/NewCourse/CourseSelector.vue';
@@ -72,7 +73,7 @@ import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
 
 export default Vue.extend({
-  components: { CourseSelector, SelectedRequirementEditor },
+  components: { CourseSelector, FlexibleModal, NewSemester, SelectedRequirementEditor },
   data() {
     return {
       selectedCourse: null as MatchingCourseSearchResult | null,

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -92,7 +92,6 @@ import spring from '@/assets/images/springEmoji.svg';
 import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
 import { inactiveGray, yuxuanBlue, darkPlaceholderGray } from '@/assets/scss/_variables.scss';
-import { FirestoreSemesterType, FirestoreSemester } from '@/user-data';
 
 type DisplayOption = {
   shown: boolean;
@@ -115,12 +114,14 @@ type Data = {
 
 export default Vue.extend({
   props: {
-    currentSemesters: Array as PropType<readonly FirestoreSemester[] | null>,
-    id: Number,
-    isEdit: Boolean,
-    year: Number,
-    type: String as PropType<FirestoreSemesterType>,
-    isCourseModelSelectingSemester: Boolean,
+    currentSemesters: {
+      type: Array as PropType<readonly FirestoreSemester[] | null>,
+      default: null,
+    },
+    isEdit: { type: Boolean, default: false },
+    year: { type: Number, default: 0 },
+    type: { type: String as PropType<FirestoreSemesterType>, default: '' },
+    isCourseModelSelectingSemester: { type: Boolean, default: false },
   },
   data(): Data {
     // years

--- a/src/components/Modals/NewSemesterModal.vue
+++ b/src/components/Modals/NewSemesterModal.vue
@@ -1,9 +1,9 @@
 <template>
   <flexible-modal
     title="New Semester"
-    contentClass="content-semester"
-    leftButtonText="CANCEL"
-    rightButtonText="ADD"
+    content-class="content-semester"
+    left-button-text="CANCEL"
+    right-button-text="ADD"
     :rightButtonIsDisabled="isDisabled"
     @modal-closed="closeCurrentModal"
     @left-button-clicked="closeCurrentModal"
@@ -24,12 +24,9 @@
 import Vue, { PropType } from 'vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
 import FlexibleModal from '@/components/Modals/FlexibleModal.vue';
-import { FirestoreSemester } from '@/user-data';
-
-Vue.component('flexible-modal', FlexibleModal);
-Vue.component('new-semester', NewSemester);
 
 export default Vue.extend({
+  components: { FlexibleModal, NewSemester },
   data() {
     return { isDisabled: false, season: '', year: 0 };
   },

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -12,18 +12,18 @@
             Let's get to know you first!
           </div>
           <div v-if="isEditingProfile" class="onboarding-description">Let's edit your profile!</div>
-          <onboardingBasic
+          <onboarding-basic
             v-if="currentPage == 1"
             :userName="name"
             :onboardingData="onboarding"
             @updateBasic="updateBasic"
           />
-          <onboardingTransfer
+          <onboarding-transfer
             v-if="currentPage == 2"
             :onboardingData="onboarding"
             @updateTransfer="updateTransfer"
           />
-          <onboardingReview
+          <onboarding-review
             v-if="currentPage == 3"
             :userName="name"
             :onboardingData="onboarding"
@@ -70,23 +70,14 @@ import Vue, { PropType } from 'vue';
 import OnboardingBasic from '@/components/Modals/Onboarding/OnboardingBasic.vue';
 import OnboardingTransfer from '@/components/Modals/Onboarding/OnboardingTransfer.vue';
 import OnboardingReview from '@/components/Modals/Onboarding/OnboardingReview.vue';
-import {
-  AppOnboardingData,
-  FirestoreAPIBExam,
-  FirestoreTransferClass,
-  FirestoreUserName,
-} from '@/user-data';
 import { db, onboardingDataCollection, usernameCollection } from '@/firebaseConfig';
 import store from '@/store';
-
-Vue.component('onboardingBasic', OnboardingBasic);
-Vue.component('onboardingTransfer', OnboardingTransfer);
-Vue.component('onboardingReview', OnboardingReview);
 
 const placeholderText = 'Select one';
 const FINAL_PAGE = 3;
 
 export default Vue.extend({
+  components: { OnboardingBasic, OnboardingReview, OnboardingTransfer },
   props: {
     isEditingProfile: { type: Boolean, required: true },
     userName: { type: Object as PropType<FirestoreUserName>, required: true },

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -78,7 +78,6 @@
 import Vue, { PropType } from 'vue';
 import reqsData from '@/requirements/typed-requirement-json';
 import { clickOutside } from '@/utilities';
-import { AppOnboardingData, FirestoreUserName } from '@/user-data';
 import OnboardingBasicMultiDropdown from './OnboardingBasicMultiDropdown.vue';
 import OnboardingBasicSingleDropdown from './OnboardingBasicSingleDropdown.vue';
 

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -164,7 +164,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { getExamCredit } from '@/components/Modals/Onboarding/OnboardingTransfer.vue';
-import { AppOnboardingData, FirestoreUserName } from '@/user-data';
 import { getCollegeFullName, getMajorFullName, getMinorFullName } from '@/utilities';
 
 const placeholderText = 'Select one';

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -166,7 +166,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { examData as reqsData } from '@/requirements/data/exams/ExamCredit';
-import { FirestoreAPIBExam, CornellCourseRosterCourse, AppOnboardingData } from '@/user-data';
 import OnboardingTransferSwimming from './OnboardingTransferSwimming.vue';
 import OnboardingTransferExamPropertyDropdown from './OnboardingTransferExamPropertyDropdown.vue';
 import CourseSelector, { MatchingCourseSearchResult } from '../NewCourse/CourseSelector.vue';

--- a/src/components/Modals/TourWindow.vue
+++ b/src/components/Modals/TourWindow.vue
@@ -33,10 +33,10 @@ import { clickOutside } from '@/utilities';
 
 export default Vue.extend({
   props: {
-    title: String,
-    text: String,
-    exit: String,
-    buttonText: String,
+    title: { type: String, required: true },
+    text: { type: String, required: true },
+    exit: { type: String, required: true },
+    buttonText: { type: String, required: true },
   },
   data() {
     return {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -20,7 +20,7 @@ import firebase from 'firebase/app';
 
 export default Vue.extend({
   props: {
-    isBottomPreview: Boolean,
+    isBottomPreview: { type: Boolean, required: true },
   },
 
   methods: {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -17,7 +17,7 @@
         </div>
       </div>
       <div class="completed-reqCourses-course-object-wrapper">
-        <reqcourse
+        <req-course
           :color="color"
           :subject="courseSubject"
           :number="courseNumber"
@@ -36,10 +36,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import ReqCourse from '@/components/Requirements/ReqCourse.vue';
-import { DisplayableRequirementFulfillment, CourseTaken } from '@/requirements/types';
-import { FirestoreSemester, FirestoreSemesterType } from '@/user-data';
-
-Vue.component('reqcourse', ReqCourse);
+import { CourseTaken } from '@/requirements/types';
 
 type CompletedSubReq = {
   color: string;
@@ -53,11 +50,11 @@ type CompletedSubReq = {
 };
 
 export default Vue.extend({
+  components: { ReqCourse },
   props: {
-    subReq: Object as PropType<DisplayableRequirementFulfillment>,
-    subReqCourseId: Number,
-    crsesTaken: Array as PropType<readonly CourseTaken[]>,
-    semesters: Array as PropType<readonly FirestoreSemester[]>,
+    subReqCourseId: { type: Number, required: true },
+    crsesTaken: { type: Array as PropType<readonly CourseTaken[]>, required: true },
+    semesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
   },
   data(): CompletedSubReq {
     return {

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -48,7 +48,7 @@
         </div>
       </draggable>
       <div v-if="subReq.fulfilledBy === 'self-check'">
-        <addcoursebutton :compact="true" :shouldClearPadding="true" @click="onAddCourse" />
+        <add-course-button :compact="true" :shouldClearPadding="true" @click="onAddCourse" />
       </div>
     </div>
   </div>
@@ -65,11 +65,6 @@ import {
   SubReqCourseSlot,
   CrseInfo,
 } from '@/requirements/types';
-import { FirestoreSemesterCourse } from '@/user-data';
-
-Vue.component('vue-skeleton-loader', VueSkeletonLoader);
-Vue.component('course', Course);
-Vue.component('addcoursebutton', AddCourseButton);
 
 type Data = {
   courseObjects: FirestoreSemesterCourse[];
@@ -78,7 +73,7 @@ type Data = {
 };
 
 export default Vue.extend({
-  components: { draggable },
+  components: { draggable, AddCourseButton, Course, VueSkeletonLoader },
   mounted() {
     this.$el.addEventListener('touchmove', this.dragListener, { passive: false });
   },
@@ -93,14 +88,17 @@ export default Vue.extend({
     this.$el.removeEventListener('touchmove', this.dragListener);
   },
   props: {
-    subReq: Object as PropType<DisplayableRequirementFulfillment>,
-    subReqCourseId: Number,
-    crseInfoObjects: Array as PropType<CrseInfo[]>,
-    subReqFetchedCourseObjectsNotTakenArray: Array as PropType<FirestoreSemesterCourse[]>,
-    subReqCoursesArray: Array as PropType<SubReqCourseSlot[]>,
-    dataReady: Boolean,
-    displayDescription: Boolean,
-    lastLoadedShowAllCourseId: Number,
+    subReq: { type: Object as PropType<DisplayableRequirementFulfillment>, required: true },
+    subReqCourseId: { type: Number, required: true },
+    crseInfoObjects: { type: Array as PropType<CrseInfo[]>, required: true },
+    subReqFetchedCourseObjectsNotTakenArray: {
+      type: Array as PropType<FirestoreSemesterCourse[]>,
+      required: true,
+    },
+    subReqCoursesArray: { type: Array as PropType<SubReqCourseSlot[]>, required: true },
+    dataReady: { type: Boolean, required: true },
+    displayDescription: { type: Boolean, required: true },
+    lastLoadedShowAllCourseId: { type: Number, required: true },
   },
   watch: {
     dataReady: {

--- a/src/components/Requirements/ReqCourse.vue
+++ b/src/components/Requirements/ReqCourse.vue
@@ -33,11 +33,11 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    color: String,
-    subject: String,
-    number: String,
-    isCompletedReqCourse: Boolean,
-    compact: Boolean,
+    color: { type: String, required: true },
+    subject: { type: String, required: true },
+    number: { type: String, required: true },
+    isCompletedReqCourse: { type: Boolean, required: true },
+    compact: { type: Boolean, required: true },
   },
   computed: {
     borderColorCSSvar(): { '--border-color': string } {

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -92,7 +92,7 @@
             class="btn"
             @click="toggleDetails()"
           >
-            <dropdownarrow
+            <drop-down-arrow
               :isFlipped="displayDetails"
               :fillColor="`#${reqGroupColorMap[req.group][0]}`"
             />
@@ -117,22 +117,23 @@
 import Vue, { PropType } from 'vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 import { SingleMenuRequirement } from '@/requirements/types';
-import { AppOnboardingData } from '@/user-data';
 import { getCollegeFullName, getMajorFullName, getMinorFullName } from '@/utilities';
 
-Vue.component('dropdownarrow', DropDownArrow);
-
 export default Vue.extend({
+  components: { DropDownArrow },
   props: {
-    reqIndex: Number,
-    displayDetails: Boolean,
-    displayedMajorIndex: Number,
-    displayedMinorIndex: Number,
-    req: Object as PropType<SingleMenuRequirement>,
-    reqGroupColorMap: Object as PropType<Readonly<Record<string, string[]>>>,
-    onboardingData: Object as PropType<AppOnboardingData>,
-    showMajorOrMinorRequirements: Boolean,
-    numOfColleges: Number,
+    reqIndex: { type: Number, required: true },
+    displayDetails: { type: Boolean, required: true },
+    displayedMajorIndex: { type: Number, required: true },
+    displayedMinorIndex: { type: Number, required: true },
+    req: { type: Object as PropType<SingleMenuRequirement>, required: true },
+    reqGroupColorMap: {
+      type: Object as PropType<Readonly<Record<string, string[]>>>,
+      required: true,
+    },
+    onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
+    showMajorOrMinorRequirements: { type: Boolean, required: true },
+    numOfColleges: { type: Number, required: true },
   },
   computed: {
     multipleMajors() {

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -85,7 +85,6 @@ import RequirementHeader from '@/components/Requirements/RequirementHeader.vue';
 import SubRequirement from '@/components/Requirements/SubRequirement.vue';
 
 import { SingleMenuRequirement } from '@/requirements/types';
-import { AppOnboardingData, FirestoreSemester, FirestoreSemesterCourse } from '@/user-data';
 
 Vue.component('requirementheader', RequirementHeader);
 Vue.component('subrequirement', SubRequirement);
@@ -99,18 +98,21 @@ const reqGroupColorMap = {
 
 export default Vue.extend({
   props: {
-    reqs: Array as PropType<readonly SingleMenuRequirement[]>,
-    req: Object as PropType<SingleMenuRequirement>,
-    reqIndex: Number, // Index of this req in reqs array
-    toggleableRequirementChoices: Object as PropType<Readonly<Record<string, string>>>,
-    displayedMajorIndex: Number,
-    displayedMinorIndex: Number,
-    onboardingData: Object as PropType<AppOnboardingData>,
-    showMajorOrMinorRequirements: Boolean,
-    numOfColleges: Number,
-    rostersFromLastTwoYears: Array as PropType<readonly string[]>,
-    lastLoadedShowAllCourseId: Number,
-    semesters: Array as PropType<readonly FirestoreSemester[]>,
+    reqs: { type: Array as PropType<readonly SingleMenuRequirement[]>, required: true },
+    req: { type: Object as PropType<SingleMenuRequirement>, required: true },
+    reqIndex: { type: Number, required: true }, // Index of this req in reqs array
+    toggleableRequirementChoices: {
+      type: Object as PropType<Readonly<Record<string, string>>>,
+      required: true,
+    },
+    displayedMajorIndex: { type: Number, required: true },
+    displayedMinorIndex: { type: Number, required: true },
+    onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
+    showMajorOrMinorRequirements: { type: Boolean, required: true },
+    numOfColleges: { type: Number, required: true },
+    rostersFromLastTwoYears: { type: Array as PropType<readonly string[]>, required: true },
+    lastLoadedShowAllCourseId: { type: Number, required: true },
+    semesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
   },
   data() {
     return {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -35,7 +35,7 @@
     <div class="fixed see-all-padding-y" v-if="shouldShowAllCourses" @scroll="onScrollSeeAll">
       <div class="see-all-padding-x see-all-header pb-3">
         <span class="arrow-left">
-          <dropdownarrow :isPointingLeft="true" :fillColor="'#32A0F2'" />
+          <drop-down-arrow :isPointingLeft="true" :fillColor="'#32A0F2'" />
         </span>
         <button class="btn back-button p-0" @click="backFromSeeAll">GO BACK TO REQUIREMENTS</button>
       </div>
@@ -72,12 +72,6 @@ import Course from '@/components/Course.vue';
 import RequirementView from '@/components/Requirements/RequirementView.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 import { SingleMenuRequirement, SubReqCourseSlot, CrseInfo } from '@/requirements/types';
-import {
-  FirestoreSemester,
-  FirestoreSemesterCourse,
-  AppToggleableRequirementChoices,
-  AppOnboardingData,
-} from '@/user-data';
 import { getRostersFromLastTwoYears } from '@/utilities';
 // emoji for clipboard
 import clipboard from '@/assets/images/clipboard.svg';
@@ -87,9 +81,7 @@ import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-c
 
 const FetchCourses = firebase.functions().httpsCallable('FetchCourses');
 
-Vue.component('course', Course);
 Vue.component('requirementview', RequirementView);
-Vue.component('dropdownarrow', DropDownArrow);
 Vue.use(VueCollapse);
 
 export type ShowAllCourses = {
@@ -116,7 +108,7 @@ tour.setOption('nextLabel', 'Next');
 tour.setOption('exitOnOverlayClick', 'false');
 
 export default Vue.extend({
-  components: { draggable },
+  components: { draggable, Course, DropDownArrow },
   props: {
     semesters: Array as PropType<readonly FirestoreSemester[]>,
     onboardingData: Object as PropType<AppOnboardingData>,

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -3,7 +3,7 @@
     <div class="row depth-req">
       <div class="col-1" @click="toggleDescription()">
         <button class="btn">
-          <dropdownarrow :isFlipped="displayDescription" :fillColor="getArrowColor()" />
+          <drop-down-arrow :isFlipped="displayDescription" :fillColor="getArrowColor()" />
         </button>
       </div>
       <div class="col-7" @click="toggleDescription()">
@@ -78,7 +78,6 @@
         <div v-for="(subReqCourseSlot, id) in subReqCoursesArray" :key="id">
           <div v-if="subReqCourseSlot.isCompleted" class="completedsubreqcourse-wrapper">
             <completedsubreqcourse
-              :subReq="subReq"
               :subReqCourseId="id"
               :crsesTaken="subReqCourseSlot.courses"
               :semesters="semesters"
@@ -120,12 +119,10 @@ import {
 } from '@/requirements/types';
 import { clickOutside } from '@/utilities';
 
-import { FirestoreSemester, FirestoreSemesterCourse } from '@/user-data';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
 
 Vue.component('completedsubreqcourse', CompletedSubReqCourse);
 Vue.component('incompletesubreqcourse', IncompleteSubReqCourse);
-Vue.component('dropdownarrow', DropDownArrow);
 
 require('firebase/functions');
 
@@ -139,19 +136,17 @@ type Data = {
 };
 
 export default Vue.extend({
+  components: { DropDownArrow },
   props: {
-    subReq: Object as PropType<DisplayableRequirementFulfillment>,
-    subReqIndex: Number, // Subrequirement index
-    reqIndex: Number, // Requirement index
-    isCompleted: Boolean,
-    toggleableRequirementChoice: {
-      type: String,
-      required: false,
-    },
-    color: String,
-    rostersFromLastTwoYears: Array as PropType<readonly string[]>,
-    lastLoadedShowAllCourseId: Number,
-    semesters: Array as PropType<readonly FirestoreSemester[]>,
+    subReq: { type: Object as PropType<DisplayableRequirementFulfillment>, required: true },
+    subReqIndex: { type: Number, required: true }, // Subrequirement index
+    reqIndex: { type: Number, required: true }, // Requirement index
+    isCompleted: { type: Boolean, required: true },
+    toggleableRequirementChoice: { type: String, default: null },
+    color: { type: String, required: true },
+    rostersFromLastTwoYears: { type: Array as PropType<readonly string[]>, required: true },
+    lastLoadedShowAllCourseId: { type: Number, required: true },
+    semesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
   },
   watch: {
     subReqCoursesArray: {

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -15,23 +15,23 @@
       :class="{ 'confirmation-modal--flex': isConfirmationOpen }"
       :text="confirmationText"
     />
-    <deletesemester
+    <delete-semester
       class="semester-modal"
       :class="{ 'modal--block': isDeleteSemesterOpen }"
       @delete-semester="deleteSemester"
       @close-delete-modal="closeDeleteModal"
-      :deleteSemType="deleteSemType"
-      :deleteSemYear="deleteSemYear"
+      :deleteSemType="type"
+      :deleteSemYear="year"
       ref="deletesemester"
     />
-    <editsemester
+    <edit-semester
       class="semester-modal"
       :class="{ 'modal--block': isEditSemesterOpen }"
       @edit-semester="editSemester"
       @close-edit-modal="closeEditModal"
       :semesters="semesters"
-      :deleteSemType="deleteSemType"
-      :deleteSemYear="deleteSemYear"
+      :deleteSemType="type"
+      :deleteSemYear="year"
       ref="modalBodyComponent"
     />
     <button
@@ -99,14 +99,14 @@
             />
           </div>
         </draggable>
-        <addcoursebutton
+        <add-course-button
           :compact="compact"
           :shouldShowWalkthrough="true"
           @click="openCourseModal"
         />
       </div>
     </div>
-    <semestermenu
+    <semester-menu
       v-if="semesterMenuOpen"
       class="semester-menu"
       @open-delete-semester-modal="openDeleteSemesterModal"
@@ -129,7 +129,6 @@ import EditSemester from '@/components/Modals/EditSemester.vue';
 import AddCourseButton from '@/components/AddCourseButton.vue';
 
 import { clickOutside } from '@/utilities';
-import { FirestoreSemester, FirestoreSemesterCourse, CornellCourseRosterCourse } from '@/user-data';
 import { SingleMenuRequirement } from '@/requirements/types';
 
 import fall from '@/assets/images/fallEmoji.svg';
@@ -138,13 +137,7 @@ import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
 
-Vue.component('course', Course);
 Vue.component('new-course-modal', NewCourseModal);
-Vue.component('confirmation', Confirmation);
-Vue.component('semestermenu', SemesterMenu);
-Vue.component('deletesemester', DeleteSemester);
-Vue.component('editsemester', EditSemester);
-Vue.component('addcoursebutton', AddCourseButton);
 
 const pageTour = introJs();
 pageTour.setOption('exitOnEsc', 'false');
@@ -154,7 +147,15 @@ pageTour.setOption('nextLabel', 'Next');
 pageTour.setOption('exitOnOverlayClick', 'false');
 
 export default Vue.extend({
-  components: { draggable },
+  components: {
+    draggable,
+    AddCourseButton,
+    Confirmation,
+    Course,
+    DeleteSemester,
+    EditSemester,
+    SemesterMenu,
+  },
   data() {
     return {
       confirmationText: '',
@@ -163,8 +164,6 @@ export default Vue.extend({
       semesterMenuOpen: false,
       stopCloseFlag: false,
 
-      deleteSemType: '',
-      deleteSemYear: 0,
       isDeleteSemesterOpen: false,
       isEditSemesterOpen: false,
       isShadow: false,
@@ -438,8 +437,6 @@ export default Vue.extend({
       }
     },
     openDeleteSemesterModal() {
-      this.deleteSemType = this.type;
-      this.deleteSemYear = this.year;
       this.isDeleteSemesterOpen = true;
     },
     deleteSemester(type: string, year: string) {
@@ -447,9 +444,6 @@ export default Vue.extend({
       this.openConfirmationModal(`Deleted ${type} ${year} from plan`);
     },
     openEditSemesterModal() {
-      this.deleteSemType = this.type;
-      this.deleteSemYear = this.year;
-
       this.isEditSemesterOpen = true;
     },
     editSemester(seasonInput: 'Fall' | 'Spring' | 'Winter' | 'Summer', yearInput: number) {

--- a/src/components/Semester/SemesterCaution.vue
+++ b/src/components/Semester/SemesterCaution.vue
@@ -16,7 +16,7 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    text: String,
+    text: { type: String, required: true },
   },
 
   computed: {

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -94,26 +94,17 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import Course from '@/components/Course.vue';
 import Semester from '@/components/Semester/Semester.vue';
 import Confirmation from '@/components/Confirmation.vue';
 import SemesterCaution from '@/components/Semester/SemesterCaution.vue';
 import NewSemesterModal from '@/components/Modals/NewSemesterModal.vue';
-import DeleteSemester from '@/components/Modals/DeleteSemester.vue';
-import EditSemester from '@/components/Modals/EditSemester.vue';
 
 import { semestersCollection } from '@/firebaseConfig';
-import { FirestoreSemester, FirestoreSemesterCourse, FirestoreSemesterType } from '@/user-data';
 import { SingleMenuRequirement } from '@/requirements/types';
 import store from '@/store';
 
-Vue.component('course', Course);
 Vue.component('semester', Semester);
-Vue.component('confirmation', Confirmation);
-Vue.component('semester-caution', SemesterCaution);
 Vue.component('new-semester-modal', NewSemesterModal);
-Vue.component('deletesemester', DeleteSemester);
-Vue.component('editsemester', EditSemester);
 
 // enum to define seasons as integers in season order
 const SeasonsEnum = Object.freeze({
@@ -124,6 +115,7 @@ const SeasonsEnum = Object.freeze({
 });
 
 export default Vue.extend({
+  components: { Confirmation, SemesterCaution },
   props: {
     semesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
     compact: { type: Boolean, required: true },

--- a/src/containers/404.vue
+++ b/src/containers/404.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="body-container">
-      <topbar />
+      <top-bar />
       <div class="message-container">
         <img class="img-404" src="@/assets/images/404.svg" alt="404" />
         <div class="oops-wrapper">
@@ -26,13 +26,12 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import Footer from '@/components/Footer.vue';
+import CustomFooter from '@/components/Footer.vue';
 import TopBar from '@/components/TopBar.vue';
 
-Vue.component('custom-footer', Footer);
-Vue.component('topbar', TopBar);
-
-export default Vue.extend({});
+export default Vue.extend({
+  components: { CustomFooter, TopBar },
+});
 </script>
 
 <style scoped lang="scss">

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -11,7 +11,7 @@
     />
     <div class="dashboard-mainView">
       <div class="dashboard-menus">
-        <navbar
+        <nav-bar
           class="dashboard-nav"
           @editProfile="editProfile"
           @toggleRequirementsBar="toggleRequirementsBar"
@@ -45,7 +45,7 @@
         @close-bar="closeBar"
       />
     </div>
-    <tourwindow
+    <tour-window
       :title="welcome"
       :text="welcomeBodytext"
       :exit="welcomeExit"
@@ -57,8 +57,8 @@
       @skip="welcomeHidden = false"
       v-if="welcomeHidden"
     >
-    </tourwindow>
-    <tourwindow
+    </tour-window>
+    <tour-window
       :title="congrats"
       :text="congratsBodytext"
       :exit="congratsExit"
@@ -66,9 +66,9 @@
       @hide="showTourEndWindow = false"
       v-if="showTourEndWindow"
     >
-    </tourwindow>
+    </tour-window>
     <div>
-      <bottombar
+      <bottom-bar
         v-if="bottomCourses.length > 0 && ((!isOpeningRequirements && isTablet) || !isTablet)"
         :bottomCourses="bottomCourses"
         :seeMoreCourses="seeMoreCourses"
@@ -87,7 +87,6 @@
 import Vue from 'vue';
 
 import introJs from 'intro.js';
-import Course from '@/components/Course.vue';
 import SemesterView from '@/components/Semester/SemesterView.vue';
 import Requirements from '@/components/Requirements/Requirements.vue';
 import BottomBar from '@/components/BottomBar/BottomBar.vue';
@@ -97,13 +96,6 @@ import TourWindow from '@/components/Modals/TourWindow.vue';
 
 import surfing from '@/assets/images/surfing.svg';
 
-import {
-  FirestoreUserName,
-  FirestoreSemester,
-  AppOnboardingData,
-  AppBottomBarCourse,
-  FirestoreSemesterCourse,
-} from '@/user-data';
 import computeRequirements from '@/requirements/reqs-functions';
 import { CourseTaken, SingleMenuRequirement } from '@/requirements/types';
 import getCourseEquivalentsFromUserExams from '@/requirements/data/exams/ExamCredit';
@@ -111,13 +103,8 @@ import store, { initializeFirestoreListeners, subscribeRequirementDependencyChan
 import { semestersCollection } from '@/firebaseConfig';
 import getCurrentSeason, { getCurrentYear } from '@/utilities';
 
-Vue.component('course', Course);
 Vue.component('semesterview', SemesterView);
 Vue.component('requirements', Requirements);
-Vue.component('bottombar', BottomBar);
-Vue.component('navbar', NavBar);
-Vue.component('onboarding', Onboarding);
-Vue.component('tourwindow', TourWindow);
 
 const tour = introJs();
 tour.setOption('exitOnEsc', 'false');
@@ -130,6 +117,7 @@ tour.setOption('exitOnOverlayClick', 'false');
 let listenerUnsubscriber = (): void => {};
 
 export default Vue.extend({
+  components: { BottomBar, NavBar, Onboarding, TourWindow },
   data() {
     return {
       loaded: true,

--- a/src/containers/Login.vue
+++ b/src/containers/Login.vue
@@ -8,7 +8,7 @@
 
     <div class="landing">
       <!--TOP BAR-->
-      <topbar />
+      <top-bar />
 
       <!--PLAN AHEAD-->
       <div class="container p-0 m-0">
@@ -172,13 +172,10 @@
 import Vue from 'vue';
 import firebase from 'firebase/app';
 
-import Footer from '@/components/Footer.vue';
+import CustomFooter from '@/components/Footer.vue';
 import TopBar from '@/components/TopBar.vue';
 
 import * as fb from '@/firebaseConfig';
-
-Vue.component('custom-footer', Footer);
-Vue.component('topbar', TopBar);
 
 const { whitelistCollection, landingEmailsCollection } = fb;
 
@@ -190,6 +187,7 @@ type Data = {
 };
 
 export default Vue.extend({
+  components: { CustomFooter, TopBar },
   data(): Data {
     return {
       loginForm: {

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -2,12 +2,6 @@ import firebase from 'firebase/app';
 
 import 'firebase/auth';
 import 'firebase/firestore';
-import type {
-  FirestoreUserName,
-  FirestoreSemester,
-  AppToggleableRequirementChoices,
-  FirestoreOnboardingUserData,
-} from './user-data';
 
 let config;
 if (process.env.VUE_APP_FIREBASE_MODE === 'prod') {

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -8,7 +8,6 @@ import {
   uniqueIncrementerCollection,
 } from './firebaseConfig';
 import store from './store';
-import { AppToggleableRequirementChoices } from './user-data';
 
 export const chooseToggleableRequirementOption = (
   toggleableRequirementChoices: AppToggleableRequirementChoices

--- a/src/requirements/data/exams/ExamCredit.ts
+++ b/src/requirements/data/exams/ExamCredit.ts
@@ -1,4 +1,3 @@
-import { AppOnboardingData, FirestoreAPIBExam } from '../../../user-data';
 import { CourseTaken } from '../../types';
 
 export type ExamRequirements = {

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -1,4 +1,4 @@
-import store from '@/store';
+import store from '../store';
 import buildRequirementFulfillmentGraphFromUserData from './requirement-graph-builder-from-user-data';
 import {
   CourseTaken,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,7 +4,7 @@ import Router from 'vue-router';
 import Login from '@/containers/Login.vue';
 import Dashboard from '@/containers/Dashboard.vue';
 import Page404 from '@/containers/404.vue';
-import store from '@/store';
+import store from '../store';
 
 Vue.use(Router);
 

--- a/src/skeleton-loader-vue.d.ts
+++ b/src/skeleton-loader-vue.d.ts
@@ -1,1 +1,6 @@
-declare module 'skeleton-loader-vue';
+declare module 'skeleton-loader-vue' {
+  import { Vue, VueConstructor } from 'vue/types/vue';
+
+  const VueSkeletonLoader: VueConstructor<Vue>;
+  export default VueSkeletonLoader;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,12 +2,6 @@ import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
 
 import * as fb from './firebaseConfig';
-import {
-  AppOnboardingData,
-  AppToggleableRequirementChoices,
-  FirestoreOnboardingUserData,
-  FirestoreUserName,
-} from './user-data';
 import { checkNotNull } from './utilities';
 
 Vue.use(Vuex);

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -1,5 +1,4 @@
 import { getOrAllocateSubjectColor, incrementUniqueID } from './global-firestore-data';
-import { CornellCourseRosterCourse, FirestoreSemesterCourse } from './user-data';
 
 /**
  * Creates credit range based on course

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -2,13 +2,13 @@
 // - all the types describing data in Firestore is prefixed with Firestore.
 // - all the data describing data converted from Firestore to be used by the app is prefixed with App.
 
-export type FirestoreUserName = {
+type FirestoreUserName = {
   readonly firstName: string;
   readonly middleName?: string;
   readonly lastName: string;
 };
 
-export type FirestoreSemesterCourse = {
+type FirestoreSemesterCourse = {
   readonly crseId: number;
   readonly lastRoster: string;
   readonly uniqueID: number;
@@ -26,25 +26,25 @@ export type FirestoreSemesterCourse = {
   readonly color: string;
 };
 
-export type FirestoreSemesterType = 'Fall' | 'Spring' | 'Summer' | 'Winter';
-export type FirestoreSemester = {
+type FirestoreSemesterType = 'Fall' | 'Spring' | 'Summer' | 'Winter';
+type FirestoreSemester = {
   readonly year: number;
   readonly type: FirestoreSemesterType;
   readonly courses: readonly FirestoreSemesterCourse[];
 };
 
-export type FirestoreCollegeOrMajorOrMinor = { readonly acronym: string };
-export type FirestoreAPIBExam = {
+type FirestoreCollegeOrMajorOrMinor = { readonly acronym: string };
+type FirestoreAPIBExam = {
   readonly type: 'AP' | 'IB';
   readonly score: number;
   readonly subject: string;
 };
-export type FirestoreTransferClass = {
+type FirestoreTransferClass = {
   readonly class: string;
   readonly course: CornellCourseRosterCourse;
   readonly credits: number;
 };
-export type FirestoreOnboardingUserData = {
+type FirestoreOnboardingUserData = {
   readonly class: readonly FirestoreTransferClass[];
   readonly colleges: readonly FirestoreCollegeOrMajorOrMinor[];
   readonly majors: readonly FirestoreCollegeOrMajorOrMinor[];
@@ -53,7 +53,7 @@ export type FirestoreOnboardingUserData = {
   readonly tookSwim: 'yes' | 'no';
 };
 
-export type FirestoreUserData = {
+type FirestoreUserData = {
   readonly name: FirestoreUserName;
   readonly semesters: readonly FirestoreSemester[];
   readonly toggleableRequirementChoices: AppToggleableRequirementChoices;
@@ -62,7 +62,7 @@ export type FirestoreUserData = {
   readonly userData: FirestoreOnboardingUserData;
 };
 
-export type CornellCourseRosterCourse = {
+type CornellCourseRosterCourse = {
   readonly crseId: number;
   readonly subject: string;
   readonly catalogNbr: string;
@@ -91,7 +91,7 @@ export type CornellCourseRosterCourse = {
   readonly roster: string;
 };
 
-export type AppOnboardingData = {
+type AppOnboardingData = {
   readonly college: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];
@@ -100,7 +100,7 @@ export type AppOnboardingData = {
   readonly tookSwim: 'yes' | 'no';
 };
 
-export type AppBottomBarCourse = {
+type AppBottomBarCourse = {
   readonly subject: string;
   readonly number: string;
   readonly name: string;
@@ -121,4 +121,4 @@ export type AppBottomBarCourse = {
 };
 
 // map from requirement ID to option chosen
-export type AppToggleableRequirementChoices = Readonly<Record<string, string>>;
+type AppToggleableRequirementChoices = Readonly<Record<string, string>>;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,4 +1,3 @@
-import type { FirestoreSemesterType } from './user-data';
 import requirementJSON from './requirements/typed-requirement-json';
 
 export function checkNotNull<T>(value: T | null | undefined): T {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -13,5 +13,5 @@
     "strict": true,
     "target": "es2015"
   },
-  "include": ["src/requirements/"]
+  "include": ["src/"]
 }


### PR DESCRIPTION
### Summary <!-- Required -->

Cleanup vue components by

- Declaring each component prop as required or give it a default value
- Declare components in `components: {...}`, instead of `Vue.component('name', Component)`. This gives better type-checking and autocompletion.

Unfortunately, the Vuetr plugin has [a bug](https://github.com/vuejs/vetur/issues/2344) with imported types in props. Therefore, I have to make all the common types global. 

### Test Plan <!-- Required -->

Move around the app and see no warnings in console.