### PR TITLE
Cleanup requirement computation

### DIFF
--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -60,7 +60,7 @@ import Vue, { PropType } from 'vue';
 import SelectedRequirementEditor, {
   RequirementWithID,
 } from '@/components/Modals/NewCourse/SelectedRequirementEditor.vue';
-import { SingleMenuRequirement } from '@/requirements/types';
+import { GroupedRequirementFulfillmentReport } from '@/requirements/types';
 import FlexibleModal from '@/components/Modals/FlexibleModal.vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
 import CourseSelector, {
@@ -90,7 +90,10 @@ export default Vue.extend({
   },
   props: {
     isCourseModelSelectingSemester: { type: Boolean, required: true },
-    reqs: { type: Array as PropType<readonly SingleMenuRequirement[]>, required: true },
+    reqs: {
+      type: Array as PropType<readonly GroupedRequirementFulfillmentReport[]>,
+      required: true,
+    },
   },
   computed: {
     leftButtonText(): string {
@@ -116,7 +119,7 @@ export default Vue.extend({
 
       // parse through reqs object
       for (let i = 0; i < this.reqs.length; i += 1) {
-        const subreqs = this.reqs[i].ongoing;
+        const subreqs = this.reqs[i].reqs.filter(it => it.minCountFulfilled < it.minCountRequired);
         for (let j = 0; j < subreqs.length; j += 1) {
           // requirements
 
@@ -129,7 +132,7 @@ export default Vue.extend({
                   if (subRequirement.allowCourseDoubleCounting) {
                     requirementsThatAllowDoubleCounting.push(subRequirement.name);
                   } else {
-                    relatedRequirements.push({ id: subreqs[j].id, name: subRequirement.name });
+                    relatedRequirements.push({ id: subRequirement.id, name: subRequirement.name });
                   }
                   break;
                 }
@@ -139,7 +142,7 @@ export default Vue.extend({
           // potential self-check requirements
           if (subreqs[j].fulfilledBy === 'self-check') {
             if (!subRequirement.allowCourseDoubleCounting) {
-              potentialRequirements.push({ id: subreqs[j].id, name: subRequirement.name });
+              potentialRequirements.push({ id: subRequirement.id, name: subRequirement.name });
             }
           }
           this.requirementsThatAllowDoubleCounting = requirementsThatAllowDoubleCounting;

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -60,11 +60,7 @@ import draggable from 'vuedraggable';
 import VueSkeletonLoader from 'skeleton-loader-vue';
 import Course from '@/components/Course.vue';
 import AddCourseButton from '@/components/AddCourseButton.vue';
-import {
-  DisplayableRequirementFulfillment,
-  SubReqCourseSlot,
-  CrseInfo,
-} from '@/requirements/types';
+import { RequirementFulfillment, SubReqCourseSlot, CrseInfo } from '@/requirements/types';
 
 type Data = {
   courseObjects: FirestoreSemesterCourse[];
@@ -88,7 +84,7 @@ export default Vue.extend({
     this.$el.removeEventListener('touchmove', this.dragListener);
   },
   props: {
-    subReq: { type: Object as PropType<DisplayableRequirementFulfillment>, required: true },
+    subReq: { type: Object as PropType<RequirementFulfillment>, required: true },
     subReqCourseId: { type: Number, required: true },
     crseInfoObjects: { type: Array as PropType<CrseInfo[]>, required: true },
     subReqFetchedCourseObjectsNotTakenArray: {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -18,7 +18,7 @@
           :toggleableRequirementChoices="toggleableRequirementChoices"
           :displayedMajorIndex="displayedMajorIndex"
           :displayedMinorIndex="displayedMinorIndex"
-          :showMajorOrMinorRequirements="showMajorOrMinorRequirements(index, req.group)"
+          :showMajorOrMinorRequirements="showMajorOrMinorRequirements(index, req.groupName)"
           :rostersFromLastTwoYears="rostersFromLastTwoYears"
           :numOfColleges="numOfColleges"
           :lastLoadedShowAllCourseId="lastLoadedShowAllCourseId"
@@ -69,7 +69,11 @@ import introJs from 'intro.js';
 import Course from '@/components/Course.vue';
 import RequirementView from '@/components/Requirements/RequirementView.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
-import { SingleMenuRequirement, SubReqCourseSlot, CrseInfo } from '@/requirements/types';
+import {
+  SubReqCourseSlot,
+  CrseInfo,
+  GroupedRequirementFulfillmentReport,
+} from '@/requirements/types';
 import { getRostersFromLastTwoYears } from '@/utilities';
 // emoji for clipboard
 import clipboard from '@/assets/images/clipboard.svg';
@@ -109,7 +113,10 @@ export default Vue.extend({
   components: { draggable, Course, DropDownArrow },
   props: {
     startTour: { type: Boolean, required: true },
-    reqs: { type: Array as PropType<readonly SingleMenuRequirement[]>, required: true },
+    reqs: {
+      type: Array as PropType<readonly GroupedRequirementFulfillmentReport[]>,
+      required: true,
+    },
   },
   data(): Data {
     return {
@@ -146,7 +153,7 @@ export default Vue.extend({
   },
   methods: {
     showMajorOrMinorRequirements(id: number, group: string): boolean {
-      if (group === 'MAJOR') {
+      if (group === 'Major') {
         return id === this.displayedMajorIndex + this.numOfColleges;
       }
       // TODO CHANGE FOR MULTIPLE COLLEGES & UNIVERISTIES

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -108,7 +108,7 @@ import IncompleteSubReqCourse from '@/components/Requirements/IncompleteSubReqCo
 import DropDownArrow from '@/components/DropDownArrow.vue';
 
 import {
-  DisplayableRequirementFulfillment,
+  RequirementFulfillment,
   EligibleCourses,
   SubReqCourseSlot,
   CrseInfo,
@@ -134,7 +134,7 @@ type Data = {
 export default Vue.extend({
   components: { DropDownArrow },
   props: {
-    subReq: { type: Object as PropType<DisplayableRequirementFulfillment>, required: true },
+    subReq: { type: Object as PropType<RequirementFulfillment>, required: true },
     subReqIndex: { type: Number, required: true }, // Subrequirement index
     reqIndex: { type: Number, required: true }, // Requirement index
     isCompleted: { type: Boolean, required: true },
@@ -178,9 +178,7 @@ export default Vue.extend({
     },
     subReqProgress(): string {
       return this.subReq.fulfilledBy !== 'self-check'
-        ? `${this.subReq.totalCountFulfilled || this.subReq.minCountFulfilled}/${
-            this.subReq.totalCountRequired || this.subReq.minCountRequired
-          } ${this.subReq.fulfilledBy}`
+        ? `${this.subReq.minCountFulfilled}/${this.subReq.minCountRequired} ${this.subReq.fulfilledBy}`
         : 'self check';
     },
   },
@@ -208,7 +206,7 @@ export default Vue.extend({
     },
     chooseFulfillmentOption(option: string) {
       this.showFulfillmentOptionsDropdown = false;
-      this.$emit('changeToggleableRequirementChoice', this.subReq.id, option);
+      this.$emit('changeToggleableRequirementChoice', this.subReq.requirement.id, option);
     },
     getFulfillededByCourses() {
       switch (this.subReq.requirement.fulfilledBy) {

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -128,7 +128,7 @@ import EditSemester from '@/components/Modals/EditSemester.vue';
 import AddCourseButton from '@/components/AddCourseButton.vue';
 
 import { clickOutside } from '@/utilities';
-import { SingleMenuRequirement } from '@/requirements/types';
+import { GroupedRequirementFulfillmentReport } from '@/requirements/types';
 
 import fall from '@/assets/images/fallEmoji.svg';
 import spring from '@/assets/images/springEmoji.svg';
@@ -187,7 +187,10 @@ export default Vue.extend({
     activatedCourse: { type: Object as PropType<FirestoreSemesterCourse>, required: true },
     duplicatedCourseCodeList: { type: Array as PropType<readonly string[]>, required: true },
     isFirstSem: { type: Boolean, required: true },
-    reqs: { type: Array as PropType<readonly SingleMenuRequirement[]>, required: true },
+    reqs: {
+      type: Array as PropType<readonly GroupedRequirementFulfillmentReport[]>,
+      required: true,
+    },
   },
   mounted() {
     this.$el.addEventListener('touchmove', this.dragListener, { passive: false });

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -97,7 +97,7 @@ import Confirmation from '@/components/Confirmation.vue';
 import SemesterCaution from '@/components/Semester/SemesterCaution.vue';
 import NewSemesterModal from '@/components/Modals/NewSemesterModal.vue';
 
-import { SingleMenuRequirement } from '@/requirements/types';
+import { GroupedRequirementFulfillmentReport } from '@/requirements/types';
 import store from '@/store';
 import { editSemesters } from '@/global-firestore-data';
 
@@ -120,7 +120,10 @@ export default Vue.extend({
     isBottomBarExpanded: { type: Boolean, required: true },
     isMobile: { type: Boolean, required: true },
     startTour: { type: Boolean, required: true },
-    reqs: { type: Array as PropType<readonly SingleMenuRequirement[]>, required: true },
+    reqs: {
+      type: Array as PropType<readonly GroupedRequirementFulfillmentReport[]>,
+      required: true,
+    },
   },
   data() {
     return {

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -51,8 +51,8 @@ type RequirementCommon = {
   readonly source: string;
   /** If this is set to true, then an edge to the course doesn't count towards double counting. */
   readonly allowCourseDoubleCounting?: true;
-  readonly progressBar?: boolean;
 };
+
 /**
  * @param T additional information only attached to credits and courses type.
  */
@@ -73,20 +73,12 @@ type RequirementFulfillmentInformation<T = Record<string, unknown>> =
        * - When fulfilledBy === 'courses', this field stores the min number of courses.
        */
       readonly minCount: number;
-      /**
-       * Some requirements have sub-requirements.
-       *
-       * - `minCount` specifies how many types of sub-requirements needs to be satisfied.
-       * - `totalCount` specifies how many courses/credits need to be earned in total.
-       */
-      readonly totalCount?: number;
     } & T)
   | {
       readonly fulfilledBy: 'toggleable';
       readonly fulfillmentOptions: {
         readonly [optionName: string]: {
           readonly minCount: number;
-          readonly totalCount?: number;
           readonly counting: 'credits' | 'courses';
           readonly subRequirementProgress: 'every-course-needed' | 'any-can-count';
           readonly description: string;
@@ -146,45 +138,23 @@ export type DecoratedRequirementsJson = {
   readonly minor: MajorRequirements<DecoratedCollegeOrMajorRequirement>;
 };
 
-export type RequirementFulfillment<M extends Record<string, unknown>> = {
-  /** ID of the requirement */
-  readonly id: string;
-  /** The original requirement object. */
-  readonly requirement: DecoratedCollegeOrMajorRequirement;
-  /** A list of courses that satisfy this requirement. */
-  readonly courses: readonly (readonly CourseTaken[])[];
-} & M;
-
 export type RequirementFulfillmentStatistics = {
   readonly fulfilledBy: 'courses' | 'credits' | 'self-check';
-  /**
-   * Current fulfillment progress.
-   * When it's a number, it's either number of courses or number of credits.
-   * When it's undefined, it means that the requirement is self-check.
-   */
   readonly minCountFulfilled: number;
   readonly minCountRequired: number;
-  readonly totalCountFulfilled?: number;
-  readonly totalCountRequired?: number;
 };
+
+export type RequirementFulfillment = {
+  /** The original requirement object. */
+  readonly requirement: RequirementWithIDSourceType;
+  /** A list of courses that satisfy this requirement. */
+  readonly courses: readonly (readonly CourseTaken[])[];
+} & RequirementFulfillmentStatistics;
 
 export type GroupedRequirementFulfillmentReport = {
-  readonly groupName: 'University' | 'College' | 'Major' | 'Minor';
+  readonly groupName: 'College' | 'Major' | 'Minor';
   readonly specific: string;
-  readonly reqs: readonly RequirementFulfillment<RequirementFulfillmentStatistics>[];
-};
-
-export type DisplayableRequirementFulfillment = RequirementFulfillment<RequirementFulfillmentStatistics>;
-
-export type SingleMenuRequirement = {
-  readonly ongoing: DisplayableRequirementFulfillment[];
-  readonly completed: DisplayableRequirementFulfillment[];
-  readonly name: string;
-  readonly group: 'COLLEGE' | 'MAJOR' | 'MINOR';
-  readonly specific: string;
-  type?: string;
-  fulfilled?: number;
-  required?: number;
+  readonly reqs: readonly RequirementFulfillment[];
 };
 
 export type CrseInfo = {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR cleans up requirement computation code by eliminating some unnecessary data transformation. It turns out that we don't really need `SingleMenuRequirement`, because it's very similar to `GroupedRequirementFulfillmentReport`. The only significant difference is that `SingleMenuRequirement` has `ongoing, completed, fulfilled, required` field that tells the fulfillment stat of requirements, but they can be easily derived in the places that need them.

In this PR, I compute the `ongoing, completed` list on demand inside `RequirementView` and `filfilled, required` inside `RequirementHeader`. As a result, we have a much slimmer set of data to pass around.

For other changes, I will explain in the review comments on why they are safe.

### Test Plan <!-- Required -->

Side by side comparison of this PR vs master. All requirement items are identical.

<img width="1004" alt="Screen Shot 2021-02-13 at 19 22 22" src="https://user-images.githubusercontent.com/4290500/107865121-73315d80-6e31-11eb-9ecc-d33daa75595c.png">

### Notes <!-- Optional -->

After this PR, we can finally make requirements into the global store.