### PR TITLE
[easy] Factor all fetch courses firebase function call into a typed version

### DIFF
--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -59,9 +59,7 @@
 </template>
 
 <script lang="ts">
-import firebase from 'firebase/app';
 import draggable from 'vuedraggable';
-import 'firebase/functions';
 import Vue, { PropType } from 'vue';
 import VueCollapse from 'vue2-collapse';
 import introJs from 'intro.js';
@@ -76,8 +74,7 @@ import clipboard from '@/assets/images/clipboard.svg';
 import store from '@/store';
 import { chooseToggleableRequirementOption } from '@/global-firestore-data';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
-
-const FetchCourses = firebase.functions().httpsCallable('FetchCourses');
+import { fetchCoursesFromFirebaseFunctions } from '@/firebaseConfig';
 
 Vue.use(VueCollapse);
 
@@ -204,16 +201,8 @@ export default Vue.extend({
             subReqCrseInfoObjectsToFetch.push(crseInfoFromSemester[0]);
           }
         });
-        FetchCourses({
-          crseInfo: subReqCrseInfoObjectsToFetch,
-          allowSameCourseForDifferentRosters: false,
-        })
-          .then(result => {
-            const fetchedCourses = result.data.courses.map(
-              cornellCourseRosterCourseToFirebaseSemesterCourse
-            );
-            return resolve(fetchedCourses);
-          })
+        fetchCoursesFromFirebaseFunctions(subReqCrseInfoObjectsToFetch)
+          .then(courses => resolve(courses.map(cornellCourseRosterCourseToFirebaseSemesterCourse)))
           .catch(error => reject(error));
       });
     },

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -102,7 +102,6 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import firebase from 'firebase/app';
 import CompletedSubReqCourse from '@/components/Requirements/CompletedSubReqCourse.vue';
 import IncompleteSubReqCourse from '@/components/Requirements/IncompleteSubReqCourse.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
@@ -111,12 +110,11 @@ import { SubReqCourseSlot, CrseInfo } from '@/requirements/types';
 import { clickOutside } from '@/utilities';
 
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
+import { fetchCoursesFromFirebaseFunctions } from '@/firebaseConfig';
 
 Vue.component('incompletesubreqcourse', IncompleteSubReqCourse);
 
 require('firebase/functions');
-
-const FetchCourses = firebase.functions().httpsCallable('FetchCourses');
 
 type Data = {
   showFulfillmentOptionsDropdown: boolean;
@@ -295,13 +293,8 @@ export default Vue.extend({
       this.subReqFetchedCourseObjectsNotTakenArray = [];
       this.dataReady = false;
       const subReqCrseInfoObjectsToFetch = this.getMaxFirstFourCrseInfoObjects();
-      let fetchedCourses;
-      FetchCourses({
-        crseInfo: subReqCrseInfoObjectsToFetch,
-        allowSameCourseForDifferentRosters: false,
-      })
-        .then(result => {
-          fetchedCourses = result.data.courses;
+      fetchCoursesFromFirebaseFunctions(subReqCrseInfoObjectsToFetch)
+        .then(fetchedCourses => {
           this.subReqFetchedCourseObjectsNotTakenArray.push(
             ...fetchedCourses.map(cornellCourseRosterCourseToFirebaseSemesterCourse)
           );

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -2,6 +2,8 @@ import firebase from 'firebase/app';
 
 import 'firebase/auth';
 import 'firebase/firestore';
+import 'firebase/functions';
+import { CrseInfo } from './requirements/types';
 
 let config;
 if (process.env.VUE_APP_FIREBASE_MODE === 'prod') {
@@ -33,6 +35,7 @@ firebase.initializeApp(config);
 // firebase utils
 export const db = firebase.firestore();
 export const auth = firebase.auth();
+const functions = firebase.functions();
 
 export const usernameCollection = db.collection('user-name').withConverter<FirestoreUserName>({
   fromFirestore(snapshot): FirestoreUserName {
@@ -102,3 +105,11 @@ export const onboardingDataCollection = db
 
 export const whitelistCollection = db.collection('betaWhitelist');
 export const landingEmailsCollection = db.collection('landingEmails');
+
+export const fetchCoursesFromFirebaseFunctions = (
+  crseInfo: readonly CrseInfo[],
+  allowSameCourseForDifferentRosters = false
+): Promise<readonly CornellCourseRosterCourse[]> =>
+  functions
+    .httpsCallable('FetchCourses')({ crseInfo, allowSameCourseForDifferentRosters })
+    .then(result => result.data.courses);


### PR DESCRIPTION
### Summary <!-- Required -->

Instead of calling `FetchCourses` function inside the components and worry about types on their own, I setup a typed version of this function inside `firebaseConfig.ts`, so that type safety is enforced. I also moved the import of `firebase/functions` into `firebaseConfig.ts`, to ensure that it's only initialized once.

### Test Plan <!-- Required -->

Courses are still fetched.

<img width="383" alt="Screen Shot 2021-02-15 at 18 25 31" src="https://user-images.githubusercontent.com/4290500/108001805-8708cb00-6fbb-11eb-87b1-f90e7dbe7237.png">
<img width="391" alt="Screen Shot 2021-02-15 at 18 25 36" src="https://user-images.githubusercontent.com/4290500/108001806-8708cb00-6fbb-11eb-9503-157e2a69dfd6.png">
