### PR TITLE
Setup shared bottom bar state

### DIFF
--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -39,7 +39,9 @@ export default Vue.extend({
       return immutableBottomBarState.isExpanded;
     },
     focusedBottomBarCourse(): AppBottomBarCourse {
-      return immutableBottomBarState.bottomCourses[immutableBottomBarState.bottomCourseFocus];
+      const focus = immutableBottomBarState.bottomCourseFocus;
+      const normalizedFocus = focus < this.maxBottomBarTabs ? focus : this.maxBottomBarTabs - 1;
+      return immutableBottomBarState.bottomCourses[normalizedFocus];
     },
   },
 

--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -1,56 +1,50 @@
 <template>
-  <div class="bottombar">
+  <div class="bottombar" v-if="hasBottomBarCourses">
     <div class="bottombar-tabviewTitleWrapper">
       <div class="bottombar-tabview" :class="{ expandedTabView: isExpanded }">
-        <bottom-bar-tab-view
-          :bottomCourses="bottomCourses"
-          :seeMoreCourses="seeMoreCourses"
-          :bottomCourseFocus="bottomCourseFocus"
-          :isExpanded="isExpanded"
-          :maxBottomBarTabs="maxBottomBarTabs"
-          @bottomBarTabToggle="bottomBarTabToggle"
-          @toggleFromTab="toggle"
-        />
+        <bottom-bar-tab-view :maxBottomBarTabs="maxBottomBarTabs" />
       </div>
-      <div class="bottombar-title" @click="toggle()">
+      <div class="bottombar-title" @click="toggleBottomBar()">
         <bottom-bar-title
-          :color="bottomCourses[bottomCourseFocus].color"
-          :name="bottomCourses[bottomCourseFocus].name"
+          :color="focusedBottomBarCourse.color"
+          :name="focusedBottomBarCourse.name"
           :isExpanded="isExpanded"
         />
       </div>
     </div>
     <div v-if="isExpanded" class="bottombar-course">
-      <bottom-bar-course :courseObj="bottomCourses[bottomCourseFocus]" />
+      <bottom-bar-course :courseObj="focusedBottomBarCourse" />
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import Vue from 'vue';
 import BottomBarCourse from '@/components/BottomBar/BottomBarCourse.vue';
 import BottomBarTabView from '@/components/BottomBar/BottomBarTabView.vue';
 import BottomBarTitle from '@/components/BottomBar/BottomBarTitle.vue';
