### PR TITLE
Cleanup BottomBar courses

### DIFF
--- a/src/components/BottomBar/BottomBarCourse.vue
+++ b/src/components/BottomBar/BottomBarCourse.vue
@@ -1,146 +1,17 @@
 <template>
   <div class="bottombarcourse">
     <div class="bottombarcourse-wrapper">
-      <div
-        :class="
-          isSmallerWidth
-            ? 'bottombarcourse-bar-info-noOverflow'
-            : 'bottombarcourse-bar-info-overflow'
-        "
-      >
-        <div class="info">
-          <div class="info-section-wrapper">
-            <div>
-              <div class="section">
-                <h1 class="info-head">Credits</h1>
-                <p class="info-fact">{{ courseObj.credits }}</p>
-              </div>
-              <div class="section">
-                <h1 class="info-head">Offered</h1>
-                <p class="info-fact">{{ courseSemesters }}</p>
-              </div>
-            </div>
-            <div>
-              <div class="section">
-                <h1 class="info-head">Instructors</h1>
-                <p class="info-fact">{{ courseInstructors }}</p>
-              </div>
-              <div class="section">
-                <h1 class="info-head">Enrollment Information</h1>
-                <p class="info-fact">{{ courseEnrollment }}</p>
-              </div>
-            </div>
-            <div>
-              <div class="section">
-                <h1 class="info-head">Distribution Category</h1>
-                <p
-                  class="info-fact"
-                  v-for="distributionCategory in courseDistributions"
-                  :key="distributionCategory"
-                >
-                  {{ distributionCategory }}
-                </p>
-              </div>
-              <div class="section">
-                <h1 class="info-head">{{ courseObj.lastRoster }} Lecture Information</h1>
-                <p
-                  class="info-fact"
-                  v-for="latestLecInfo in courseLectureTimes"
-                  :key="latestLecInfo"
-                >
-                  {{ latestLecInfo }}
-                </p>
-              </div>
-            </div>
-          </div>
-          <div class="info-link">
-            <a :href="rosterLink" class="info-link-blue" target="_blank">
-              View Course Information on Roster
-              <span class="info-link-blue-img"
-                ><img src="@/assets/images/link-blue.svg" alt="link arrow"
-              /></span>
-            </a>
-          </div>
-        </div>
+      <div class="bottombarcourse-bar-info-overflow" v-if="!isSmallerWidth">
+        <bottom-bar-course-info :courseObj="courseObj" />
       </div>
-      <div
-        :class="
-          isSmallerWidth
-            ? 'bottombarcourse-bar-details-noOverflow'
-            : 'bottombarcourse-bar-details-overflow'
-        "
-      >
-        <div class="details">
-          <div class="details-ratings-link-wrapper">
-            <a :href="CURLink" class="details-ratings-link" target="_blank">See All Reviews</a>
-          </div>
-          <div class="details-ratings-wrapper">
-            <div class="details-ratings">
-              <p class="details-ratings-title">
-                <span class="details-ratings-title-strong">Overall: </span>
-                <span class="details-ratings-strong">{{ CUROverallRating }}</span>
-              </p>
-              <div class="progress rating">
-                <div
-                  class="progress-bar"
-                  role="progressbar"
-                  :style="{
-                    width: `${(courseObj.overallRating / 5) * 100}%`,
-                    background: reviewsColor(courseObj.overallRating),
-                  }"
-                  aria-label="Overall Rating"
-                  :aria-valuenow="(courseObj.overallRating / 5) * 100"
-                  aria-valuemin="0"
-                  aria-valuemax="100"
-                ></div>
-              </div>
-            </div>
-            <div class="details-ratings">
-              <p class="details-ratings-title">
-                <span class="details-ratings-title-strong">Difficulty: </span>
-                <span class="details-ratings-strong"> {{ CURDifficulty }}</span>
-              </p>
-              <div class="progress rating">
-                <div
-                  class="progress-bar"
-                  role="progressbar"
-                  :style="{
-                    width: `${(courseObj.difficulty / 5) * 100}%`,
-                    background: reviewsColor(courseObj.difficulty, true),
-                  }"
-                  aria-label="Difficulty Rating"
-                  :aria-valuenow="(courseObj.difficulty / 5) * 100"
-                  aria-valuemin="0"
-                  aria-valuemax="100"
-                ></div>
-              </div>
-            </div>
-            <div class="details-ratings">
-              <p class="details-ratings-title">
-                <span class="details-ratings-title-strong">Workload: </span>
-                <span class="details-ratings-strong">{{ CURWorkload }}</span>
-              </p>
-              <div class="progress rating">
-                <div
-                  class="progress-bar"
-                  role="progressbar"
-                  :style="{
-                    width: `${(courseObj.workload / 5) * 100}%`,
-                    background: reviewsColor(courseObj.workload, true),
-                  }"
-                  aria-label="Workload Rating"
-                  :aria-valuenow="(courseObj.workload / 5) * 100"
-                  aria-valuemin="0"
-                  aria-valuemax="100"
-                ></div>
-              </div>
-            </div>
-          </div>
-          <div class="details-head">Prerequisites</div>
-          <p class="info-fact">{{ coursePrereqs }}</p>
-          <div class="details-head">Description</div>
-          <p class="info-fact">{{ courseObj.description }}</p>
-        </div>
+      <div class="bottombarcourse-bar-details-overflow" v-if="!isSmallerWidth">
+        <bottom-bar-course-review :courseObj="courseObj" />
+      </div>
+      <div class="bottombarcourse-bar-details-noOverflow" v-if="isSmallerWidth">
+        <bottom-bar-course-review :courseObj="courseObj" />
+      </div>
+      <div class="bottombarcourse-bar-info-noOverflow" v-if="isSmallerWidth">
+        <bottom-bar-course-info :courseObj="courseObj" />
       </div>
     </div>
   </div>
