### PR TITLE
Remove v-html directives

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     // TODO: auto-fix of this and the next rule introduces too many code changes that might cause merge conflict.
     'vue/attributes-order': ['off'],
     'vue/order-in-components': ['off'],
+    'vue/no-v-html': ['error'],
     // TODO: change no-console to error out for prod
     'no-console': ['warn'],
     'no-await-in-loop': ['error'],

--- a/src/components/CourseCaution.vue
+++ b/src/components/CourseCaution.vue
@@ -7,7 +7,7 @@
         alt="caution sign"
       />
     </div>
-    <div class="course-tooltiptext course-tooltiptext--caution" v-html="cautionString"></div>
+    <div class="course-tooltiptext course-tooltiptext--caution">{{ cautionString }}</div>
   </div>
 </template>
 

--- a/src/components/Modals/TourWindow.vue
+++ b/src/components/Modals/TourWindow.vue
@@ -40,8 +40,8 @@ export default Vue.extend({
     text: { type: String, required: true },
     exit: { type: String, required: true },
     buttonText: { type: String, required: true },
-    alt: { type: String, required: false, default: ''  },
-    image: { type: Object, required: false, default: null  },
+    alt: { type: String, required: false, default: '' },
+    image: { type: String, required: false, default: null },
   },
   data() {
     return {

--- a/src/components/Modals/TourWindow.vue
+++ b/src/components/Modals/TourWindow.vue
@@ -9,7 +9,10 @@
           <div class="title">
             {{ title }}
           </div>
-          <div class="body" v-html="text"></div>
+          <div class="body">
+            {{ text }}
+            <img v-if="image" :src="image" class="emoji-text" :alt="alt" />
+          </div>
           <button
             @click="
               $emit('hide');
@@ -37,6 +40,8 @@ export default Vue.extend({
     text: { type: String, required: true },
     exit: { type: String, required: true },
     buttonText: { type: String, required: true },
+    alt: { type: String, required: false, default: ''  },
+    image: { type: Object, required: false, default: null  },
   },
   data() {
     return {

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -53,6 +53,8 @@
       :text="congratsBodytext"
       :exit="congratsExit"
       :buttonText="congratsButtonText"
+      :image="congratsBodyImage"
+      :alt="congratsBodyAlt"
       @hide="showTourEndWindow = false"
       v-if="showTourEndWindow"
     >
@@ -123,9 +125,9 @@ export default Vue.extend({
       startTour: false,
       showTourEndWindow: false,
       congrats: 'Congratulations! That’s a wrap',
-      congratsBodytext: `Other than this, there is more you can explore,
-        so feel free to surf through CoursePlan <img src = "${surfing}"
-        class = "emoji-text" alt = "surf">`,
+      congratsBodytext: 'Other than this, there is more you can explore, so feel free to surf through CoursePlan',
+      congratsBodyImage: surfing,
+      congratsBodyAlt: 'surf',
       congratsExit: '',
       congratsButtonText: 'Start Planning',
     };

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -125,7 +125,8 @@ export default Vue.extend({
       startTour: false,
       showTourEndWindow: false,
       congrats: 'Congratulations! That’s a wrap',
-      congratsBodytext: 'Other than this, there is more you can explore, so feel free to surf through CoursePlan',
+      congratsBodytext:
+        'Other than this, there is more you can explore, so feel free to surf through CoursePlan',
       congratsBodyImage: surfing,
       congratsBodyAlt: 'surf',
       congratsExit: '',


### PR DESCRIPTION
### Summary <!-- Required -->

Remove two uses of v-html directives to fix a couple linter warnings due to recent linter config changes (see #289). The linter restricts this because of possible security issues from injecting html (see https://vuejs.org/v2/guide/security.html#Injecting-HTML).

- [x] Remove usage in CourseCaution (currently only text passed through, not html)
- [x] Remove usage in TourWindow (created a separate image tag to handle that html)
- [x] Set no-v-html to cause a linter error in the future

Remaining TODOs:

- [ ] resolve remaining linter warnings (currently 18 left) and TODOs in .eslintrc.js

See Notion item to handle all linter warnings here: https://www.notion.so/Clean-Code-Week-NPM-run-lint-warnings-and-errors-f01ddbf6aa9047739d17a4f104773584

### Test Plan <!-- Required -->

1. Confirm caution modals still say 'Duplicate' when two courses are duplicated in a plan
2. Confirm the first page of the walkthrough is unchanged, and the last page still has the emoji icon