### PR TITLE
Unbreak course selector on certain classes

### DIFF
--- a/src/components/Modals/NewCourse/CourseSelector.vue
+++ b/src/components/Modals/NewCourse/CourseSelector.vue
@@ -13,7 +13,7 @@
     <div v-if="matches.length > 0" class="autocomplete-items">
       <div
         v-for="(matchingCourse, index) in matches"
-        :key="matchingCourse.id"
+        :key="index"
         v-bind:class="['search-result', currentFocus === index ? 'autocomplete-active' : '']"
         @click="selectCourse(matchingCourse)"
       >


### PR DESCRIPTION
### Summary <!-- Required -->

We should not use id as the key since courses might have the same id (e.g. crosslisted courses).

### Test Plan <!-- Required -->

Search wine in the add modal and it no longer errors in console.