@@ -148,35 +19,11 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import { reviewColors } from '@/assets/constants/colors';
-
-const joinOrNAString = (arr: readonly string[]): string =>
-  arr.length !== 0 && arr[0] !== '' ? arr.join(', ') : 'N/A';
-
-const noneIfEmpty = (str: string): string => (str && str.length !== 0 ? str : 'None');
-
-const naIfEmptyStringArray = (arr: readonly string[]): readonly string[] =>
-  arr && arr.length !== 0 && arr[0] !== '' ? arr : ['N/A'];
-
-const cleanCourseDistributionsArray = (distributions: readonly string[]): readonly string[] => {
-  // Iterates over distributions array and cleans every entry
-  // Removes stray parentheses, spaces, and commas
-  let matches: string[] = [];
-  if (distributions[0] === '') {
-    matches = ['N/A'];
-  } else {
-    for (let i = 0; i < distributions.length; i += 1) {
-      distributions[i].replace(/[A-Za-z0-9-]+/g, d => {
-        matches.push(d);
-        return d;
-      });
-    }
-  }
-
-  return matches;
-};
+import BottomBarCourseInfo from '@/components/BottomBar/BottomBarCourseInfo.vue';
+import BottomBarCourseReview from '@/components/BottomBar/BottomBarCourseReview.vue';
 
 export default Vue.extend({
+  components: { BottomBarCourseInfo, BottomBarCourseReview },
   data() {
     return {
       isSmallerWidth: window.innerWidth <= 976,
@@ -195,70 +42,6 @@ export default Vue.extend({
   methods: {
     isSmallerWidthEventHandler() {
       this.isSmallerWidth = window.innerWidth <= 976;
-    },
-
-    joinIfExists(arr: readonly string[]) {
-      return arr ? arr.join(',') : '';
-    },
-
-    reviewsColor(review: number, flip = false) {
-      const colors = Object.values(reviewColors);
-      let index;
-      if (review < 2) {
-        index = 0;
-      } else if (review >= 2 && review < 4) {
-        index = 1;
-      } else {
-        index = 2;
-      }
-
-      return flip ? colors[colors.length - 1 - index] : colors[index];
-    },
-  },
-
-  computed: {
-    courseSemesters(): string {
-      return joinOrNAString(this.courseObj.semesters);
-    },
-    courseInstructors(): string {
-      return joinOrNAString(this.courseObj.instructors);
-    },
-    courseEnrollment(): string {
-      return joinOrNAString(this.courseObj.enrollment);
-    },
-    coursePrereqs(): string {
-      return noneIfEmpty(this.courseObj.prereqs);
-    },
-    courseLectureTimes(): readonly string[] {
-      return naIfEmptyStringArray(this.courseObj.lectureTimes);
-    },
-    courseSubjectAndNumber(): { readonly subject: string; readonly number: string } {
-      const [subject, number] = this.courseObj.code.split(' ');
-      return { subject, number };
-    },
-    courseDistributions(): readonly string[] {
-      return cleanCourseDistributionsArray(this.courseObj.distributions);
-    },
-    rosterLink(): string {
-      return `https://classes.cornell.edu/browse/roster/${this.courseObj.lastRoster}/class/${this.courseSubjectAndNumber.subject}/${this.courseSubjectAndNumber.number}`;
-    },
-    CURLink(): string {
-      return `https://www.cureviews.org/course/${this.courseSubjectAndNumber.subject}/${this.courseSubjectAndNumber.number}`;
-    },
-    CUROverallRating() {
-      if (this.courseObj.overallRating === 0) return '';
-      if (!this.courseObj.overallRating) return 'N/A';
-      return Math.round(this.courseObj.overallRating * 10) / 10;
-    },
-    CURDifficulty() {
-      if (this.courseObj.difficulty === 0) return '';
-      if (!this.courseObj.difficulty) return 'N/A';
-      return Math.round(this.courseObj.difficulty * 10) / 10;
-    },
-    CURWorkload() {
-      if (this.courseObj.workload === 0) return '';
-      if (!this.courseObj.workload) return 'N/A';
-      return Math.round(this.courseObj.workload * 10) / 10;
     },
   },
 });
@@ -304,114 +87,6 @@ export default Vue.extend({
       }
     }
   }
-}
-
-.info {
-  margin: 20px;
-  display: flex;
-  flex-direction: column;
-  height: 90%;
-  justify-content: space-between;
-  margin-bottom: 0rem;
-
-  &-head {
-    margin-top: 5px;
-    font-weight: 500;
-    font-size: 12px;
-    color: $darkGray2;
-    margin-bottom: 0rem;
-  }
-
-  &-fact {
-    padding-right: 10px;
-    font-size: 16px;
-    color: $primaryGray;
-    margin-bottom: 0rem;
-  }
-
-  &-link {
-    font-size: 16px;
-    line-height: 16px;
-    text-decoration-line: underline;
-    margin-top: inherit;
-
-    &-blue {
-      color: $yuxuanBlue;
-      // TODO: update picture
-      font-weight: 500;
-
-      &-img {
-        margin-left: 0.2rem;
-      }
-    }
-  }
-}
-
-.section {
-  margin-bottom: 8px;
-  float: left;
-  width: 50%;
-  height: inherit;
-}
-
-.details {
-  margin: 20px;
-
-  &-head {
-    margin-top: 10px;
-    font-weight: 500;
-    font-size: 12px;
-    color: $darkGray2;
-    margin-bottom: 0rem;
-  }
-
-  &-ratings {
-    margin-right: 3%;
-    width: 30%;
-    float: left;
-    margin-bottom: 1rem;
-
-    &-title {
-      font-size: 16px;
-      line-height: 16px;
-      color: $primaryGray;
-
-      &-strong {
-        font-weight: 500;
-      }
-    }
-
-    &-strong {
-      font-weight: 2000;
-    }
-
-    &-link {
-      font-size: 14px;
-      text-decoration-line: underline;
-      color: $yuxuanBlue;
-      &-wrapper {
-        display: flex;
-        flex-direction: row-reverse;
-        width: 100%;
-        margin-top: -1rem;
-        margin-bottom: 1rem;
-        margin-left: 1rem;
-      }
-    }
-  }
-}
-
-.progress-bar {
-  transition: width 0s ease;
-}
-
-.rating {
-  width: 100%;
-  border-radius: 100px;
-}
-
-.hide {
-  height: 0;
 }
 
 @media only screen and (max-width: 976px) {
@@ -461,16 +136,6 @@ export default Vue.extend({
   .bottombarcourse {
     left: 0rem;
     width: 100%;
-  }
-  .details {
-    &-ratings {
-      width: 60%;
-      &-wrapper {
-        display: flex;
-        flex-direction: column;
-        width: 100%;
-      }
-    }
   }
 }
 

--- a/src/components/BottomBar/BottomBarCourse.vue
+++ b/src/components/BottomBar/BottomBarCourse.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="bottombarcourse">
     <div class="bottombarcourse-wrapper">
-      <div class="bottombarcourse-bar-info-overflow" v-if="!isSmallerWidth">
+      <div
+        :class="
+          isSmallerWidth
+            ? 'bottombarcourse-bar-info-noOverflow'
+            : 'bottombarcourse-bar-info-overflow'
+        "
+      >
         <div class="info">
           <div class="info-section-wrapper">
             <div>
@@ -11,17 +17,17 @@
               </div>
               <div class="section">
                 <h1 class="info-head">Offered</h1>
-                <p class="info-fact">{{ courseObj.semesters }}</p>
+                <p class="info-fact">{{ courseSemesters }}</p>
               </div>
             </div>
             <div>
               <div class="section">
                 <h1 class="info-head">Instructors</h1>
-                <p class="info-fact">{{ courseObj.instructors }}</p>
+                <p class="info-fact">{{ courseInstructors }}</p>
               </div>
               <div class="section">
                 <h1 class="info-head">Enrollment Information</h1>
-                <p class="info-fact">{{ courseObj.enrollmentInfo }}</p>
+                <p class="info-fact">{{ courseEnrollment }}</p>
               </div>
             </div>
             <div>
@@ -29,17 +35,17 @@
                 <h1 class="info-head">Distribution Category</h1>
                 <p
                   class="info-fact"
-                  v-for="distributionCategory in courseObj.distributionCategories"
+                  v-for="distributionCategory in courseDistributions"
                   :key="distributionCategory"
                 >
                   {{ distributionCategory }}
                 </p>
               </div>
               <div class="section">
-                <h1 class="info-head">{{ courseObj.latestSem }} Lecture Information</h1>
+                <h1 class="info-head">{{ courseObj.lastRoster }} Lecture Information</h1>
                 <p
                   class="info-fact"
-                  v-for="latestLecInfo in courseObj.latestLecInfo"
+                  v-for="latestLecInfo in courseLectureTimes"
                   :key="latestLecInfo"
                 >
                   {{ latestLecInfo }}
@@ -48,11 +54,7 @@
             </div>
           </div>
           <div class="info-link">
-            <a
-              :href="`https://classes.cornell.edu/browse/roster/${courseObj.latestSem}/class/${courseObj.subject}/${courseObj.number}`"
-              class="info-link-blue"
-              target="_blank"
-            >
+            <a :href="rosterLink" class="info-link-blue" target="_blank">
               View Course Information on Roster
               <span class="info-link-blue-img"
                 ><img src="@/assets/images/link-blue.svg" alt="link arrow"
@@ -61,15 +63,16 @@
           </div>
         </div>
       </div>
-      <div class="bottombarcourse-bar-details-overflow" v-if="!isSmallerWidth">
+      <div
+        :class="
+          isSmallerWidth
+            ? 'bottombarcourse-bar-details-noOverflow'
+            : 'bottombarcourse-bar-details-overflow'
+        "
+      >
         <div class="details">
           <div class="details-ratings-link-wrapper">
-            <a
-              :href="`https://www.cureviews.org/course/${courseObj.subject}/${courseObj.number}`"
-              class="details-ratings-link"
-              target="_blank"
-              >See All Reviews</a
-            >
+            <a :href="CURLink" class="details-ratings-link" target="_blank">See All Reviews</a>
           </div>
           <div class="details-ratings-wrapper">
             <div class="details-ratings">
@@ -94,8 +97,8 @@
             </div>
             <div class="details-ratings">
               <p class="details-ratings-title">
-                <span class="details-ratings-title-strong">Difficulty:</span
-                ><span class="details-ratings-strong"> {{ CURDifficulty }}</span>
+                <span class="details-ratings-title-strong">Difficulty: </span>
+                <span class="details-ratings-strong"> {{ CURDifficulty }}</span>
               </p>
               <div class="progress rating">
                 <div
@@ -134,147 +137,9 @@
             </div>
           </div>
           <div class="details-head">Prerequisites</div>
-          <p class="info-fact">{{ courseObj.prerequisites }}</p>
+          <p class="info-fact">{{ coursePrereqs }}</p>
           <div class="details-head">Description</div>
           <p class="info-fact">{{ courseObj.description }}</p>
-        </div>
-      </div>
-      <div class="bottombarcourse-bar-details-noOverflow" v-if="isSmallerWidth">
-        <div class="details">
-          <div class="details-ratings-link-wrapper">
-            <a
-              :href="`https://www.cureviews.org/course/${courseObj.subject}/${courseObj.number}`"
-              class="details-ratings-link"
-              target="_blank"
-              >See All Reviews</a
-            >
-          </div>
-          <div class="details-ratings-wrapper">
-            <div class="details-ratings">
-              <p class="details-ratings-title">
-                <span class="details-ratings-title-strong">Overall: </span>
-                <span class="details-ratings-strong">{{ CUROverallRating }}</span>
-              </p>
-              <div class="progress rating">
-                <div
-                  class="progress-bar"
-                  role="progressbar"
-                  :style="{
-                    width: `${(courseObj.overallRating / 5) * 100}%`,
-                    background: reviewsColor(courseObj.overallRating),
-                  }"
-                  aria-label="Overall Rating"
-                  :aria-valuenow="(courseObj.overallRating / 5) * 100"
-                  aria-valuemin="0"
-                  aria-valuemax="100"
-                ></div>
-              </div>
-            </div>
-            <div class="details-ratings">
-              <p class="details-ratings-title">
-                <span class="details-ratings-title-strong">Difficulty: </span
-                ><span class="details-ratings-strong"> {{ CURDifficulty }}</span>
-              </p>
-              <div class="progress rating">
-                <div
-                  class="progress-bar"
-                  role="progressbar"
-                  :style="{
-                    width: `${(courseObj.difficulty / 5) * 100}%`,
-                    background: reviewsColor(courseObj.difficulty, true),
-                  }"
-                  aria-label="Difficulty Rating"
-                  :aria-valuenow="(courseObj.difficulty / 5) * 100"
-                  aria-valuemin="0"
-                  aria-valuemax="100"
-                ></div>
-              </div>
-            </div>
-            <div class="details-ratings">
-              <p class="details-ratings-title">
-                <span class="details-ratings-title-strong">Workload: </span>
-                <span class="details-ratings-strong">{{ CURWorkload }}</span>
-              </p>
-              <div class="progress rating">
-                <div
-                  class="progress-bar"
-                  role="progressbar"
-                  :style="{
-                    width: `${(courseObj.workload / 5) * 100}%`,
-                    background: reviewsColor(courseObj.workload, true),
-                  }"
-                  aria-label="Workload Rating"
-                  :aria-valuenow="(courseObj.workload / 5) * 100"
-                  aria-valuemin="0"
-                  aria-valuemax="100"
-                ></div>
-              </div>
-            </div>
-          </div>
-          <div class="details-head">Prerequisites</div>
-          <p class="info-fact">{{ courseObj.prerequisites }}</p>
-          <div class="details-head">Description</div>
-          <p class="info-fact">{{ courseObj.description }}</p>
-        </div>
-      </div>
-      <div class="bottombarcourse-bar-info-noOverflow" v-if="isSmallerWidth">
-        <div class="info">
-          <div class="info-section-wrapper">
-            <div>
-              <div class="section">
-                <h1 class="info-head">Credits</h1>
-                <p class="info-fact">{{ courseObj.credits }}</p>
-              </div>
-              <div class="section">
-                <h1 class="info-head">Offered</h1>
-                <p class="info-fact">{{ courseObj.semesters }}</p>
-              </div>
-            </div>
-            <div>
-              <div class="section">
-                <h1 class="info-head">Instructors</h1>
-                <p class="info-fact">{{ courseObj.instructors }}</p>
-              </div>
-              <div class="section">
-                <h1 class="info-head">Enrollment Information</h1>
-                <p class="info-fact">{{ courseObj.enrollmentInfo }}</p>
-              </div>
-            </div>
-            <div>
-              <div class="section">
-                <h1 class="info-head">Distribution Category</h1>
-                <p
-                  class="info-fact"
-                  v-for="distributionCategory in courseObj.distributionCategories"
-                  :key="distributionCategory"
-                >
-                  {{ distributionCategory }}
-                </p>
-              </div>
-              <div class="section">
-                <h1 class="info-head">{{ courseObj.latestSem }} Lecture Information</h1>
-                <p
-                  class="info-fact"
-                  v-for="latestLecInfo in courseObj.latestLecInfo"
-                  :key="latestLecInfo"
-                >
-                  {{ latestLecInfo }}
-                </p>
-              </div>
-            </div>
-          </div>
-          <div class="info-link">
-            <a
-              :href="`https://classes.cornell.edu/browse/roster/${courseObj.latestSem}/class/${courseObj.subject}/${courseObj.number}`"
-              class="info-link-blue"
-              target="_blank"
-            >
-              View Course Information on Roster
-              <span class="info-link-blue-img"
-                ><img src="@/assets/images/link-blue.svg" alt="link arrow"
-              /></span>
-            </a>
-          </div>
         </div>
       </div>
     </div>
@@ -284,6 +149,32 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { reviewColors } from '@/assets/constants/colors';
+
+const joinOrNAString = (arr: readonly string[]): string =>
+  arr.length !== 0 && arr[0] !== '' ? arr.join(', ') : 'N/A';
+
+const noneIfEmpty = (str: string): string => (str && str.length !== 0 ? str : 'None');
+
+const naIfEmptyStringArray = (arr: readonly string[]): readonly string[] =>
+  arr && arr.length !== 0 && arr[0] !== '' ? arr : ['N/A'];
+
+const cleanCourseDistributionsArray = (distributions: readonly string[]): readonly string[] => {
+  // Iterates over distributions array and cleans every entry
+  // Removes stray parentheses, spaces, and commas
+  let matches: string[] = [];
+  if (distributions[0] === '') {
+    matches = ['N/A'];
+  } else {
+    for (let i = 0; i < distributions.length; i += 1) {
+      distributions[i].replace(/[A-Za-z0-9-]+/g, d => {
+        matches.push(d);
+        return d;
+      });
+    }
+  }
+
+  return matches;
+};
 
 export default Vue.extend({
   data() {
@@ -326,18 +217,44 @@ export default Vue.extend({
   },
 
   computed: {
+    courseSemesters(): string {
+      return joinOrNAString(this.courseObj.semesters);
+    },
+    courseInstructors(): string {
+      return joinOrNAString(this.courseObj.instructors);
+    },
+    courseEnrollment(): string {
+      return joinOrNAString(this.courseObj.enrollment);
+    },
+    coursePrereqs(): string {
+      return noneIfEmpty(this.courseObj.prereqs);
+    },
+    courseLectureTimes(): readonly string[] {
+      return naIfEmptyStringArray(this.courseObj.lectureTimes);
+    },
+    courseSubjectAndNumber(): { readonly subject: string; readonly number: string } {
+      const [subject, number] = this.courseObj.code.split(' ');
+      return { subject, number };
+    },
+    courseDistributions(): readonly string[] {
+      return cleanCourseDistributionsArray(this.courseObj.distributions);
+    },
+    rosterLink(): string {
+      return `https://classes.cornell.edu/browse/roster/${this.courseObj.lastRoster}/class/${this.courseSubjectAndNumber.subject}/${this.courseSubjectAndNumber.number}`;
+    },
+    CURLink(): string {
+      return `https://www.cureviews.org/course/${this.courseSubjectAndNumber.subject}/${this.courseSubjectAndNumber.number}`;
+    },
     CUROverallRating() {
       if (this.courseObj.overallRating === 0) return '';
       if (!this.courseObj.overallRating) return 'N/A';
       return Math.round(this.courseObj.overallRating * 10) / 10;
     },
-
     CURDifficulty() {
       if (this.courseObj.difficulty === 0) return '';
       if (!this.courseObj.difficulty) return 'N/A';
       return Math.round(this.courseObj.difficulty * 10) / 10;
     },
-
     CURWorkload() {
       if (this.courseObj.workload === 0) return '';
       if (!this.courseObj.workload) return 'N/A';

--- a/src/components/BottomBar/BottomBarCourseInfo.vue
+++ b/src/components/BottomBar/BottomBarCourseInfo.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="info">
+    <div class="info-section-wrapper">
+      <div>
+        <div class="section">
+          <h1 class="info-head">Credits</h1>
+          <p class="info-fact">{{ courseObj.credits }}</p>
+        </div>
+        <div class="section">
+          <h1 class="info-head">Offered</h1>
+          <p class="info-fact">{{ courseSemesters }}</p>
+        </div>
+      </div>
+      <div>
+        <div class="section">
+          <h1 class="info-head">Instructors</h1>
+          <p class="info-fact">{{ courseInstructors }}</p>
+        </div>
+        <div class="section">
+          <h1 class="info-head">Enrollment Information</h1>
+          <p class="info-fact">{{ courseEnrollment }}</p>
+        </div>
+      </div>
+      <div>
+        <div class="section">
+          <h1 class="info-head">Distribution Category</h1>
+          <p
+            class="info-fact"
+            v-for="distributionCategory in courseDistributions"
+            :key="distributionCategory"
+          >
+            {{ distributionCategory }}
+          </p>
+        </div>
+        <div class="section">
+          <h1 class="info-head">{{ courseObj.lastRoster }} Lecture Information</h1>
+          <p class="info-fact" v-for="latestLecInfo in courseLectureTimes" :key="latestLecInfo">
+            {{ latestLecInfo }}
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="info-link">
+      <a :href="rosterLink" class="info-link-blue" target="_blank">
+        View Course Information on Roster
+        <span class="info-link-blue-img"
+          ><img src="@/assets/images/link-blue.svg" alt="link arrow"
+        /></span>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+
+const joinOrNAString = (arr: readonly string[]): string =>
+  arr.length !== 0 && arr[0] !== '' ? arr.join(', ') : 'N/A';
+
+const naIfEmptyStringArray = (arr: readonly string[]): readonly string[] =>
+  arr && arr.length !== 0 && arr[0] !== '' ? arr : ['N/A'];
+
+const cleanCourseDistributionsArray = (distributions: readonly string[]): readonly string[] => {
+  // Iterates over distributions array and cleans every entry
+  // Removes stray parentheses, spaces, and commas
+  let matches: string[] = [];
+  if (distributions[0] === '') {
+    matches = ['N/A'];
+  } else {
+    for (let i = 0; i < distributions.length; i += 1) {
+      distributions[i].replace(/[A-Za-z0-9-]+/g, d => {
+        matches.push(d);
+        return d;
+      });
+    }
+  }
+
+  return matches;
+};
+
+export default Vue.extend({
+  props: {
+    courseObj: { type: Object as PropType<AppBottomBarCourse>, required: true },
+  },
+
+  computed: {
+    courseSemesters(): string {
+      return joinOrNAString(this.courseObj.semesters);
+    },
+    courseInstructors(): string {
+      return joinOrNAString(this.courseObj.instructors);
+    },
+    courseEnrollment(): string {
+      return joinOrNAString(this.courseObj.enrollment);
+    },
+    courseLectureTimes(): readonly string[] {
+      return naIfEmptyStringArray(this.courseObj.lectureTimes);
+    },
+    courseDistributions(): readonly string[] {
+      return cleanCourseDistributionsArray(this.courseObj.distributions);
+    },
+    rosterLink(): string {
+      const [subject, number] = this.courseObj.code.split(' ');
+      return `https://classes.cornell.edu/browse/roster/${this.courseObj.lastRoster}/class/${subject}/${number}`;
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/assets/scss/_variables.scss';
+
+.info {
+  margin: 20px;
+  display: flex;
+  flex-direction: column;
+  height: 90%;
+  justify-content: space-between;
+  margin-bottom: 0rem;
+
+  &-head {
+    margin-top: 5px;
+    font-weight: 500;
+    font-size: 12px;
+    color: $darkGray2;
+    margin-bottom: 0rem;
+  }
+
+  &-fact {
+    padding-right: 10px;
+    font-size: 16px;
+    color: $primaryGray;
+    margin-bottom: 0rem;
+  }
+
+  &-link {
+    font-size: 16px;
+    line-height: 16px;
+    text-decoration-line: underline;
+    margin-top: inherit;
+
+    &-blue {
+      color: $yuxuanBlue;
+      // TODO: update picture
+      font-weight: 500;
+
+      &-img {
+        margin-left: 0.2rem;
+      }
+    }
+  }
+}
+
+.section {
+  margin-bottom: 8px;
+  float: left;
+  width: 50%;
+  height: inherit;
+}
+</style>

--- a/src/components/BottomBar/BottomBarCourseReview.vue
+++ b/src/components/BottomBar/BottomBarCourseReview.vue
@@ -1,0 +1,204 @@
+<template>
+  <div class="details">
+    <div class="details-ratings-link-wrapper">
+      <a :href="CURLink" class="details-ratings-link" target="_blank">See All Reviews</a>
+    </div>
+    <div class="details-ratings-wrapper">
+      <div class="details-ratings">
+        <p class="details-ratings-title">
+          <span class="details-ratings-title-strong">Overall: </span>
+          <span class="details-ratings-strong">{{ CUROverallRating }}</span>
+        </p>
+        <div class="progress rating">
+          <div
+            class="progress-bar"
+            role="progressbar"
+            :style="{
+              width: `${(courseObj.overallRating / 5) * 100}%`,
+              background: reviewsColor(courseObj.overallRating),
+            }"
+            aria-label="Overall Rating"
+            :aria-valuenow="(courseObj.overallRating / 5) * 100"
+            aria-valuemin="0"
+            aria-valuemax="100"
+          ></div>
+        </div>
+      </div>
+      <div class="details-ratings">
+        <p class="details-ratings-title">
+          <span class="details-ratings-title-strong">Difficulty: </span>
+          <span class="details-ratings-strong"> {{ CURDifficulty }}</span>
+        </p>
+        <div class="progress rating">
+          <div
+            class="progress-bar"
+            role="progressbar"
+            :style="{
+              width: `${(courseObj.difficulty / 5) * 100}%`,
+              background: reviewsColor(courseObj.difficulty, true),
+            }"
+            aria-label="Difficulty Rating"
+            :aria-valuenow="(courseObj.difficulty / 5) * 100"
+            aria-valuemin="0"
+            aria-valuemax="100"
+          ></div>
+        </div>
+      </div>
+      <div class="details-ratings">
+        <p class="details-ratings-title">
+          <span class="details-ratings-title-strong">Workload: </span>
+          <span class="details-ratings-strong">{{ CURWorkload }}</span>
+        </p>
+        <div class="progress rating">
+          <div
+            class="progress-bar"
+            role="progressbar"
+            :style="{
+              width: `${(courseObj.workload / 5) * 100}%`,
+              background: reviewsColor(courseObj.workload, true),
+            }"
+            aria-label="Workload Rating"
+            :aria-valuenow="(courseObj.workload / 5) * 100"
+            aria-valuemin="0"
+            aria-valuemax="100"
+          ></div>
+        </div>
+      </div>
+    </div>
+    <div class="details-head">Prerequisites</div>
+    <p class="info-fact">{{ coursePrereqs }}</p>
+    <div class="details-head">Description</div>
+    <p class="info-fact">{{ courseObj.description }}</p>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import { reviewColors } from '@/assets/constants/colors';
+
+const noneIfEmpty = (str: string): string => (str && str.length !== 0 ? str : 'None');
+
+export default Vue.extend({
+  props: {
+    courseObj: { type: Object as PropType<AppBottomBarCourse>, required: true },
+  },
+
+  methods: {
+    joinIfExists(arr: readonly string[]) {
+      return arr ? arr.join(',') : '';
+    },
+
+    reviewsColor(review: number, flip = false) {
+      const colors = Object.values(reviewColors);
+      let index;
+      if (review < 2) {
+        index = 0;
+      } else if (review >= 2 && review < 4) {
+        index = 1;
+      } else {
+        index = 2;
+      }
+
+      return flip ? colors[colors.length - 1 - index] : colors[index];
+    },
+  },
+
+  computed: {
+    coursePrereqs(): string {
+      return noneIfEmpty(this.courseObj.prereqs);
+    },
+    CURLink(): string {
+      const [subject, number] = this.courseObj.code;
+      return `https://www.cureviews.org/course/${subject}/${number}`;
+    },
+    CUROverallRating() {
+      if (this.courseObj.overallRating === 0) return '';
+      if (!this.courseObj.overallRating) return 'N/A';
+      return Math.round(this.courseObj.overallRating * 10) / 10;
+    },
+    CURDifficulty() {
+      if (this.courseObj.difficulty === 0) return '';
+      if (!this.courseObj.difficulty) return 'N/A';
+      return Math.round(this.courseObj.difficulty * 10) / 10;
+    },
+    CURWorkload() {
+      if (this.courseObj.workload === 0) return '';
+      if (!this.courseObj.workload) return 'N/A';
+      return Math.round(this.courseObj.workload * 10) / 10;
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/assets/scss/_variables.scss';
+
+.details {
+  margin: 20px;
+
+  &-head {
+    margin-top: 10px;
+    font-weight: 500;
+    font-size: 12px;
+    color: $darkGray2;
+    margin-bottom: 0rem;
+  }
+
+  &-ratings {
+    margin-right: 3%;
+    width: 30%;
+    float: left;
+    margin-bottom: 1rem;
+
+    &-title {
+      font-size: 16px;
+      line-height: 16px;
+      color: $primaryGray;
+
+      &-strong {
+        font-weight: 500;
+      }
+    }
+
+    &-strong {
+      font-weight: 2000;
+    }
+
+    &-link {
+      font-size: 14px;
+      text-decoration-line: underline;
+      color: $yuxuanBlue;
+      &-wrapper {
+        display: flex;
+        flex-direction: row-reverse;
+        width: 100%;
+        margin-top: -1rem;
+        margin-bottom: 1rem;
+        margin-left: 1rem;
+      }
+    }
+  }
+}
+
+.progress-bar {
+  transition: width 0s ease;
+}
+
+.rating {
+  width: 100%;
+  border-radius: 100px;
+}
+
+@media only screen and (max-width: 878px) {
+  .details {
+    &-ratings {
+      width: 60%;
+      &-wrapper {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -6,7 +6,7 @@
     @click="bottomBarTabToggle(courseObj)"
   >
     <div class="bottombartab-wrapper">
-      <div class="bottombartab-name">{{ subject }} {{ number }}</div>
+      <div class="bottombartab-name">{{ courseObj.code }}</div>
     </div>
     <img
       class="bottombartab-delete"
@@ -22,8 +22,6 @@ import Vue, { PropType } from 'vue';
 
 export default Vue.extend({
   props: {
-    subject: { type: String, required: true },
-    number: { type: String, required: true },
     color: { type: String, required: true },
     courseObj: { type: Object as PropType<AppBottomBarCourse>, required: true },
     tabIndex: { type: Number, required: true },

--- a/src/components/BottomBar/BottomBarTabView.vue
+++ b/src/components/BottomBar/BottomBarTabView.vue
@@ -7,8 +7,6 @@
         class="bottombartabview-courseWrapper"
       >
         <bottom-bar-tab
-          :subject="bottomCourse.subject"
-          :number="bottomCourse.number"
           :color="bottomCourse.color"
           :courseObj="bottomCourse"
           :tabIndex="index"
@@ -44,9 +42,9 @@
             :key="index"
             class="seeMoreCourse-option"
           >
-            <span class="seeMoreCourse-option-text" @click="moveToBottomBar(seeMoreCourse)"
-              >{{ seeMoreCourse.subject }} {{ seeMoreCourse.number }}</span
-            >
+            <span class="seeMoreCourse-option-text" @click="moveToBottomBar(seeMoreCourse)">{{
+              seeMoreCourse.code
+            }}</span>
             <img
               class="seeMoreCourse-option-delete"
               src="@/assets/images/x-blue.svg"

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -90,6 +90,7 @@ import surfing from '@/assets/images/surfing.svg';
 
 import store, { initializeFirestoreListeners } from '@/store';
 import { editSemesters } from '@/global-firestore-data';
+import { firestoreSemesterCourseToBottomBarCourse } from '@/user-data-converter';
 
 const tour = introJs();
 tour.setOption('exitOnEsc', 'false');
@@ -193,26 +194,7 @@ export default Vue.extend({
     updateBar(course: FirestoreSemesterCourse, colorJustChanged: string, color: string) {
       const [subject, number] = course.code.split(' ');
       // Update Bar Information
-      const courseToAdd: AppBottomBarCourse = {
-        subject,
-        number,
-        name: course.name,
-        credits: course.credits,
-        semesters: this.joinOrNAString(course.semesters),
-        color: course.color,
-        latestSem: course.lastRoster,
-        // Array data
-        instructors: this.joinOrNAString(course.instructors),
-        distributionCategories: this.cleanCourseDistributionsArray(course.distributions),
-        enrollmentInfo: this.joinOrNAString(course.enrollment),
-        latestLecInfo: this.naIfEmptyStringArray(course.lectureTimes),
-        overallRating: 0,
-        difficulty: 0,
-        workload: 0,
-        prerequisites: this.noneIfEmpty(course.prereqs),
-        description: course.description,
-        uniqueID: course.uniqueID,
-      };
+      const courseToAdd = firestoreSemesterCourseToBottomBarCourse(course);
 
       // expand bottombar if first course added
       if (this.bottomCourses.length === 0) {
@@ -345,36 +327,6 @@ export default Vue.extend({
     editProfile() {
       this.isOnboarding = true;
       this.isEditingProfile = true;
-    },
-
-    cleanCourseDistributionsArray(distributions: readonly string[]) {
-      // Iterates over distributions array and cleans every entry
-      // Removes stray parentheses, spaces, and commas
-      let matches: string[] = [];
-      if (distributions[0] === '') {
-        matches = ['N/A'];
-      } else {
-        for (let i = 0; i < distributions.length; i += 1) {
-          distributions[i].replace(/[A-Za-z0-9-]+/g, d => {
-            matches.push(d);
-            return d;
-          });
-        }
-      }
-
-      return matches;
-    },
-
-    joinOrNAString(arr: readonly unknown[]) {
-      return arr.length !== 0 && arr[0] !== '' ? arr.join(', ') : 'N/A';
-    },
-
-    noneIfEmpty(str: string) {
-      return str && str.length !== 0 ? str : 'None';
-    },
-
-    naIfEmptyStringArray(arr: readonly string[]) {
-      return arr && arr.length !== 0 && arr[0] !== '' ? arr : ['N/A'];
     },
 
     deleteCourseFromSemesters(uniqueID: number) {

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -95,4 +95,35 @@ export const cornellCourseRosterCourseToFirebaseSemesterCourse = (
   };
 };
 
-export default cornellCourseRosterCourseToFirebaseSemesterCourse;
+export const firestoreSemesterCourseToBottomBarCourse = ({
+  code,
+  name,
+  credits,
+  semesters,
+  color,
+  lastRoster,
+  instructors,
+  distributions,
+  enrollment,
+  lectureTimes,
+  prereqs,
+  description,
+  uniqueID,
+}: FirestoreSemesterCourse): AppBottomBarCourse => ({
+  code,
+  name,
+  credits,
+  semesters,
+  color,
+  lastRoster,
+  instructors,
+  distributions,
+  enrollment,
+  lectureTimes,
+  prereqs,
+  description,
+  uniqueID,
+  overallRating: 0,
+  difficulty: 0,
+  workload: 0,
+});

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -101,23 +101,22 @@ type AppOnboardingData = {
 };
 
 type AppBottomBarCourse = {
-  readonly subject: string;
-  readonly number: string;
+  readonly code: string;
   readonly name: string;
   readonly credits: number;
-  readonly semesters: string;
+  readonly semesters: readonly string[];
   color: string;
-  readonly latestSem: string;
-  readonly instructors: string;
-  readonly distributionCategories: readonly string[];
-  readonly enrollmentInfo: string;
-  readonly latestLecInfo: readonly string[];
+  readonly lastRoster: string;
+  readonly instructors: readonly string[];
+  readonly distributions: readonly string[];
+  readonly enrollment: readonly string[];
+  readonly lectureTimes: readonly string[];
+  readonly prereqs: string;
+  readonly description: string;
+  readonly uniqueID: number;
   overallRating: number;
   difficulty: number;
   workload: number;
-  readonly prerequisites: string;
-  readonly description: string;
-  readonly uniqueID: number;
 };
 
 // map from requirement ID to option chosen


### PR DESCRIPTION
### Summary <!-- Required -->

This PR moves some of the data transformation code for `AppBottomBarCourse` into their own components, so that `Dashboard.vue` doesn't need to contain random data format changing code that doesn't seem to be very top-level. Also, this makes the data format of BottomBar course closer to firebase course, which paves way for unifying the two.

It also resolves this [notion task](https://www.notion.so/82bf355c4b7b49f99691eb9f3afb203c?v=f61b6258c5634200a9f45e381a0fb501&p=40fbeb2b11384fc391790a4ae173c60b) to deduplicate a lot of vue template copy-pasta when dealing with small-width screen.

### Test Plan <!-- Required -->

Desktop comparison against master:
<img width="2415" alt="desktop" src="https://user-images.githubusercontent.com/4290500/108244183-ec280200-711c-11eb-9489-e85baf40e075.png">
Mobile comparison against master:
<img width="1742" alt="mobile" src="https://user-images.githubusercontent.com/4290500/108244184-ecc09880-711c-11eb-85cd-3e643044dfaa.png">

### Note

This PR does introduce some behavior change. In the master version on mobile, the info is below the reviews, while in this PR, info is above the reviews. I can't find any design on figma regarding the mobile behavior, so I'm not sure whether the original behavior is a bug.
