### PR TITLE
Add semesters data to global store

### DIFF
--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -40,11 +40,11 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
+import store from '@/store';
 
 export default Vue.extend({
   components: { NewSemester },
   props: {
-    semesters: Array as PropType<readonly FirestoreSemester[]>,
     deleteSemType: { type: String as PropType<FirestoreSemesterType>, required: true },
     deleteSemYear: { type: Number, required: true },
   },
@@ -54,6 +54,11 @@ export default Vue.extend({
       season: '',
       year: '',
     };
+  },
+  computed: {
+    semesters(): readonly FirestoreSemester[] {
+      return store.state.semesters;
+    },
   },
   methods: {
     closeCurrentModal() {

--- a/src/components/Modals/NewSemesterModal.vue
+++ b/src/components/Modals/NewSemesterModal.vue
@@ -10,7 +10,7 @@
     @right-button-clicked="addSemester"
   >
     <new-semester
-      :currentSemesters="currentSemesters"
+      :currentSemesters="semesters"
       :isEdit="false"
       :isCourseModelSelectingSemester="false"
       @duplicateSemester="disableButton"
@@ -21,17 +21,20 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import Vue from 'vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
 import FlexibleModal from '@/components/Modals/FlexibleModal.vue';
+import store from '@/store';
 
 export default Vue.extend({
   components: { FlexibleModal, NewSemester },
   data() {
     return { isDisabled: false, season: '', year: 0 };
   },
-  props: {
-    currentSemesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
+  computed: {
+    semesters(): readonly FirestoreSemester[] {
+      return store.state.semesters;
+    },
   },
   methods: {
     disableButton(disabled: boolean) {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -37,6 +37,7 @@
 import Vue, { PropType } from 'vue';
 import ReqCourse from '@/components/Requirements/ReqCourse.vue';
 import { CourseTaken } from '@/requirements/types';
+import store from '@/store';
 
 type CompletedSubReq = {
   color: string;
@@ -54,7 +55,6 @@ export default Vue.extend({
   props: {
     subReqCourseId: { type: Number, required: true },
     crsesTaken: { type: Array as PropType<readonly CourseTaken[]>, required: true },
-    semesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
   },
   data(): CompletedSubReq {
     return {
@@ -78,6 +78,9 @@ export default Vue.extend({
     }
   },
   computed: {
+    semesters(): readonly FirestoreSemester[] {
+      return store.state.semesters;
+    },
     courseLabel() {
       return `Course ${this.subReqCourseId + 1}`;
     },

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -95,7 +95,7 @@ export default Vue.extend({
       type: Array as PropType<FirestoreSemesterCourse[]>,
       required: true,
     },
-    subReqCoursesArray: { type: Array as PropType<SubReqCourseSlot[]>, required: true },
+    subReqCoursesArray: { type: Array as PropType<readonly SubReqCourseSlot[]>, required: true },
     dataReady: { type: Boolean, required: true },
     displayDescription: { type: Boolean, required: true },
     lastLoadedShowAllCourseId: { type: Number, required: true },

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -29,7 +29,6 @@
             :isCompleted="false"
             :rostersFromLastTwoYears="rostersFromLastTwoYears"
             :lastLoadedShowAllCourseId="lastLoadedShowAllCourseId"
-            :semesters="semesters"
             @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
             @onShowAllCourses="onShowAllCourses"
             @deleteCourseFromSemesters="deleteCourseFromSemesters"
@@ -64,7 +63,6 @@
               :isCompleted="true"
               :rostersFromLastTwoYears="rostersFromLastTwoYears"
               :lastLoadedShowAllCourseId="lastLoadedShowAllCourseId"
-              :semesters="semesters"
               @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
               @onShowAllCourses="onShowAllCourses"
               @deleteCourseFromSemesters="deleteCourseFromSemesters"
@@ -85,6 +83,7 @@ import RequirementHeader from '@/components/Requirements/RequirementHeader.vue';
 import SubRequirement from '@/components/Requirements/SubRequirement.vue';
 
 import { SingleMenuRequirement } from '@/requirements/types';
+import store from '@/store';
 
 Vue.component('requirementheader', RequirementHeader);
 Vue.component('subrequirement', SubRequirement);
@@ -107,12 +106,10 @@ export default Vue.extend({
     },
     displayedMajorIndex: { type: Number, required: true },
     displayedMinorIndex: { type: Number, required: true },
-    onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
     showMajorOrMinorRequirements: { type: Boolean, required: true },
     numOfColleges: { type: Number, required: true },
     rostersFromLastTwoYears: { type: Array as PropType<readonly string[]>, required: true },
     lastLoadedShowAllCourseId: { type: Number, required: true },
-    semesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
   },
   data() {
     return {
@@ -121,6 +118,9 @@ export default Vue.extend({
     };
   },
   computed: {
+    onboardingData(): AppOnboardingData {
+      return store.state.onboardingData;
+    },
     reqGroupColorMap() {
       return reqGroupColorMap;
     },

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -18,12 +18,10 @@
           :toggleableRequirementChoices="toggleableRequirementChoices"
           :displayedMajorIndex="displayedMajorIndex"
           :displayedMinorIndex="displayedMinorIndex"
-          :onboardingData="onboardingData"
           :showMajorOrMinorRequirements="showMajorOrMinorRequirements(index, req.group)"
           :rostersFromLastTwoYears="rostersFromLastTwoYears"
           :numOfColleges="numOfColleges"
           :lastLoadedShowAllCourseId="lastLoadedShowAllCourseId"
-          :semesters="semesters"
           @changeToggleableRequirementChoice="chooseToggleableRequirementOption"
           @activateMajor="activateMajor"
           @activateMinor="activateMinor"
@@ -110,11 +108,8 @@ tour.setOption('exitOnOverlayClick', 'false');
 export default Vue.extend({
   components: { draggable, Course, DropDownArrow },
   props: {
-    semesters: Array as PropType<readonly FirestoreSemester[]>,
-    onboardingData: Object as PropType<AppOnboardingData>,
-    compact: Boolean,
-    startTour: Boolean,
-    reqs: Array as PropType<readonly SingleMenuRequirement[]>,
+    startTour: { type: Boolean, required: true },
+    reqs: { type: Array as PropType<readonly SingleMenuRequirement[]>, required: true },
   },
   data(): Data {
     return {
@@ -136,6 +131,12 @@ export default Vue.extend({
     },
   },
   computed: {
+    semesters(): readonly FirestoreSemester[] {
+      return store.state.semesters;
+    },
+    onboardingData(): AppOnboardingData {
+      return store.state.onboardingData;
+    },
     toggleableRequirementChoices(): AppToggleableRequirementChoices {
       return store.state.toggleableRequirementChoices;
     },

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -80,7 +80,6 @@
             <completedsubreqcourse
               :subReqCourseId="id"
               :crsesTaken="subReqCourseSlot.courses"
-              :semesters="semesters"
               @deleteCourseFromSemesters="deleteCourseFromSemesters"
             />
           </div>
@@ -146,7 +145,6 @@ export default Vue.extend({
     color: { type: String, required: true },
     rostersFromLastTwoYears: { type: Array as PropType<readonly string[]>, required: true },
     lastLoadedShowAllCourseId: { type: Number, required: true },
-    semesters: { type: Array as PropType<readonly FirestoreSemester[]>, required: true },
   },
   watch: {
     subReqCoursesArray: {

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -29,7 +29,6 @@
       :class="{ 'modal--block': isEditSemesterOpen }"
       @edit-semester="editSemester"
       @close-edit-modal="closeEditModal"
-      :semesters="semesters"
       :deleteSemType="type"
       :deleteSemYear="year"
       ref="modalBodyComponent"
@@ -187,7 +186,6 @@ export default Vue.extend({
     compact: Boolean,
     activatedCourse: Object as PropType<FirestoreSemesterCourse>,
     duplicatedCourseCodeList: Array as PropType<readonly string[]>,
-    semesters: Array as PropType<readonly FirestoreSemester[]>,
     isFirstSem: Boolean,
     reqs: Array as PropType<readonly SingleMenuRequirement[]>,
   },

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -3,11 +3,20 @@
  */
 
 import {
+  semestersCollection,
   toggleableRequirementChoicesCollection,
   subjectColorsCollection,
   uniqueIncrementerCollection,
 } from './firebaseConfig';
 import store from './store';
+
+export const editSemesters = (
+  updater: (oldSemesters: readonly FirestoreSemester[]) => readonly FirestoreSemester[]
+): void => {
+  const newSemesters = updater(store.state.semesters);
+  store.commit('setSemesters', newSemesters);
+  semestersCollection.doc(store.state.currentFirebaseUser.email).set({ semesters: newSemesters });
+};
 
 export const chooseToggleableRequirementOption = (
   toggleableRequirementChoices: AppToggleableRequirementChoices


### PR DESCRIPTION
### Summary <!-- Required -->

Unlike other data, we don't rely on real time listening here. It's because real time listening still has a delay, which makes drag and drop really wracky. Therefore, we still synchronously update the store and at the same time update firestore to make things consistent. However, with this setup we can now read semesters from everywhere!

Remaining TODOs:

Integrate requirement data into global store.

### Test Plan <!-- Required -->

- add/edit/remove semesters
- drag and drop courses
- open the requirement menu to check all courses are loaded