### PR TITLE
Remove console logs

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -28,9 +28,7 @@ export default Vue.extend({
       firebase
         .auth()
         .signOut()
-        .then(
-          () => window.location.reload(),
-        );
+        .then(() => window.location.reload());
     },
     editProfile() {
       this.$emit('editProfile');

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -30,10 +30,6 @@ export default Vue.extend({
         .signOut()
         .then(
           () => window.location.reload(),
-          error => {
-            // TODO: error
-            console.log(error);
-          }
         );
     },
     editProfile() {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -217,9 +217,6 @@ export default Vue.extend({
           this.lastLoadedShowAllCourseId = lastCourse.crseId;
           this.showAllCourses = { name: showAllCourses.requirementName, courses: fetchedCourses };
         })
-        .catch(err => {
-          console.log('Fetch Error: ', err);
-        });
     },
     onScrollSeeAll(event: Event) {
       const { target } = event;
@@ -232,9 +229,6 @@ export default Vue.extend({
               courses: [...this.showAllCourses.courses, ...fetchedCourses],
             };
           })
-          .catch(err => {
-            console.log('Fetch error: ', err);
-          });
       }
     },
     backFromSeeAll() {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -211,24 +211,22 @@ export default Vue.extend({
     }) {
       this.shouldShowAllCourses = true;
       this.showAllSubReqCourses = showAllCourses.subReqCoursesArray;
-      this.getAllCrseInfoFromSemester(showAllCourses.subReqCoursesArray)
-        .then(fetchedCourses => {
-          const lastCourse = fetchedCourses[fetchedCourses.length - 1];
-          this.lastLoadedShowAllCourseId = lastCourse.crseId;
-          this.showAllCourses = { name: showAllCourses.requirementName, courses: fetchedCourses };
-        })
+      this.getAllCrseInfoFromSemester(showAllCourses.subReqCoursesArray).then(fetchedCourses => {
+        const lastCourse = fetchedCourses[fetchedCourses.length - 1];
+        this.lastLoadedShowAllCourseId = lastCourse.crseId;
+        this.showAllCourses = { name: showAllCourses.requirementName, courses: fetchedCourses };
+      });
     },
     onScrollSeeAll(event: Event) {
       const { target } = event;
       const { scrollTop, clientHeight, scrollHeight } = target as HTMLDivElement;
       if (scrollTop + clientHeight >= scrollHeight) {
-        this.getAllCrseInfoFromSemester(this.showAllSubReqCourses)
-          .then(fetchedCourses => {
-            this.showAllCourses = {
-              ...this.showAllCourses,
-              courses: [...this.showAllCourses.courses, ...fetchedCourses],
-            };
-          })
+        this.getAllCrseInfoFromSemester(this.showAllSubReqCourses).then(fetchedCourses => {
+          this.showAllCourses = {
+            ...this.showAllCourses,
+            courses: [...this.showAllCourses.courses, ...fetchedCourses],
+          };
+        });
       }
     },
     backFromSeeAll() {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -302,13 +302,12 @@ export default Vue.extend({
       this.subReqFetchedCourseObjectsNotTakenArray = [];
       this.dataReady = false;
       const subReqCrseInfoObjectsToFetch = this.getMaxFirstFourCrseInfoObjects();
-      fetchCoursesFromFirebaseFunctions(subReqCrseInfoObjectsToFetch)
-        .then(fetchedCourses => {
-          this.subReqFetchedCourseObjectsNotTakenArray.push(
-            ...fetchedCourses.map(cornellCourseRosterCourseToFirebaseSemesterCourse)
-          );
-          this.isDataReady();
-        })
+      fetchCoursesFromFirebaseFunctions(subReqCrseInfoObjectsToFetch).then(fetchedCourses => {
+        this.subReqFetchedCourseObjectsNotTakenArray.push(
+          ...fetchedCourses.map(cornellCourseRosterCourseToFirebaseSemesterCourse)
+        );
+        this.isDataReady();
+      });
     },
     deleteCourseFromSemesters(uniqueId: number) {
       this.$emit('deleteCourseFromSemesters', uniqueId);

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -309,9 +309,6 @@ export default Vue.extend({
           );
           this.isDataReady();
         })
-        .catch(error => {
-          console.log('FetchCourses() Error: ', error);
-        });
     },
     deleteCourseFromSemesters(uniqueId: number) {
       this.$emit('deleteCourseFromSemesters', uniqueId);


### PR DESCRIPTION
### Summary <!-- Required -->

Remove 4 console logs in components to decrease linter warnings from 16 -> 12. This [notion item](https://www.notion.so/82bf355c4b7b49f99691eb9f3afb203c?v=f61b6258c5634200a9f45e381a0fb501&p=3068e663c70f45edb54c2eb67e3d6ed9) explains why we can just remove them, but they were all just logging errors either from firebase or our from our own returned requirements promises.

- [x] Removed all console logs in src/components

### Test Plan <!-- Required -->

Confirm that everything still works where console logs were (so logging in, requirements, and sub req courses)

### Notes <!-- Optional -->

I chose not to change console logs to error in the future instead of just provide warnings so that people can still log when testing their code. Do people agree with this?