### PR TITLE
Remove all v-bind

### DIFF
--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -55,7 +55,11 @@ export default Vue.extend({
   components: { CourseCaution, CourseMenu },
   props: {
     courseObj: { type: Object as PropType<FirestoreSemesterCourse>, required: true },
-    duplicatedCourseCodeList: { type: Array, required: false, default: null },
+    duplicatedCourseCodeList: {
+      type: Array as PropType<readonly string[]>,
+      required: false,
+      default: null,
+    },
     compact: { type: Boolean, required: true },
     active: { type: Boolean, required: true },
     isReqCourse: { type: Boolean, required: true },

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -38,7 +38,6 @@
           class="requirements-courseWrapper"
         >
           <course
-            v-bind="course"
             :courseObj="course"
             :isReqCourse="true"
             :compact="true"

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -3,7 +3,7 @@
     <div
       class="fixed"
       data-intro-group="req-tooltip"
-      :v-bind:class="{ 'd-none': !shouldShowAllCourses }"
+      :class="{ 'd-none': shouldShowAllCourses }"
       :data-intro="getRequirementsTooltipText()"
       data-disable-interaction="1"
       data-step="1"
@@ -42,7 +42,6 @@
           <div v-for="(courseData, index) in showAllCourses.courses" :key="index">
             <div class="mt-3">
               <course
-                v-bind="courseData"
                 :courseObj="courseData"
                 :compact="false"
                 :active="false"

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -82,7 +82,6 @@
             class="semester-courseWrapper"
           >
             <course
-              v-bind="course"
               :courseObj="course"
               :duplicatedCourseCodeList="duplicatedCourseCodeList"
               :isReqCourse="false"

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -53,8 +53,10 @@
         :class="{ 'semesterView-wrapper--compact': compact }"
       >
         <semester
-          v-bind="sem"
           ref="semester"
+          :type="sem.type"
+          :year="sem.year"
+          :courses="sem.courses"
           :semesterIndex="semesterIndex"
           :compact="compact"
           :activatedCourse="activatedCourse"
@@ -122,7 +124,7 @@ export default Vue.extend({
       confirmationText: '',
       cautionText: '',
       key: 0,
-      activatedCourse: {},
+      activatedCourse: {} as FirestoreSemesterCourse,
       duplicatedCourseCodeList: [] as readonly string[],
       isCourseClicked: false,
       isSemesterConfirmationOpen: false,


### PR DESCRIPTION
### Summary <!-- Required -->

v-bind will destructure the object to pass down many props implicitly. This can be very confusing because it's unclear by reading the code on what has been passed. As a result, deciding whether some props are unused or whether some props passed in are always true/false becomes harder.

Therefore, I decide to remove all the v-bind once and for all.

### Test Plan <!-- Required -->

It will pass type checking, which shows that all the needed props are still passed down.

Also tested that drag and drop still works.

### Notes <!-- Optional -->

I left a few v-bind because dragula still depends on it. Now that we removed dragula, they are finally safe to remove.