### PR TITLE
[easy] Fix easy ts-ignore error on regex replace

### DIFF
--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -366,9 +366,9 @@ export default Vue.extend({
         matches = ['N/A'];
       } else {
         for (let i = 0; i < distributions.length; i += 1) {
-          // @ts-ignore
           distributions[i].replace(/[A-Za-z0-9-]+/g, d => {
             matches.push(d);
+            return d;
           });
         }
       }


### PR DESCRIPTION
### Summary <!-- Required -->

The typedef for the `replace` function excepts the replacer function to return a value.

<img width="630" alt="Screen Shot 2021-02-13 at 13 46 31" src="https://user-images.githubusercontent.com/4290500/107858421-00f55480-6e02-11eb-8f0d-b79f4b1e3f80.png">

This isn't useful for our case, but it's good to get rid of this @ts-ignore and one linter warning.

### Test Plan <!-- Required -->

CI, everything type checks