+import { immutableBottomBarState, toggleBottomBar } from '@/components/BottomBar/BottomBarState';
 
 export default Vue.extend({
   components: { BottomBarCourse, BottomBarTabView, BottomBarTitle },
   props: {
-    bottomCourses: { type: Array as PropType<AppBottomBarCourse[]>, required: true },
-    seeMoreCourses: { type: Array as PropType<AppBottomBarCourse[]>, required: true },
-    bottomCourseFocus: { type: Number, required: true },
-    isExpanded: { type: Boolean, required: true },
     maxBottomBarTabs: { type: Number, required: true },
   },
 
+  computed: {
+    hasBottomBarCourses(): boolean {
+      return immutableBottomBarState.bottomCourses.length > 0;
+    },
+    isExpanded(): boolean {
+      return immutableBottomBarState.isExpanded;
+    },
+    focusedBottomBarCourse(): AppBottomBarCourse {
+      return immutableBottomBarState.bottomCourses[immutableBottomBarState.bottomCourseFocus];
+    },
+  },
+
   methods: {
-    toggle() {
-      if (this.isExpanded) this.$emit('close-bar');
-      else this.$emit('open-bar');
-    },
-    bottomBarTabToggle(courseObj: AppBottomBarCourse) {
-      const newBottomCourseFocus = this.bottomCourses.indexOf(courseObj);
-      this.$emit('change-focus', newBottomCourseFocus);
-    },
+    toggleBottomBar,
   },
 });
 </script>

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -1,0 +1,90 @@
+import { firestoreSemesterCourseToBottomBarCourse } from '@/user-data-converter';
+import Vue from 'vue';
+
+export type BottomBarState = {
+  bottomCourses: readonly AppBottomBarCourse[];
+  bottomCourseFocus: number;
+  isExpanded: boolean;
+};
+
+const vueForBottomBar: BottomBarState & Vue = new Vue({
+  data: {
+    bottomCourses: [] as AppBottomBarCourse[],
+    bottomCourseFocus: 0,
+    isExpanded: false,
+  },
+});
+
+export const immutableBottomBarState: Readonly<BottomBarState> = vueForBottomBar;
+
+export const reportCourseColorChange = (courseUniqueID: number, color: string): void => {
+  vueForBottomBar.bottomCourses = vueForBottomBar.bottomCourses.map(course =>
+    course.uniqueID === courseUniqueID ? { ...course, color } : course
+  );
+};
+
+const getReviews = (
+  subject: string,
+  number: string
+): Promise<{
+  classRating: number;
+  classDifficulty: number;
+  classWorkload: number;
+}> =>
+  fetch(`https://www.cureviews.org/classInfo/${subject}/${number}/CY0LG2ukc2EOBRcoRbQy`).then(res =>
+    res.json().then(reviews => reviews[0])
+  );
+
+export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
+  for (let i = 0; i < vueForBottomBar.bottomCourses.length; i += 1) {
+    const existingCourse = vueForBottomBar.bottomCourses[i];
+    if (existingCourse.uniqueID === course.uniqueID) {
+      vueForBottomBar.bottomCourseFocus = i;
+      return;
+    }
+  }
+
+  if (vueForBottomBar.bottomCourses.length === 0) {
+    vueForBottomBar.isExpanded = true;
+  }
+
+  const bottomBarCourse = firestoreSemesterCourseToBottomBarCourse(course);
+  const [subject, number] = bottomBarCourse.code.split(' ');
+  getReviews(subject, number).then(({ classRating, classDifficulty, classWorkload }) => {
+    bottomBarCourse.overallRating = classRating;
+    bottomBarCourse.difficulty = classDifficulty;
+    bottomBarCourse.workload = classWorkload;
+  });
+
+  vueForBottomBar.bottomCourses = [bottomBarCourse, ...vueForBottomBar.bottomCourses];
+  vueForBottomBar.bottomCourseFocus = 0;
+};
+
+export const toggleBottomBar = (): void => {
+  vueForBottomBar.isExpanded = !vueForBottomBar.isExpanded;
+};
+
+export const closeBottomBar = (): void => {
+  vueForBottomBar.isExpanded = false;
+};
+
+export const changeBottomBarCourseFocus = (index: number): void => {
+  vueForBottomBar.bottomCourseFocus = index;
+};
+
+export const deleteBottomBarCourse = (index: number): void => {
+  vueForBottomBar.bottomCourses = vueForBottomBar.bottomCourses.filter((_, i) => i !== index);
+  if (vueForBottomBar.bottomCourseFocus >= vueForBottomBar.bottomCourses.length) {
+    vueForBottomBar.bottomCourseFocus = vueForBottomBar.bottomCourses.length - 1;
+  }
+};
+
+export const moveBottomBarCourseToFirst = (index: number): void => {
+  const courseToMove = vueForBottomBar.bottomCourses[index];
+  vueForBottomBar.bottomCourses = [
+    courseToMove,
+    ...vueForBottomBar.bottomCourses.slice(0, index),
+    ...vueForBottomBar.bottomCourses.slice(index + 1),
+  ];
+  vueForBottomBar.bottomCourseFocus = 0;
+};

--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -3,7 +3,7 @@
     class="bottombartab"
     :style="{ background: `#${color}` }"
     :class="{ inactive: !isBottomCourseFocus }"
-    @click="bottomBarTabToggle(courseObj)"
+    @click="$emit('on-change-focus')"
   >
     <div class="bottombartab-wrapper">
       <div class="bottombartab-name">{{ courseObj.code }}</div>
