### PR TITLE
Avoid width hardcoding and unnecessary override in Course.vue css

### DIFF
--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -179,7 +179,7 @@ export default Vue.extend({
     justify-content: center;
 
     &--active {
-      width: 19px;
+      width: 1.188rem;
     }
   }
 
@@ -282,7 +282,7 @@ export default Vue.extend({
     }
     &-color {
       &--active {
-        width: 19px;
+        width: 1.188rem;
       }
     }
 

--- a/src/components/Course.vue
+++ b/src/components/Course.vue
@@ -1,18 +1,12 @@
 <template>
   <div :class="{ 'course--min': compact, active: active }" class="course" @click="courseOnClick()">
-    <div
-      class="course-color"
-      :style="cssVars"
-      :class="{ 'course-color--active': active, 'course-color--min': compact }"
-    >
+    <div class="course-color" :style="cssVars" :class="{ 'course-color--active': active }">
       <img src="@/assets/images/dots/sixDots.svg" alt="dots" />
     </div>
-    <div :class="{ 'course-content--min': compact }" class="course-content">
-      <div :class="{ 'course-main--min': compact }" class="course-main">
-        <div :class="{ 'course-top--min': compact }" class="course-top">
-          <div :class="{ 'course-code--min': compact }" class="course-code">
-            {{ courseObj.code }}
-          </div>
+    <div class="course-content">
+      <div class="course-main">
+        <div class="course-top">
+          <div class="course-code">{{ courseObj.code }}</div>
           <div v-if="!isReqCourse" class="course-dotRow" @click="openMenu">
             <img src="@/assets/images/dots/threeDots.svg" alt="dots" />
           </div>
@@ -166,20 +160,18 @@ export default Vue.extend({
   &--min {
     width: 10rem;
     height: 2.125rem;
+
+    & .course-content {
+      margin: 0 0.5em;
+    }
   }
 
   &-main {
-    &--min {
-      display: flex;
-      align-items: center;
-      width: 100%;
-      justify-content: space-between;
-    }
+    width: 100%;
   }
 
   &-color {
     width: 1.25rem;
-    height: 5.625rem;
     border-radius: 0.42rem 0 0 0.42rem;
     background-color: var(--bg-color);
     display: flex;
@@ -188,15 +180,6 @@ export default Vue.extend({
 
     &--active {
       width: 19px;
-      height: 5.5rem;
-    }
-
-    &--min {
-      height: 2.125rem;
-
-      &.course-color--active {
-        height: 2rem;
-      }
     }
   }
 
@@ -212,41 +195,25 @@ export default Vue.extend({
   }
 
   &-content {
-    width: 18rem;
+    flex: 1 1 auto;
     margin: 0 1rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
-
-    &--min {
-      width: 9.25rem;
-      margin-bottom: 0;
-      margin-top: 0;
-      margin-right: 0.5rem;
-      margin-left: 0.5rem;
-    }
   }
 
   &-top {
     display: flex;
+    width: 100%;
     justify-content: space-between;
     align-items: center;
-
-    &--min {
-      display: flex;
-      justify-content: space-between;
-      width: 100%;
-    }
   }
 
   &-code {
+    flex: 1 1 auto;
     font-size: 14px;
     line-height: 17px;
     color: $primaryGray;
-
-    &--min {
-      color: $primaryGray;
-    }
   }
 
   &-name {
@@ -304,13 +271,6 @@ export default Vue.extend({
 
 .active {
   border: 1px solid $yuxuanBlue;
-  height: 5.625rem;
-  width: 21.375rem;
-
-  &.course--min {
-    height: 2.125rem;
-    width: 10rem;
-  }
 }
 
 @media only screen and (max-width: 878px) {
@@ -320,53 +280,9 @@ export default Vue.extend({
       width: 10rem;
       height: 2.125rem;
     }
-    &-main {
-      &--min {
-        display: flex;
-        align-items: center;
-        width: 100%;
-        justify-content: space-between;
-      }
-    }
     &-color {
-      width: 1.25rem;
-      height: 5.625rem;
-      border-radius: 0.42rem 0 0 0.42rem;
-      background-color: var(--bg-color);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
       &--active {
         width: 19px;
-        height: 5.5rem;
-      }
-
-      &--min {
-        height: 2.125rem;
-
-        &.course-color--active {
-          height: 2rem;
-        }
-      }
-    }
-
-    &-content {
-      width: 17rem;
-      &--min {
-        width: 9.25rem;
-        margin-bottom: 0;
-        margin-top: 0;
-        margin-right: 0.5rem;
-      }
-    }
-
-    &-top {
-      width: 14rem;
-      &--min {
-        display: flex;
-        justify-content: space-between;
-        width: 100%;
       }
     }
 
@@ -376,16 +292,6 @@ export default Vue.extend({
 
     &-menu {
       right: -1rem;
-    }
-  }
-  .active {
-    border: 1px solid $yuxuanBlue;
-    height: 5.625rem;
-    width: 17rem;
-
-    &.course--min {
-      height: 2.125rem;
-      width: 10rem;
     }
   }
 }


### PR DESCRIPTION
### Summary <!-- Required -->

The css in `Course.vue` is unnecessarily long. We hardcoded a lot of width values and override a lot of things that are exactly the same. 

I solve the width hardcoding by using the flexbox's `flex: 1 1 auto`. It ensures that the element will use up all the available space, so that we don't need to hardcode a width for all compact x screen-size combinations.

Then I just removed those repeated overrides.

### Test Plan <!-- Required -->

side-by-side comparisons against master
<img width="2473" alt="Screen Shot 2021-02-19 at 13 15 23" src="https://user-images.githubusercontent.com/4290500/108544531-9c7c3e80-72b4-11eb-9469-c2d70226e54e.png">
<img width="2457" alt="Screen Shot 2021-02-19 at 13 15 36" src="https://user-images.githubusercontent.com/4290500/108544533-9dad6b80-72b4-11eb-9609-8879eec4fb3b.png">
<img width="984" alt="Screen Shot 2021-02-19 at 13 15 45" src="https://user-images.githubusercontent.com/4290500/108544538-9e460200-72b4-11eb-9e96-80298923c8bd.png">
<img width="991" alt="Screen Shot 2021-02-19 at 13 15 50" src="https://user-images.githubusercontent.com/4290500/108544539-9e460200-72b4-11eb-8b4e-78a8b3876ff6.png">
