### PR TITLE
Setup global types for requirements

### DIFF
--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -60,7 +60,6 @@ import Vue, { PropType } from 'vue';
 import SelectedRequirementEditor, {
   RequirementWithID,
 } from '@/components/Modals/NewCourse/SelectedRequirementEditor.vue';
-import { GroupedRequirementFulfillmentReport } from '@/requirements/types';
 import FlexibleModal from '@/components/Modals/FlexibleModal.vue';
 import NewSemester from '@/components/Modals/NewSemester.vue';
 import CourseSelector, {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -36,7 +36,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import ReqCourse from '@/components/Requirements/ReqCourse.vue';
-import { CourseTaken } from '@/requirements/types';
 import store from '@/store';
 
 type CompletedSubReq = {

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -60,7 +60,7 @@ import draggable from 'vuedraggable';
 import VueSkeletonLoader from 'skeleton-loader-vue';
 import Course from '@/components/Course.vue';
 import AddCourseButton from '@/components/AddCourseButton.vue';
-import { RequirementFulfillment, SubReqCourseSlot, CrseInfo } from '@/requirements/types';
+import { SubReqCourseSlot, CrseInfo } from '@/requirements/types';
 
 type Data = {
   courseObjects: FirestoreSemesterCourse[];

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -119,7 +119,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
-import { GroupedRequirementFulfillmentReport } from '@/requirements/types';
 import { getCollegeFullName, getMajorFullName, getMinorFullName } from '@/utilities';
 
 export default Vue.extend({

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="requirementview">
-    <requirementheader
+    <requirement-header
       :reqIndex="reqIndex"
       :displayDetails="displayDetails"
       :displayedMajorIndex="displayedMajorIndex"
@@ -20,7 +20,7 @@
         <p class="sub-title">In-Depth College Requirements</p>
         <div class="separator"></div>
         <div v-for="(subReq, id) in partitionedRequirementsProgress.ongoing" :key="id">
-          <subrequirement
+          <sub-requirement
             :subReqIndex="id"
             :subReq="subReq"
             :reqIndex="reqIndex"
@@ -54,7 +54,7 @@
         <div v-if="displayCompleted">
           <div v-for="(subReq, id) in partitionedRequirementsProgress.completed" :key="id">
             <div class="separator" v-if="reqIndex < reqs.length - 1 || displayDetails"></div>
-            <subrequirement
+            <sub-requirement
               :subReqIndex="id"
               :subReq="subReq"
               :reqIndex="reqIndex"
@@ -82,11 +82,7 @@ import Vue, { PropType } from 'vue';
 import RequirementHeader from '@/components/Requirements/RequirementHeader.vue';
 import SubRequirement from '@/components/Requirements/SubRequirement.vue';
 
-import { RequirementFulfillment, GroupedRequirementFulfillmentReport } from '@/requirements/types';
 import store from '@/store';
-
-Vue.component('requirementheader', RequirementHeader);
-Vue.component('subrequirement', SubRequirement);
 
 // reqGroupColorMap maps reqGroup to an array [<hex color for progress bar>, <color for arrow image>]
 const reqGroupColorMap = {
@@ -101,6 +97,7 @@ type PartitionedRequirementsProgress = {
 };
 
 export default Vue.extend({
+  components: { RequirementHeader, SubRequirement },
   props: {
     reqs: {
       type: Array as PropType<readonly GroupedRequirementFulfillmentReport[]>,

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -11,7 +11,7 @@
     >
       <!-- loop through reqs array of req objects -->
       <div class="req" v-for="(req, index) in reqs" :key="index">
-        <requirementview
+        <requirement-view
           :reqs="reqs"
           :req="req"
           :reqIndex="index"
@@ -69,11 +69,7 @@ import introJs from 'intro.js';
 import Course from '@/components/Course.vue';
 import RequirementView from '@/components/Requirements/RequirementView.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
-import {
-  SubReqCourseSlot,
-  CrseInfo,
-  GroupedRequirementFulfillmentReport,
-} from '@/requirements/types';
+import { SubReqCourseSlot, CrseInfo } from '@/requirements/types';
 import { getRostersFromLastTwoYears } from '@/utilities';
 // emoji for clipboard
 import clipboard from '@/assets/images/clipboard.svg';
@@ -83,7 +79,6 @@ import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-c
 
 const FetchCourses = firebase.functions().httpsCallable('FetchCourses');
 
-Vue.component('requirementview', RequirementView);
 Vue.use(VueCollapse);
 
 export type ShowAllCourses = {
@@ -110,7 +105,7 @@ tour.setOption('nextLabel', 'Next');
 tour.setOption('exitOnOverlayClick', 'false');
 
 export default Vue.extend({
-  components: { draggable, Course, DropDownArrow },
+  components: { draggable, Course, DropDownArrow, RequirementView },
   props: {
     startTour: { type: Boolean, required: true },
     reqs: {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -74,7 +74,7 @@
       <div v-if="displayDescription" class="subreqcourse-wrapper">
         <div v-for="(subReqCourseSlot, id) in subReqCoursesArray" :key="id">
           <div v-if="subReqCourseSlot.isCompleted" class="completedsubreqcourse-wrapper">
-            <completedsubreqcourse
+            <completed-sub-req-course
               :subReqCourseId="id"
               :crsesTaken="subReqCourseSlot.courses"
               @deleteCourseFromSemesters="deleteCourseFromSemesters"
@@ -107,17 +107,11 @@ import CompletedSubReqCourse from '@/components/Requirements/CompletedSubReqCour
 import IncompleteSubReqCourse from '@/components/Requirements/IncompleteSubReqCourse.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 
-import {
-  RequirementFulfillment,
-  EligibleCourses,
-  SubReqCourseSlot,
-  CrseInfo,
-} from '@/requirements/types';
+import { SubReqCourseSlot, CrseInfo } from '@/requirements/types';
 import { clickOutside } from '@/utilities';
 
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
 
-Vue.component('completedsubreqcourse', CompletedSubReqCourse);
 Vue.component('incompletesubreqcourse', IncompleteSubReqCourse);
 
 require('firebase/functions');
@@ -132,7 +126,7 @@ type Data = {
 };
 
 export default Vue.extend({
-  components: { DropDownArrow },
+  components: { CompletedSubReqCourse, DropDownArrow },
   props: {
     subReq: { type: Object as PropType<RequirementFulfillment>, required: true },
     subReqIndex: { type: Number, required: true }, // Subrequirement index

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -128,15 +128,12 @@ import EditSemester from '@/components/Modals/EditSemester.vue';
 import AddCourseButton from '@/components/AddCourseButton.vue';
 
 import { clickOutside } from '@/utilities';
-import { GroupedRequirementFulfillmentReport } from '@/requirements/types';
 
 import fall from '@/assets/images/fallEmoji.svg';
 import spring from '@/assets/images/springEmoji.svg';
 import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
-
-Vue.component('new-course-modal', NewCourseModal);
 
 const pageTour = introJs();
 pageTour.setOption('exitOnEsc', 'false');
@@ -153,6 +150,7 @@ export default Vue.extend({
     Course,
     DeleteSemester,
     EditSemester,
+    NewCourseModal,
     SemesterMenu,
   },
   data() {

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -97,12 +97,8 @@ import Confirmation from '@/components/Confirmation.vue';
 import SemesterCaution from '@/components/Semester/SemesterCaution.vue';
 import NewSemesterModal from '@/components/Modals/NewSemesterModal.vue';
 
-import { GroupedRequirementFulfillmentReport } from '@/requirements/types';
 import store from '@/store';
 import { editSemesters } from '@/global-firestore-data';
-
-Vue.component('semester', Semester);
-Vue.component('new-semester-modal', NewSemesterModal);
 
 // enum to define seasons as integers in season order
 const SeasonsEnum = Object.freeze({
@@ -113,7 +109,7 @@ const SeasonsEnum = Object.freeze({
 });
 
 export default Vue.extend({
-  components: { Confirmation, SemesterCaution },
+  components: { Confirmation, NewSemesterModal, Semester, SemesterCaution },
   props: {
     compact: { type: Boolean, required: true },
     isBottomBar: { type: Boolean, required: true },

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -26,7 +26,7 @@
           @deleteCourseFromSemesters="deleteCourseFromSemesters"
         />
       </div>
-      <semesterview
+      <semester-view
         v-if="loaded && ((!isOpeningRequirements && isTablet) || !isTablet)"
         ref="semesterview"
         :compact="compactVal"
@@ -89,12 +89,8 @@ import TourWindow from '@/components/Modals/TourWindow.vue';
 import surfing from '@/assets/images/surfing.svg';
 
 import computeRequirements from '@/requirements/reqs-functions';
-import { GroupedRequirementFulfillmentReport } from '@/requirements/types';
 import store, { initializeFirestoreListeners, subscribeRequirementDependencyChange } from '@/store';
 import { editSemesters } from '@/global-firestore-data';
-
-Vue.component('semesterview', SemesterView);
-Vue.component('requirements', Requirements);
 
 const tour = introJs();
 tour.setOption('exitOnEsc', 'false');
@@ -107,7 +103,7 @@ tour.setOption('exitOnOverlayClick', 'false');
 let listenerUnsubscriber = (): void => {};
 
 export default Vue.extend({
-  components: { BottomBar, NavBar, Onboarding, TourWindow },
+  components: { BottomBar, NavBar, Onboarding, Requirements, SemesterView, TourWindow },
   data() {
     return {
       loaded: true,

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -1,0 +1,87 @@
+type RequirementCommon = {
+  /** Full name of the requirement. */
+  readonly name: string;
+  /** Description of the requirement. */
+  readonly description: string;
+  /** The source with more information on the requirement. (This should be a URL string.) */
+  readonly source: string;
+  /** If this is set to true, then an edge to the course doesn't count towards double counting. */
+  readonly allowCourseDoubleCounting?: true;
+};
+
+type EligibleCourses = {
+  // "FA20": [123456, 42, 65536, /* and another crseId */]
+  readonly [semester: string]: readonly number[];
+};
+
+/**
+ * @param T additional information only attached to credits and courses type.
+ */
+type RequirementFulfillmentInformation<T = Record<string, unknown>> =
+  | {
+      readonly fulfilledBy: 'self-check';
+      // Currently unused.
+      readonly minCount?: number;
+    }
+  | ({
+      /** Defines how courses in a sub-requirement can be all counted towards a stat. */
+      readonly subRequirementProgress: 'every-course-needed' | 'any-can-count';
+      readonly fulfilledBy: 'credits' | 'courses';
+      /**
+       * The minimum count required to fulfill this requirement.
+       *
+       * - When fulfilledBy === 'credits', this field stores the min number of credits.
+       * - When fulfilledBy === 'courses', this field stores the min number of courses.
+       */
+      readonly minCount: number;
+    } & T)
+  | {
+      readonly fulfilledBy: 'toggleable';
+      readonly fulfillmentOptions: {
+        readonly [optionName: string]: {
+          readonly minCount: number;
+          readonly counting: 'credits' | 'courses';
+          readonly subRequirementProgress: 'every-course-needed' | 'any-can-count';
+          readonly description: string;
+        } & T;
+      };
+    };
+
+type DecoratedCollegeOrMajorRequirement = RequirementCommon &
+  RequirementFulfillmentInformation<{ readonly courses: readonly EligibleCourses[] }>;
+
+type CourseTaken = {
+  readonly roster: string;
+  readonly courseId: number;
+  readonly code: string;
+  readonly subject: string;
+  readonly number: string;
+  readonly credits: number;
+};
+
+type RequirementGroupType = 'College' | 'Major' | 'Minor';
+
+type RequirementWithIDSourceType = DecoratedCollegeOrMajorRequirement & {
+  readonly id: string;
+  readonly sourceType: RequirementGroupType;
+  readonly sourceSpecificName: string;
+};
+
+type RequirementFulfillmentStatistics = {
+  readonly fulfilledBy: 'courses' | 'credits' | 'self-check';
+  readonly minCountFulfilled: number;
+  readonly minCountRequired: number;
+};
+
+type RequirementFulfillment = {
+  /** The original requirement object. */
+  readonly requirement: RequirementWithIDSourceType;
+  /** A list of courses that satisfy this requirement. */
+  readonly courses: readonly (readonly CourseTaken[])[];
+} & RequirementFulfillmentStatistics;
+
+type GroupedRequirementFulfillmentReport = {
+  readonly groupName: 'College' | 'Major' | 'Minor';
+  readonly specific: string;
+  readonly reqs: readonly RequirementFulfillment[];
+};

--- a/src/requirements/data/exams/ExamCredit.ts
+++ b/src/requirements/data/exams/ExamCredit.ts
@@ -1,5 +1,3 @@
-import { CourseTaken } from '../../types';
-
 export type ExamRequirements = {
   readonly name: string;
   readonly fulfillment: {

--- a/src/requirements/reqs-functions.ts
+++ b/src/requirements/reqs-functions.ts
@@ -2,13 +2,6 @@ import store from '../store';
 import { CREDITS_COURSE_ID, FWS_COURSE_ID } from './data/constants';
 import getCourseEquivalentsFromUserExams from './data/exams/ExamCredit';
 import buildRequirementFulfillmentGraphFromUserData from './requirement-graph-builder-from-user-data';
-import {
-  CourseTaken,
-  EligibleCourses,
-  DecoratedCollegeOrMajorRequirement,
-  RequirementFulfillmentStatistics,
-  GroupedRequirementFulfillmentReport,
-} from './types';
 
 type FulfillmentStatistics = {
   readonly requirement: RequirementWithIDSourceType;

--- a/src/requirements/requirement-graph-builder-from-user-data.ts
+++ b/src/requirements/requirement-graph-builder-from-user-data.ts
@@ -2,7 +2,6 @@ import store from '../store';
 import RequirementFulfillmentGraph from './requirement-graph';
 import buildRequirementFulfillmentGraph from './requirement-graph-builder';
 import requirementJson from './typed-requirement-json';
-import { CourseTaken, RequirementWithIDSourceType, EligibleCourses } from './types';
 
 /**
  * Removes all AP/IB equivalent course credit if it's a duplicate crseId.

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -2,8 +2,6 @@ import { writeFileSync } from 'fs';
 import {
   CollegeOrMajorRequirement,
   DecoratedRequirementsJson,
-  DecoratedCollegeOrMajorRequirement,
-  EligibleCourses,
   RequirementChecker,
   Course,
 } from './types';

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -33,58 +33,6 @@ export type Course = {
   readonly acadGroup: string;
 };
 
-export type CourseTaken = {
-  readonly roster: string;
-  readonly courseId: number;
-  readonly code: string;
-  readonly subject: string;
-  readonly number: string;
-  readonly credits: number;
-};
-
-type RequirementCommon = {
-  /** Full name of the requirement. */
-  readonly name: string;
-  /** Description of the requirement. */
-  readonly description: string;
-  /** The source with more information on the requirement. (This should be a URL string.) */
-  readonly source: string;
-  /** If this is set to true, then an edge to the course doesn't count towards double counting. */
-  readonly allowCourseDoubleCounting?: true;
-};
-
-/**
- * @param T additional information only attached to credits and courses type.
- */
-type RequirementFulfillmentInformation<T = Record<string, unknown>> =
-  | {
-      readonly fulfilledBy: 'self-check';
-      // Currently unused.
-      readonly minCount?: number;
-    }
-  | ({
-      /** Defines how courses in a sub-requirement can be all counted towards a stat. */
-      readonly subRequirementProgress: 'every-course-needed' | 'any-can-count';
-      readonly fulfilledBy: 'credits' | 'courses';
-      /**
-       * The minimum count required to fulfill this requirement.
-       *
-       * - When fulfilledBy === 'credits', this field stores the min number of credits.
-       * - When fulfilledBy === 'courses', this field stores the min number of courses.
-       */
-      readonly minCount: number;
-    } & T)
-  | {
-      readonly fulfilledBy: 'toggleable';
-      readonly fulfillmentOptions: {
-        readonly [optionName: string]: {
-          readonly minCount: number;
-          readonly counting: 'credits' | 'courses';
-          readonly subRequirementProgress: 'every-course-needed' | 'any-can-count';
-          readonly description: string;
-        } & T;
-      };
-    };
 export type BaseRequirement = RequirementCommon & RequirementFulfillmentInformation;
 
 export type RequirementChecker = (course: Course) => boolean;
@@ -92,20 +40,6 @@ export type CollegeOrMajorRequirement = RequirementCommon &
   RequirementFulfillmentInformation<{
     readonly checker: RequirementChecker | readonly RequirementChecker[];
   }>;
-
-export type EligibleCourses = {
-  // "FA20": [123456, 42, 65536, /* and another crseId */]
-  readonly [semester: string]: readonly number[];
-};
-
-export type DecoratedCollegeOrMajorRequirement = RequirementCommon &
-  RequirementFulfillmentInformation<{ readonly courses: readonly EligibleCourses[] }>;
-
-export type RequirementWithIDSourceType = DecoratedCollegeOrMajorRequirement & {
-  readonly id: string;
-  readonly sourceType: 'College' | 'Major' | 'Minor';
-  readonly sourceSpecificName: string;
-};
 
 export type CollegeRequirements<R> = {
   readonly [collegeCode: string]: {
@@ -138,28 +72,9 @@ export type DecoratedRequirementsJson = {
   readonly minor: MajorRequirements<DecoratedCollegeOrMajorRequirement>;
 };
 
-export type RequirementFulfillmentStatistics = {
-  readonly fulfilledBy: 'courses' | 'credits' | 'self-check';
-  readonly minCountFulfilled: number;
-  readonly minCountRequired: number;
-};
-
-export type RequirementFulfillment = {
-  /** The original requirement object. */
-  readonly requirement: RequirementWithIDSourceType;
-  /** A list of courses that satisfy this requirement. */
-  readonly courses: readonly (readonly CourseTaken[])[];
-} & RequirementFulfillmentStatistics;
-
-export type GroupedRequirementFulfillmentReport = {
-  readonly groupName: 'College' | 'Major' | 'Minor';
-  readonly specific: string;
-  readonly reqs: readonly RequirementFulfillment[];
-};
-
 export type CrseInfo = {
   readonly roster: string;
-  crseIds: number[];
+  readonly crseIds: number[];
 };
 
 export type CompletedSubReqCourseSlot = {


### PR DESCRIPTION
### Summary <!-- Required -->

Move requirement types into a global typedef file, so that they can be used everywhere without import. This is used to unblock final setup to add requirements into global store.

Depends on #290.

### Test Plan <!-- Required -->

This is mostly a type only change, so check everything still type checks.
I also migrated more components to avoid using `Vue.component('...', Component)`. We can check it works by ensuring every part of the app still loads without error.