@@ -11,7 +11,7 @@
     <img
       class="bottombartab-delete"
       src="@/assets/images/x-white.svg"
-      @click.stop="deleteBottomTab(courseObj)"
+      @click.stop="$emit('on-delete')"
       alt="x"
     />
   </div>
@@ -29,25 +29,8 @@ export default Vue.extend({
     isExpanded: { type: Boolean, required: true },
   },
 
-  methods: {
-    bottomBarTabToggle(courseObj: AppBottomBarCourse) {
-      this.$emit('bottomBarTabToggle', courseObj);
-      this.toggleFromTab();
-    },
-
-    deleteBottomTab(courseObj: AppBottomBarCourse) {
-      this.$emit('deleteBottomTab', courseObj);
-    },
-
-    toggleFromTab() {
-      if (this.tabIndex === this.bottomCourseFocus || !this.isExpanded) {
-        this.$emit('toggleFromTab');
-      }
-    },
-  },
-
   computed: {
-    isBottomCourseFocus() {
+    isBottomCourseFocus(): boolean {
       return this.tabIndex === this.bottomCourseFocus;
     },
   },

--- a/src/components/BottomBar/BottomBarTabView.vue
+++ b/src/components/BottomBar/BottomBarTabView.vue
@@ -2,7 +2,7 @@
   <div class="bottombartabview">
     <div class="bottombartabview-bottomCourseWrapper">
       <div
-        v-for="(bottomCourse, index) in bottomCourses"
+        v-for="(bottomCourse, index) in firstFewCourses"
         :key="index"
         class="bottombartabview-courseWrapper"
       >
@@ -12,16 +12,14 @@
           :tabIndex="index"
           :bottomCourseFocus="bottomCourseFocus"
           :isExpanded="isExpanded"
-          @bottomBarTabToggle="bottomBarTabToggle"
-          @deleteBottomTab="deleteBottomTab"
-          @toggleFromTab="toggleFromTab"
-          @updateBarTabs="updateBarTabs"
+          @on-change-focus="() => changeBottomBarCourseFocus(index)"
+          @on-delete="() => deleteBottomBarCourse(index)"
         />
       </div>
     </div>
     <div v-if="seeMoreCourses.length > 0" class="bottombartabview-seeMoreWrapper">
       <div class="bottombarSeeMoreTab" @click="bottomBarSeeMoreToggle">
-        <div class="bottombarSeeMoreTab-name">{{ seeMoreString }}</div>
+        <div class="bottombarSeeMoreTab-name">See More</div>
         <img
           v-if="!seeMoreOpen"
           class="bottombarSeeMoreTab-arrow"
@@ -42,13 +40,15 @@
             :key="index"
             class="seeMoreCourse-option"
           >
-            <span class="seeMoreCourse-option-text" @click="moveToBottomBar(seeMoreCourse)">{{
-              seeMoreCourse.code
-            }}</span>
+            <span
+              class="seeMoreCourse-option-text"
+              @click="moveBottomBarCourseToFirst(index + maxBottomBarTabs)"
+              >{{ seeMoreCourse.code }}</span
+            >
             <img
               class="seeMoreCourse-option-delete"
               src="@/assets/images/x-blue.svg"
-              @click="deleteSeeMoreCourse(seeMoreCourse)"
+              @click="deleteBottomBarCourse(index + maxBottomBarTabs)"
               alt="x"
             />
           </div>
@@ -59,8 +59,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import Vue from 'vue';
 import BottomBarTab from '@/components/BottomBar/BottomBarTab.vue';
+import {
+  immutableBottomBarState,
+  changeBottomBarCourseFocus,
+  deleteBottomBarCourse,
+  moveBottomBarCourseToFirst,
+} from '@/components/BottomBar/BottomBarState';
 
 export default Vue.extend({
   components: { BottomBarTab },
@@ -70,96 +76,32 @@ export default Vue.extend({
     };
   },
   props: {
-    bottomCourses: { type: Array as PropType<AppBottomBarCourse[]>, required: true },
-    seeMoreCourses: { type: Array as PropType<AppBottomBarCourse[]>, required: true },
-    bottomCourseFocus: { type: Number, required: true },
-    isExpanded: { type: Boolean, required: true },
     maxBottomBarTabs: { type: Number, required: true },
   },
 
   computed: {
-    seeMoreString() {
-      return 'See More';
+    bottomCourseFocus(): number {
+      const focus = immutableBottomBarState.bottomCourseFocus;
+      return focus < this.maxBottomBarTabs ? focus : this.maxBottomBarTabs - 1;
+    },
+    isExpanded(): boolean {
+      return immutableBottomBarState.isExpanded;
+    },
+    /** The first few courses that can fit in the bottom bar tabs without see more. */
+    firstFewCourses(): readonly AppBottomBarCourse[] {
+      return immutableBottomBarState.bottomCourses.slice(0, this.maxBottomBarTabs);
+    },
+    seeMoreCourses(): readonly AppBottomBarCourse[] {
+      return immutableBottomBarState.bottomCourses.slice(this.maxBottomBarTabs);
     },
   },
 
   methods: {
-    bottomBarTabToggle(courseObj: AppBottomBarCourse) {
-      this.$emit('bottomBarTabToggle', courseObj);
-    },
-
-    deleteBottomTab(courseObj: AppBottomBarCourse) {
-      let focusedCourse: AppBottomBarCourse | undefined = this.bottomCourses[
-        this.bottomCourseFocus
-      ];
-      let focusedCourseIndex = 0;
-
-      for (let i = 0; i < this.bottomCourses.length; i += 1) {
-        if (this.bottomCourses[i].uniqueID === courseObj.uniqueID) {
-          this.bottomCourses.splice(i, 1);
-          if (i === this.bottomCourseFocus) {
-            focusedCourse = undefined;
-            focusedCourseIndex = i;
-          }
-        }
-      }
-
-      // if any See More courses exist, move first See More Course to end of tab
-      if (this.seeMoreCourses.length > 0) {
-        const seeMoreCourseToMove = this.seeMoreCourses[0];
-        // remove course from See More Courses
-        this.seeMoreCourses.splice(0, 1);
-
-        // add course to end of bottomCourses
-        this.bottomCourses.push(seeMoreCourseToMove);
-      }
-
-      // update focused course
-      if (focusedCourse) {
-        this.bottomBarTabToggle(focusedCourse);
-      } else if (focusedCourseIndex < this.bottomCourses.length) {
-        this.bottomBarTabToggle(this.bottomCourses[focusedCourseIndex]);
-      } else {
-        this.bottomBarTabToggle(this.bottomCourses[this.bottomCourses.length - 1]);
-      }
-    },
-
+    changeBottomBarCourseFocus,
+    deleteBottomBarCourse,
+    moveBottomBarCourseToFirst,
     bottomBarSeeMoreToggle() {
       this.seeMoreOpen = !this.seeMoreOpen;
-    },
-
-    moveToBottomBar(course: AppBottomBarCourse) {
-      if (this.bottomCourses.length >= this.maxBottomBarTabs) {
-        const bottomCourseToMove = this.bottomCourses[this.bottomCourses.length - 1];
-        // remove bottomCourseToMove from bottomCourses
-        this.bottomCourses.splice(this.bottomCourses.length - 1, 1);
-
-        // add bottomCourseToMove to seeMoreCourses
-        this.seeMoreCourses.unshift(bottomCourseToMove);
-      }
-      // add course to bottomCourses
-      this.bottomCourses.unshift(course);
-      this.bottomBarTabToggle(this.bottomCourses[0]);
-      // remove course from seeMoreCourses
-      this.deleteSeeMoreCourse(course);
-    },
-
-    deleteSeeMoreCourse(course: AppBottomBarCourse) {
-      // remove course from seeMoreCourses
-      for (let i = 0; i < this.seeMoreCourses.length; i += 1) {
-        if (this.seeMoreCourses[i].uniqueID === course.uniqueID) {
-          this.seeMoreCourses.splice(i, 1);
-        }
-      }
-      this.updateBarTabs();
-    },
-
-    toggleFromTab() {
-      this.$emit('toggleFromTab');
-    },
-
-    updateBarTabs() {
-      this.$emit('updateBarTabs');
     },
   },
 });

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{ 'course--min': compact, active: active }" class="course" @click="updateBar()">
+  <div :class="{ 'course--min': compact, active: active }" class="course" @click="courseOnClick()">
     <div
       class="course-color"
       :style="cssVars"
@@ -45,6 +45,10 @@
 import Vue, { PropType } from 'vue';
 import CourseMenu from '@/components/Modals/CourseMenu.vue';
 import CourseCaution from '@/components/CourseCaution.vue';
+import {
+  addCourseToBottomBar,
+  reportCourseColorChange,
+} from '@/components/BottomBar/BottomBarState';
 import { clickOutside } from '@/utilities';
 
 export default Vue.extend({
@@ -62,7 +66,6 @@ export default Vue.extend({
       menuOpen: false,
       stopCloseFlag: false,
       getCreditRange: this.courseObj.creditRange,
-      colorJustChanged: false,
     };
   },
   computed: {
@@ -122,14 +125,14 @@ export default Vue.extend({
     },
     colorCourse(color: string) {
       this.$emit('color-course', color, this.courseObj.uniqueID);
+      reportCourseColorChange(this.courseObj.uniqueID, color);
       this.closeMenuIfOpen();
-      this.colorJustChanged = true;
     },
-    updateBar() {
+    courseOnClick() {
       if (!this.menuOpen) {
-        this.$emit('updateBar', this.courseObj, this.colorJustChanged, this.courseObj.color);
+        this.$emit('course-on-click', this.courseObj);
+        addCourseToBottomBar(this.courseObj);
       }
-      this.colorJustChanged = false;
     },
     editCourseCredit(credit: number) {
       this.$emit('edit-course-credit', credit, this.courseObj.uniqueID);

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="navbar" :class="{ bottomPreview: isBottomPreview }">
+  <div class="navbar">
     <div class="navbar-top">
       <div class="navbar-iconWrapper">
         <img class="navbar-icon" src="@/assets/images/branding/logo.svg" alt="Courseplan logo" />
@@ -19,10 +19,6 @@ import Vue from 'vue';
 import firebase from 'firebase/app';
 
 export default Vue.extend({
-  props: {
-    isBottomPreview: { type: Boolean, required: true },
-  },
-
   methods: {
     logout() {
       firebase
@@ -116,10 +112,6 @@ export default Vue.extend({
   &:active {
     background-image: url('~@/assets/images/navbar/logoutBlue.svg');
   }
-}
-
-.bottomPreview {
-  padding-bottom: calc(2.25rem + 15px);
 }
 
 .mobile {

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -92,7 +92,7 @@
               :semesterIndex="semesterIndex + 1"
               @delete-course="deleteCourse"
               @color-course="colorCourse"
-              @updateBar="updateBar"
+              @course-on-click="courseOnClick"
               @edit-course-credit="editCourseCredit"
             />
           </div>
@@ -367,8 +367,8 @@ export default Vue.extend({
         })
       );
     },
-    updateBar(course: FirestoreSemesterCourse, colorJustChanged: string, color: string) {
-      this.$emit('updateBar', course, colorJustChanged, color);
+    courseOnClick(course: FirestoreSemesterCourse) {
+      this.$emit('course-onclick', course);
     },
     editCourseCredit(credit: number, uniqueID: number) {
       this.$emit(

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -60,7 +60,7 @@
           :activatedCourse="activatedCourse"
           :duplicatedCourseCodeList="duplicatedCourseCodeList"
           :isFirstSem="checkIfFirstSem(sem)"
-          @updateBar="updateBar"
+          @course-onclick="courseOnClick"
           @new-semester="openSemesterModal"
           @delete-semester="deleteSemester"
           @edit-semester="editSemester"
@@ -98,6 +98,7 @@ import NewSemesterModal from '@/components/Modals/NewSemesterModal.vue';
 
 import store from '@/store';
 import { editSemesters } from '@/global-firestore-data';
+import { closeBottomBar } from '@/components/BottomBar/BottomBarState';
 
 // enum to define seasons as integers in season order
 const SeasonsEnum = Object.freeze({
@@ -297,15 +298,14 @@ export default Vue.extend({
           .sort(this.compare)
       );
     },
-    updateBar(course: FirestoreSemesterCourse, colorJustChanged: string, color: string) {
+    courseOnClick(course: FirestoreSemesterCourse) {
       this.activatedCourse = course;
       this.key += 1;
-      this.$emit('updateBar', course, colorJustChanged, color);
       this.isCourseClicked = true;
     },
     closeBar() {
       if (!this.isCourseClicked) {
-        this.$emit('close-bar');
+        closeBottomBar();
       }
       this.isCourseClicked = false;
     },

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -15,7 +15,6 @@
           class="dashboard-nav"
           @editProfile="editProfile"
           @toggleRequirementsBar="toggleRequirementsBar"
-          :isBottomPreview="false"
         />
         <requirements
           class="dashboard-reqs"

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -15,7 +15,7 @@
           class="dashboard-nav"
           @editProfile="editProfile"
           @toggleRequirementsBar="toggleRequirementsBar"
-          :isBottomPreview="bottomBar.isPreview"
+          :isBottomPreview="false"
         />
         <requirements
           class="dashboard-reqs"
@@ -30,12 +30,10 @@
         ref="semesterview"
         :compact="compactVal"
         :startTour="startTour"
-        :isBottomBarExpanded="bottomBar.isExpanded"
-        :isBottomBar="bottomCourses.length > 0"
+        :isBottomBarExpanded="bottomBarIsExpanded"
+        :isBottomBar="hasBottomCourses"
         :isMobile="isMobile"
         @compact-updated="compactVal = $event"
-        @updateBar="updateBar"
-        @close-bar="closeBar"
       />
     </div>
     <tour-window
@@ -61,15 +59,9 @@
     </tour-window>
     <div>
       <bottom-bar
-        v-if="bottomCourses.length > 0 && ((!isOpeningRequirements && isTablet) || !isTablet)"
-        :bottomCourses="bottomCourses"
-        :seeMoreCourses="seeMoreCourses"
-        :bottomCourseFocus="bottomBar.bottomCourseFocus"
-        :isExpanded="bottomBar.isExpanded"
+        v-if="(!isOpeningRequirements && isTablet) || !isTablet"
+        :isExpanded="bottomBarIsExpanded"
         :maxBottomBarTabs="maxBottomBarTabs"
-        @close-bar="closeBar"
-        @open-bar="openBar"
-        @change-focus="changeBottomCourseFocus"
       />
     </div>
   </div>
@@ -90,7 +82,7 @@ import surfing from '@/assets/images/surfing.svg';
 
 import store, { initializeFirestoreListeners } from '@/store';
 import { editSemesters } from '@/global-firestore-data';
-import { firestoreSemesterCourseToBottomBarCourse } from '@/user-data-converter';
+import { immutableBottomBarState } from '@/components/BottomBar/BottomBarState';
 
 const tour = introJs();
 tour.setOption('exitOnEsc', 'false');
@@ -108,10 +100,6 @@ export default Vue.extend({
     return {
       loaded: true,
       compactVal: false,
-      bottomCourses: [] as AppBottomBarCourse[],
-      seeMoreCourses: [] as AppBottomBarCourse[],
-      // Default bottombar info without info
-      bottomBar: { isPreview: false, isExpanded: false, bottomCourseFocus: 0 },
       isOnboarding: false,
       isEditingProfile: false,
       isOpeningRequirements: false,
@@ -144,6 +132,12 @@ export default Vue.extend({
     semesters(): readonly FirestoreSemester[] {
       return store.state.semesters;
     },
+    hasBottomCourses(): boolean {
+      return immutableBottomBarState.bottomCourses.length > 0;
+    },
+    bottomBarIsExpanded(): boolean {
+      return immutableBottomBarState.isExpanded;
+    },
   },
   created() {
     window.addEventListener('resize', this.resizeEventHandler);
@@ -166,10 +160,6 @@ export default Vue.extend({
       this.isMobile = window.innerWidth <= 440;
       this.isTablet = window.innerWidth <= 878;
       this.maxBottomBarTabs = window.innerWidth <= 1347 ? 2 : 4;
-      if (this.bottomBar.bottomCourseFocus >= this.maxBottomBarTabs) {
-        this.changeBottomCourseFocus(this.maxBottomBarTabs - 1);
-      }
-      this.updateBarTabs();
       this.updateSemesterView();
     },
     toggleRequirementsBar() {
@@ -186,121 +176,6 @@ export default Vue.extend({
       if (!this.isMobile) {
         this.showTourEndWindow = true;
       }
-    },
-    changeBottomCourseFocus(newBottomCourseFocus: number) {
-      this.bottomBar.bottomCourseFocus = newBottomCourseFocus;
-    },
-
-    updateBar(course: FirestoreSemesterCourse, colorJustChanged: string, color: string) {
-      const [subject, number] = course.code.split(' ');
-      // Update Bar Information
-      const courseToAdd = firestoreSemesterCourseToBottomBarCourse(course);
-
-      // expand bottombar if first course added
-      if (this.bottomCourses.length === 0) {
-        this.bottomBar.bottomCourseFocus = 0;
-        this.openBar();
-      }
-
-      let bottomCourseIndex = -1;
-      // if course already exists in bottomCourses, first remove course
-      for (let i = 0; i < this.bottomCourses.length; i += 1) {
-        // if colorJustChanged and course already exists, just update course color
-        if (this.bottomCourses[i].uniqueID === course.uniqueID) {
-          if (colorJustChanged) {
-            this.bottomCourses[i].color = color;
-          } else {
-            bottomCourseIndex = i;
-          }
-        }
-      }
-
-      if (bottomCourseIndex < 0) {
-        // Prepending bottomCourse to front of bottom courses array if bottomCourses < this.maxBottomBarTabs
-        // Do not add course to bottomCourses if color was only changed
-        if (this.bottomCourses.length < this.maxBottomBarTabs && !colorJustChanged) {
-          this.bottomCourses.unshift(courseToAdd);
-        } else {
-          // else check no dupe in seeMoreCourses and add to seeMoreCourses
-          for (let i = 0; i < this.seeMoreCourses.length; i += 1) {
-            // if colorJustChanged and course already exists in seeMoreCourses, just update course color
-            if (this.seeMoreCourses[i].uniqueID === course.uniqueID && colorJustChanged) {
-              this.seeMoreCourses[i].color = color;
-            } else if (this.seeMoreCourses[i].uniqueID === course.uniqueID && !colorJustChanged) {
-              this.seeMoreCourses.splice(i, 1);
-            }
-          }
-          // Do not move courses around from bottomCourses to seeMoreCourses if only color changed
-          if (!colorJustChanged) {
-            this.bottomCourses.unshift(courseToAdd);
-            this.seeMoreCourses.unshift(this.bottomCourses[this.bottomCourses.length - 1]);
-            this.bottomCourses.splice(this.bottomCourses.length - 1, 1);
-          }
-        }
-        bottomCourseIndex = 0;
-      }
-      if (!colorJustChanged) {
-        this.bottomBar.bottomCourseFocus = bottomCourseIndex;
-      }
-
-      this.getReviews(subject, number, review => {
-        this.bottomCourses[bottomCourseIndex].overallRating = review.classRating;
-        this.bottomCourses[bottomCourseIndex].difficulty = review.classDifficulty;
-        this.bottomCourses[bottomCourseIndex].workload = review.classWorkload;
-      });
-    },
-
-    getReviews(
-      subject: string,
-      number: string,
-      callback: (review: {
-        classRating: number;
-        classDifficulty: number;
-        classWorkload: number;
-      }) => void
-    ) {
-      fetch(`https://www.cureviews.org/classInfo/${subject}/${number}/CY0LG2ukc2EOBRcoRbQy`).then(
-        res => {
-          res.json().then(reviews => {
-            callback(reviews[0]);
-          });
-        }
-      );
-    },
-
-    updateBarTabs() {
-      // Move courses from see more to bottom tab to fulfill increased bottom tab capacity
-      if (
-        this.maxBottomBarTabs === 4 &&
-        this.bottomCourses.length < 4 &&
-        this.seeMoreCourses.length > 0
-      ) {
-        while (this.bottomCourses.length < 4) {
-          // if any See More courses exist, move first See More Course to end of tab
-          if (this.seeMoreCourses.length > 0) {
-            const seeMoreCourseToMove = this.seeMoreCourses[0];
-            // remove course from See More Courses
-            this.seeMoreCourses.splice(0, 1);
-
-            // add course to end of bottomCourses
-            this.bottomCourses.push(seeMoreCourseToMove);
-          }
-        }
-      } else if (this.maxBottomBarTabs === 2 && this.bottomCourses.length > 2) {
-        // Move courses from bottom tab to see more for decreased max of 2
-        while (this.bottomCourses.length > 2) {
-          const bottomCourseToMove = this.bottomCourses.pop()!;
-          this.seeMoreCourses.unshift(bottomCourseToMove);
-        }
-      }
-    },
-
-    openBar() {
-      this.bottomBar.isExpanded = true;
-    },
-
-    closeBar() {
-      this.bottomBar.isExpanded = false;
     },
 
     startOnboarding() {

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -105,7 +105,7 @@ type AppBottomBarCourse = {
   readonly name: string;
   readonly credits: number;
   readonly semesters: readonly string[];
-  color: string;
+  readonly color: string;
   readonly lastRoster: string;
   readonly instructors: readonly string[];
   readonly distributions: readonly string[];


### PR DESCRIPTION
### Summary <!-- Required -->

The state of bottom bar is complicated. We have bottom courses and see all courses. We have the course that needs to be focused. In addition, bottom bar courses can be updated from everywhere, both inside the bottom bar by clicking and removing, and outside of it by clicking a course in semester view.

It's important to realize that we shouldn't really partition the courses into `bottomBarCourses` and `seeAllCourses`. After all, they logically belong to the same ordered list. We should only partition it inside `BottomBarTabView`, when the courses absolutely needed to be separated into the first few that can be fit into the tab and the rest that must appear in see all. Refactoring it to use a single list removes a lot of hard-to-reason code that if-else on whether a class belong to `bottomBarCourses` or `seeAllCourses`.

To support updating the bottom bar courses from everywhere, I setup another vue instance that acts as the scoped bottom bar courses storage and as a message bus. I decide not to put the data into the Vuex, since Vuex is mostly used for storing data that has strong dependency between each other, especially for requirements.

Setting up the shared bottom bar state makes one thing clear: we can easily update the state with 4 basic operations:

1. report color change of a firestore course
2. add a course to bottom bar
3. change course to focus
4. delete a course

Each of these basic operations is very easy to implement, when we have the data globally. Therefore, I implemented them inside `BottomBarState.ts`, and let all the other components call functions inside this file.

In the end, we have a much better codebase such that:

- `Dashboard.vue` is no longer cluttered with bottom bar update code.
- No more ugly deep props passing and event emitting related to bottom bar.
- Much cleaner bottom bar course logic without a lot of if-else.

### Test Plan <!-- Required -->

- click to add courses to bottom bar. try to remove the courses and click on a tab to change focus.
- focus the last course in the bottom bar and check the focus has been transferred to previous course.
- resize the window to see the focused class between updated, when the original focused one is the 3rd or 4th.
- click on semester to see bottom bar collapses.

### Notes

As a result of this PR, 4 linter warnings related to mutating bottom bar related props have been eliminated!