### PR TITLE
[easy] Fix linter warnings and strictify linter config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   // add your custom rules here
   rules: {
-    '@typescript-eslint/ban-ts-comment': ['warn'],
+    '@typescript-eslint/ban-ts-comment': ['error'],
     'vue/attribute-hyphenation': ['off'],
     // TODO: auto-fix of this and the next rule introduces too many code changes that might cause merge conflict.
     'vue/attributes-order': ['off'],

--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -88,7 +88,6 @@ export default Vue.extend({
       selfCheckRequirements: [] as readonly RequirementWithIDSourceType[],
       editMode: false,
       courseSelectorKey: 0,
-      courseIsAddable: true,
       season: '' as FirestoreSemesterType,
       year: 0,
     };
@@ -145,10 +144,6 @@ export default Vue.extend({
       this.reset();
       this.$emit('close-course-modal');
     },
-    // Note: Currently not used
-    checkCourseDuplicate(key: string) {
-      this.$emit('check-course-duplicate', key);
-    },
     addItem() {
       if (this.editMode) {
         this.editMode = false;
@@ -174,10 +169,8 @@ export default Vue.extend({
           resultJSON.data.classes.forEach((resultJSONclass: CornellCourseRosterCourse) => {
             if (resultJSONclass.catalogNbr === number) {
               const course = { ...resultJSONclass, roster };
-              if (this.courseIsAddable) {
-                this.$emit('add-course', course, this.season, this.year);
-                this.chooseSelectableRequirementOption(course.crseId.toString(), requirementID);
-              }
+              this.$emit('add-course', course, this.season, this.year);
+              this.chooseSelectableRequirementOption(course.crseId.toString(), requirementID);
             }
           });
         });

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -4,10 +4,8 @@
       class="semester-modal"
       :class="{ 'modal--block': isCourseModalOpen }"
       :isCourseModelSelectingSemester="isCourseModelSelectingSemester"
-      @check-course-duplicate="checkCourseDuplicate"
       @close-course-modal="closeCourseModal"
       @add-course="addCourse"
-      ref="modal"
     />
     <confirmation
       class="confirmation-modal"
@@ -390,30 +388,6 @@ export default Vue.extend({
     },
     dragListener(event: Event) {
       if (!this.$data.scrollable) event.preventDefault();
-    },
-    // TODO: unused
-    buildIncorrectPlacementCautions() {
-      if (this.courses) {
-        this.courses.forEach(course => {
-          if (!course.semesters.includes(this.type))
-            // @ts-ignore
-            course.alerts.caution = `Course unavailable in the ${this.type}`;
-        });
-      }
-    },
-
-    checkCourseDuplicate(key: string) {
-      if (this.courses) {
-        // @ts-ignore
-        this.$refs.modal.courseIsAddable = true;
-        this.courses.forEach(course => {
-          if (course.code === key) {
-            // @ts-ignore
-            this.$refs.modal.courseIsAddable = false;
-            this.$emit('open-caution-modal');
-          }
-        });
-      }
     },
     seasonMessage() {
       return `<b>This is a Semester Card of your current semester!

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -225,8 +225,7 @@ function filterAndPartitionCoursesThatFulfillRequirement(
 function computeFulfillmentCoursesAndStatistics(
   requirement: RequirementWithIDSourceType,
   coursesTaken: readonly CourseTaken[],
-  toggleableRequirementChoices: AppToggleableRequirementChoices,
-  selectableRequirementChoices: AppSelectableRequirementChoices
+  toggleableRequirementChoices: AppToggleableRequirementChoices
 ): RequirementFulfillmentStatistics & { readonly courses: readonly (readonly CourseTaken[])[] } {
   const spec = getMatchedRequirementFulfillmentSpecification(
     requirement,
@@ -312,12 +311,7 @@ export default function computeGroupedRequirementFulfillmentReports(
     const fulfillmentStatistics = {
       id: requirement.id,
       requirement,
-      ...computeFulfillmentCoursesAndStatistics(
-        requirement,
-        courses,
-        toggleableRequirementChoices,
-        selectableRequirementChoices
-      ),
+      ...computeFulfillmentCoursesAndStatistics(requirement, courses, toggleableRequirementChoices),
     };
 
     switch (requirement.sourceType) {


### PR DESCRIPTION
### Summary <!-- Required -->

Deleted some dead code that are guaranteed to be useless, since the correct course warning code has been merged in.

As a result, we removed all the `@ts-ignore`, so I strictify the level to `error`. In the future, every ts error suppression must be `@ts-expect-error: your reason why this is needed`.

### Test Plan <!-- Required -->

New course modal can still open and work.