### PR TITLE
[easy] Remove the deprecated forcedReload argument

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -29,9 +29,7 @@ export default Vue.extend({
         .auth()
         .signOut()
         .then(
-          () => {
-            window.location.reload(false);
-          },
+          () => window.location.reload(),
           error => {
             // TODO: error
             console.log(error);


### PR DESCRIPTION
### Summary <!-- Required -->

<img width="968" alt="deprecated" src="https://user-images.githubusercontent.com/4290500/107859172-a5c56100-6e05-11eb-9068-286086ce5108.png">

It is deprecated, and according to https://stackoverflow.com/questions/55127650/location-reloadtrue-is-deprecated, we probably don't need it.

### Test Plan <!-- Required -->

👀 
