### PR TITLE
[easy] Strictify linter config from vue/essential to vue/recommended

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:vue/essential',
+    'plugin:vue/recommended',
     '@vue/airbnb',
     '@vue/typescript',
     'plugin:import/typescript',
@@ -27,6 +27,12 @@ module.exports = {
   // add your custom rules here
   rules: {
     '@typescript-eslint/ban-ts-comment': ['warn'],
+    'vue/attribute-hyphenation': ['off'],
+    // TODO: change when we migrated away all Vue.component('...', Component).
+    'vue/component-definition-name-casing': ['off'],
+    // TODO: auto-fix of this and the next rule introduces too many code changes that might cause merge conflict.
+    'vue/attributes-order': ['off'],
+    'vue/order-in-components': ['off'],
     // TODO: change no-console to error out for prod
     'no-console': ['warn'],
     'no-await-in-loop': ['error'],

--- a/src/components/AddCourseButton.vue
+++ b/src/components/AddCourseButton.vue
@@ -3,15 +3,15 @@
     class="semester-courseWrapper semester-addWrapper"
     :class="{ 'semester-addWrapper--compact': compact, 'my-2 mx-0': shouldClearPadding }"
     @click="onClick"
-    v-bind:data-intro-group="shouldShowWalkthrough ? 'pageTour' : null"
-    v-bind:data-step="shouldShowWalkthrough ? '3' : null"
-    v-bind:data-intro="
+    :data-intro-group="shouldShowWalkthrough ? 'pageTour' : null"
+    :data-step="shouldShowWalkthrough ? '3' : null"
+    :data-intro="
       shouldShowWalkthrough
         ? `<b>Add your course in this semester!</b><br>
       <div class = &quot;introjs-bodytext&quot;>To start planning your college career, you should try adding a course in your current semester.</div>`
         : null
     "
-    v-bind:data-disable-interaction="shouldShowWalkthrough ? '1' : null"
+    :data-disable-interaction="shouldShowWalkthrough ? '1' : null"
   >
     <span class="semester-buttonText" :class="{ 'semester-buttonText--compact': compact }">
       {{ addCourseText }}

--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -35,11 +35,11 @@ import BottomBarTitle from '@/components/BottomBar/BottomBarTitle.vue';
 export default Vue.extend({
   components: { BottomBarCourse, BottomBarTabView, BottomBarTitle },
   props: {
-    bottomCourses: Array as PropType<AppBottomBarCourse[]>,
-    seeMoreCourses: Array as PropType<AppBottomBarCourse[]>,
-    bottomCourseFocus: Number,
-    isExpanded: Boolean,
-    maxBottomBarTabs: Number,
+    bottomCourses: { type: Array as PropType<AppBottomBarCourse[]>, required: true },
+    seeMoreCourses: { type: Array as PropType<AppBottomBarCourse[]>, required: true },
+    bottomCourseFocus: { type: Number, required: true },
+    isExpanded: { type: Boolean, required: true },
+    maxBottomBarTabs: { type: Number, required: true },
   },
 
   methods: {

--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bottombar">
     <div class="bottombar-tabviewTitleWrapper">
-      <div class="bottombar-tabview" v-bind:class="{ expandedTabView: isExpanded }">
+      <div class="bottombar-tabview" :class="{ expandedTabView: isExpanded }">
         <bottom-bar-tab-view
           :bottomCourses="bottomCourses"
           :seeMoreCourses="seeMoreCourses"

--- a/src/components/BottomBar/BottomBarTitle.vue
+++ b/src/components/BottomBar/BottomBarTitle.vue
@@ -2,7 +2,7 @@
   <div
     class="bottombartitle"
     :style="{ background: `#${color}` }"
-    v-bind:class="{ expandedBottomBarTitle: isExpanded }"
+    :class="{ expandedBottomBarTitle: isExpanded }"
   >
     <div class="bottombar-square-title">{{ name }}</div>
     <img

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -51,11 +51,11 @@ export default Vue.extend({
   components: { CourseCaution, CourseMenu },
   props: {
     courseObj: { type: Object as PropType<FirestoreSemesterCourse>, required: true },
-    duplicatedCourseCodeList: { type: Array, required: false },
+    duplicatedCourseCodeList: { type: Array, required: false, default: null },
     compact: { type: Boolean, required: true },
     active: { type: Boolean, required: true },
     isReqCourse: { type: Boolean, required: true },
-    semesterIndex: { type: Number, required: false },
+    semesterIndex: { type: Number, required: false, default: 0 },
   },
   data() {
     return {

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -38,7 +38,7 @@
         class="courseMenu-section"
         @mouseover="setDisplayEditCourseCredits(true)"
         @mouseleave="setDisplayEditCourseCredits(false)"
-        v-if="this.getCreditRange[0] != this.getCreditRange[1]"
+        v-if="getCreditRange[0] != getCreditRange[1]"
       >
         <img v-if="isLeft" class="courseMenu-arrow" src="@/assets/images/sidearrowleft.svg" />
         <div class="courseMenu-left">

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -87,9 +87,12 @@ import { coursesColorSet } from '@/assets/constants/colors';
 
 export default Vue.extend({
   props: {
-    getCreditRange: (Array as PropType<readonly number[]>) as PropType<readonly [number, number]>,
-    semesterIndex: Number,
-    isCompact: Boolean,
+    getCreditRange: {
+      type: (Array as PropType<readonly number[]>) as PropType<readonly [number, number]>,
+      required: true,
+    },
+    semesterIndex: { type: Number, required: true },
+    isCompact: { type: Boolean, required: true },
   },
   data() {
     return {

--- a/src/components/Modals/DeleteSemester.vue
+++ b/src/components/Modals/DeleteSemester.vue
@@ -36,8 +36,8 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    deleteSemType: String,
-    deleteSemYear: Number,
+    deleteSemType: { type: String, required: true },
+    deleteSemYear: { type: Number, required: true },
   },
 
   computed: {

--- a/src/components/Modals/FlexibleModal.vue
+++ b/src/components/Modals/FlexibleModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="modal">
-    <div v-bind:class="['modal-content', contentClass]">
+    <div :class="['modal-content', contentClass]">
       <div class="modal-top">
         <span class="modal-title">{{ title }}</span>
         <img class="modal-exit" src="@/assets/images/x.png" @click="closeCurrentModal" />

--- a/src/components/Modals/NewCourse/CourseSelector.vue
+++ b/src/components/Modals/NewCourse/CourseSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="autocomplete">
     <input
-      v-bind:class="['search-box', searchBoxClassName]"
+      :class="['search-box', searchBoxClassName]"
       ref="dropdownInput"
       v-model="searchText"
       :placeholder="placeholder"
@@ -14,7 +14,7 @@
       <div
         v-for="(matchingCourse, index) in matches"
         :key="index"
-        v-bind:class="['search-result', currentFocus === index ? 'autocomplete-active' : '']"
+        :class="['search-result', currentFocus === index ? 'autocomplete-active' : '']"
         @click="selectCourse(matchingCourse)"
       >
         {{ matchingCourse.title }}

--- a/src/components/Modals/NewCourse/EditSingleRequirement.vue
+++ b/src/components/Modals/NewCourse/EditSingleRequirement.vue
@@ -21,9 +21,9 @@ import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    name: String,
-    selected: Boolean,
-    isClickable: Boolean,
+    name: { type: String, required: true },
+    selected: { type: Boolean, required: true },
+    isClickable: { type: Boolean, required: true },
   },
   data() {
     return {

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -6,7 +6,7 @@
           >Type</label
         >
         <div
-          v-bind:class="[{ duplicate: isDuplicate() }, { 'newSemester-select': !isDuplicate() }]"
+          :class="[{ duplicate: isDuplicate() }, { 'newSemester-select': !isDuplicate() }]"
           class="position-relative"
           v-click-outside="closeSeasonDropdownIfOpen"
         >
@@ -30,13 +30,13 @@
             v-if="displayOptions.season.shown"
           >
             <div
-              v-bind:class="{ warning: isDuplicate }"
+              :class="{ warning: isDuplicate }"
               v-for="season in seasons"
               :key="season[1]"
               class="newSemester-dropdown-content-item"
               @click="selectSeason(season[1])"
             >
-              <img v-bind:src="season[0]" class="newSemester-dropdown-content-season" />
+              <img :src="season[0]" class="newSemester-dropdown-content-season" />
               {{ season[1] }}
             </div>
           </div>
@@ -47,7 +47,7 @@
           >Year</label
         >
         <div
-          v-bind:class="[{ duplicate: isDuplicate() }, { 'newSemester-select': !isDuplicate() }]"
+          :class="[{ duplicate: isDuplicate() }, { 'newSemester-select': !isDuplicate() }]"
           class="position-relative"
           v-click-outside="closeYearDropdownIfOpen"
         >
@@ -68,12 +68,12 @@
             v-if="displayOptions.year.shown"
           >
             <div
-              v-for="year in years"
-              :key="year"
+              v-for="yearChoice in years"
+              :key="yearChoice"
               class="newSemester-dropdown-content-item"
-              @click="selectYear(year)"
+              @click="selectYear(yearChoice)"
             >
-              {{ year }}
+              {{ yearChoice }}
             </div>
           </div>
         </div>

--- a/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
@@ -26,9 +26,12 @@ export default Vue.extend({
   components: { OnboardingBasicSingleDropdown },
   props: {
     /** Mapping from acronym to full name */
-    availableChoices: Object as PropType<Readonly<Record<string, string>>>,
-    dropdownChoices: Array as PropType<readonly string[]>,
-    addDropdownText: String,
+    availableChoices: {
+      type: Object as PropType<Readonly<Record<string, string>>>,
+      required: true,
+    },
+    dropdownChoices: { type: Array as PropType<readonly string[]>, required: true },
+    addDropdownText: { type: String, required: true },
   },
   methods: {
     onSelect(key: string, index: number) {

--- a/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
@@ -51,9 +51,12 @@ import { inactiveGray, yuxuanBlue, lightPlaceholderGray } from '@/assets/scss/_v
 export default Vue.extend({
   props: {
     /** Mapping from acronym to full name */
-    availableChoices: Object as PropType<Readonly<Record<string, string>>>,
-    choice: String,
-    cannotBeRemoved: Boolean,
+    availableChoices: {
+      type: Object as PropType<Readonly<Record<string, string>>>,
+      required: true,
+    },
+    choice: { type: String, required: true },
+    cannotBeRemoved: { type: Boolean, required: true },
   },
   data() {
     return {

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -79,7 +79,7 @@
           <div class="onboarding-selectWrapper-review">
             <label class="onboarding-label">
               <img class="checkmark" src="@/assets/images/checkmark-onboarding.svg" />
-              {{ this.onboardingData.tookSwim === 'yes' ? 'Yes' : 'No' }}
+              {{ onboardingData.tookSwim === 'yes' ? 'Yes' : 'No' }}
             </label>
           </div>
         </div>

--- a/src/components/Modals/Onboarding/OnboardingTransferExamPropertyDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransferExamPropertyDropdown.vue
@@ -23,12 +23,12 @@
       </div>
       <div class="onboarding-dropdown-content college-content" v-if="shown">
         <div
-          v-for="(choice, index) in availableOptions"
+          v-for="(option, index) in availableOptions"
           :key="index"
           class="onboarding-dropdown-content-item"
-          @click="selectChoice(choice)"
+          @click="selectChoice(option)"
         >
-          {{ choice }}
+          {{ option }}
         </div>
       </div>
     </div>

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -44,8 +44,8 @@
               :style="{ color: `#${reqGroupColorMap[req.group][0]}` }"
             >
               <!-- Toggle to display completed reqs -->
-              <p class="toggle" v-if="displayCompleted" v-on:click="turnCompleted(false)">HIDE</p>
-              <p class="toggle" v-else v-on:click="turnCompleted(true)">SHOW</p>
+              <p class="toggle" v-if="displayCompleted" @click="turnCompleted(false)">HIDE</p>
+              <p class="toggle" v-else @click="turnCompleted(true)">SHOW</p>
             </button>
           </div>
         </div>

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -8,30 +8,27 @@
       </div>
       <div class="col-7" @click="toggleDescription()">
         <p
-          v-bind:class="[
-            { 'sup-req': !this.isFulfilled },
+          :class="[
+            { 'sup-req': !isFulfilled },
             'pointer',
-            this.isFulfilled ? 'completed-ptext' : 'incomplete-ptext',
+            isFulfilled ? 'completed-ptext' : 'incomplete-ptext',
           ]"
         >
           <span>{{ subReq.requirement.name }}</span>
         </p>
       </div>
       <div class="col">
-        <p v-if="!this.isCompleted" class="sup-req-progress text-right incomplete-ptext">
+        <p v-if="!isCompleted" class="sup-req-progress text-right incomplete-ptext">
           {{ subReqProgress }}
         </p>
-        <p v-if="this.isFulfilled" class="text-right completed-ptext">
+        <p v-if="isFulfilled" class="text-right completed-ptext">
           <span
             >{{ subReq.minCountFulfilled }}/{{ subReq.minCountRequired }}
             {{ subReq.fulfilledBy }}</span
           >
         </p>
       </div>
-      <div
-        v-if="displayDescription"
-        :class="[{ 'completed-ptext': this.isFulfilled }, 'description']"
-      >
+      <div v-if="displayDescription" :class="[{ 'completed-ptext': isFulfilled }, 'description']">
         {{ subReq.requirement.description }}
         <a
           class="more"
@@ -70,7 +67,7 @@
                 <span>{{ optionName }}</span>
               </div>
             </div>
-            {{ this.subReq.requirement.fulfillmentOptions[selectedFulfillmentOption].description }}
+            {{ subReq.requirement.fulfillmentOptions[selectedFulfillmentOption].description }}
           </div>
         </div>
       </div>

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -179,15 +179,15 @@ export default Vue.extend({
     };
   },
   props: {
-    semesterIndex: Number,
-    type: String as PropType<'Fall' | 'Spring' | 'Winter' | 'Summer'>,
-    year: Number,
-    courses: Array as PropType<readonly FirestoreSemesterCourse[]>,
-    compact: Boolean,
-    activatedCourse: Object as PropType<FirestoreSemesterCourse>,
-    duplicatedCourseCodeList: Array as PropType<readonly string[]>,
-    isFirstSem: Boolean,
-    reqs: Array as PropType<readonly SingleMenuRequirement[]>,
+    semesterIndex: { type: Number, required: true },
+    type: { type: String as PropType<'Fall' | 'Spring' | 'Winter' | 'Summer'>, required: true },
+    year: { type: Number, required: true },
+    courses: { type: Array as PropType<readonly FirestoreSemesterCourse[]>, required: true },
+    compact: { type: Boolean, required: true },
+    activatedCourse: { type: Object as PropType<FirestoreSemesterCourse>, required: true },
+    duplicatedCourseCodeList: { type: Array as PropType<readonly string[]>, required: true },
+    isFirstSem: { type: Boolean, required: true },
+    reqs: { type: Array as PropType<readonly SingleMenuRequirement[]>, required: true },
   },
   mounted() {
     this.$el.addEventListener('touchmove', this.dragListener, { passive: false });

--- a/src/containers/Login.vue
+++ b/src/containers/Login.vue
@@ -154,7 +154,7 @@
               />
             </div>
             <div class="col-12 col-md-12 email">
-              <button class="email-button" variant="primary" v-on:click="addUser()">
+              <button class="email-button" variant="primary" @click="addUser()">
                 Join Waitlist
               </button>
             </div>


### PR DESCRIPTION
### Summary <!-- Required -->

This PR strictifies linter config from `vue/essential` to `vue/recommended`. It results in the additional "strongly recommended" and "recommended" rules that you can see here: https://eslint.vuejs.org/rules/.

The fix in this PR is auto generated by `npm run lint`. Here is a list of issues fixed.

- `v-bind:xxx="..."` to `:xxx="..."` shorthand
- `v-on:click="..."` to `@click="..."` shorthand
- No `this` in templates.

This PR also adds two v-html warnings. They should be fixed later (opportunity for someone else to get cleanup credit), since they allow XSS attack. Once they are fixed, the linter level should be turned to error to ensure we don't do this again.

Depends on #287.

### Test Plan <!-- Required -->

CI