### PR TITLE
Integrate user's requirement choice into requirement graph

### DIFF
--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -44,7 +44,7 @@ const getCourseCautions = (course: FirestoreSemesterCourse): CourseCautions => {
   if (illegallyDoubleCountedCourseIDs.has(course.crseId)) {
     illegallyDoubleCountedCourseIDs.forEach(courseId => {
       doubleCountingRequirementWarning = requirementFulfillmentGraph
-        .getConnectedRequirementsFromCourse({ courseId, subject: '', number: '', credits: 0 })
+        .getConnectedRequirementsFromCourse({ courseId, uniqueId: -1, code: '', credits: 0 })
         .filter(id => !userRequirementsMap[id].allowCourseDoubleCounting)
         .map(id => userRequirementsMap[id].name);
     });

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -19,8 +19,7 @@
       <div class="completed-reqCourses-course-object-wrapper">
         <req-course
           :color="courseInfoAndSemesterLabel.color"
-          :subject="courseTaken.subject"
-          :number="courseTaken.number"
+          :courseCode="courseTaken.code"
           :compact="true"
           :isCompletedReqCourse="true"
           class="completed-reqCourses-course-object"
@@ -58,11 +57,7 @@ export default Vue.extend({
       return 'Reset';
     },
     isTransferCredit(): boolean {
-      return (
-        this.courseTaken.subject === 'AP' ||
-        this.courseTaken.subject === 'IB' ||
-        this.courseTaken.subject === 'Swim'
-      );
+      return this.courseTaken.uniqueId === -1;
     },
     courseInfoAndSemesterLabel(): {
       readonly semesterLabel: string;
@@ -73,22 +68,16 @@ export default Vue.extend({
         return { semesterLabel: 'Transfer Credits', color: transferCreditColor, uniqueID: 0 };
       }
 
-      const courseTakenCode = `${this.courseTaken.subject} ${this.courseTaken.number}`;
+      const course = store.state.derivedCoursesData.courseMap[this.courseTaken.uniqueId];
+      const courseSemester =
+        store.state.derivedCoursesData.courseToSemesterMap[this.courseTaken.uniqueId];
+      const courseColor = course != null ? course.color : '';
+      const semesterLabel =
+        courseSemester != null
+          ? `${courseSemester.type} ${courseSemester.year}`
+          : `${getCurrentSeason()} ${getCurrentYear()}`;
 
-      for (let i = 0; i < this.semesters.length; i += 1) {
-        const semester = this.semesters[i];
-        const filteredSemesterCourses = semester.courses.filter(
-          course => course.crseId === this.courseTaken.courseId && course.code === courseTakenCode
-        );
-        if (filteredSemesterCourses.length > 0) {
-          return {
-            semesterLabel: `${semester.type} ${semester.year}`,
-            uniqueID: filteredSemesterCourses[0].uniqueID,
-            color: filteredSemesterCourses[0].color,
-          };
-        }
-      }
-      return { semesterLabel: `${getCurrentSeason()} ${getCurrentYear()}`, uniqueID: 0, color: '' };
+      return { semesterLabel, uniqueID: this.courseTaken.uniqueId, color: courseColor };
     },
   },
   methods: {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -18,15 +18,13 @@
       </div>
       <div class="completed-reqCourses-course-object-wrapper">
         <req-course
-          :color="courseInfoAndSemesterLabel.color"
+          :color="courseColor"
           :courseCode="courseTaken.code"
           :compact="true"
           :isCompletedReqCourse="true"
           class="completed-reqCourses-course-object"
         />
-        <div class="completed-reqCourses-course-object-semester">
-          in {{ courseInfoAndSemesterLabel.semesterLabel }}
-        </div>
+        <div class="completed-reqCourses-course-object-semester">in {{ semesterLabel }}</div>
       </div>
     </div>
   </div>
@@ -59,30 +57,23 @@ export default Vue.extend({
     isTransferCredit(): boolean {
       return this.courseTaken.uniqueId === -1;
     },
-    courseInfoAndSemesterLabel(): {
-      readonly semesterLabel: string;
-      readonly uniqueID: number;
-      readonly color: string;
-    } {
-      if (this.isTransferCredit) {
-        return { semesterLabel: 'Transfer Credits', color: transferCreditColor, uniqueID: 0 };
-      }
-
-      const course = store.state.derivedCoursesData.courseMap[this.courseTaken.uniqueId];
+    semesterLabel(): string {
+      if (this.isTransferCredit) return 'Transfer Credits';
       const courseSemester =
         store.state.derivedCoursesData.courseToSemesterMap[this.courseTaken.uniqueId];
-      const courseColor = course != null ? course.color : '';
-      const semesterLabel =
-        courseSemester != null
-          ? `${courseSemester.type} ${courseSemester.year}`
-          : `${getCurrentSeason()} ${getCurrentYear()}`;
-
-      return { semesterLabel, uniqueID: this.courseTaken.uniqueId, color: courseColor };
+      return courseSemester != null
+        ? `${courseSemester.type} ${courseSemester.year}`
+        : `${getCurrentSeason()} ${getCurrentYear()}`;
+    },
+    courseColor(): string {
+      if (this.isTransferCredit) return transferCreditColor;
+      const course = store.state.derivedCoursesData.courseMap[this.courseTaken.uniqueId];
+      return course != null ? course.color : '';
     },
   },
   methods: {
     onReset() {
-      this.$emit('deleteCourseFromSemesters', this.courseInfoAndSemesterLabel.uniqueID);
+      this.$emit('deleteCourseFromSemesters', this.courseTaken.uniqueId);
     },
   },
 });

--- a/src/components/Requirements/ReqCourse.vue
+++ b/src/components/Requirements/ReqCourse.vue
@@ -17,10 +17,10 @@
         <div :class="{ 'reqcourse-top--min': compact }" class="reqcourse-top">
           <div
             :class="{ 'reqcourse-code--min': compact }"
-            :title="courseCodeLabel"
+            :title="courseCode"
             class="reqcourse-code"
           >
-            {{ courseCodeLabel }}
+            {{ courseCode }}
           </div>
         </div>
       </div>
@@ -34,8 +34,7 @@ import Vue from 'vue';
 export default Vue.extend({
   props: {
     color: { type: String, required: true },
-    subject: { type: String, required: true },
-    number: { type: String, required: true },
+    courseCode: { type: String, required: true },
     isCompletedReqCourse: { type: Boolean, required: true },
     compact: { type: Boolean, required: true },
   },
@@ -45,9 +44,6 @@ export default Vue.extend({
     },
     courseColorCSSvar(): { '--bg-color': string } {
       return { '--bg-color': `#${this.color}` };
-    },
-    courseCodeLabel(): string {
-      return `${this.subject} ${this.number}`;
     },
   },
 });

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -51,10 +51,22 @@ type RequirementFulfillmentInformation<T = Record<string, unknown>> =
 type DecoratedCollegeOrMajorRequirement = RequirementCommon &
   RequirementFulfillmentInformation<{ readonly courses: readonly (readonly number[])[] }>;
 
+/**
+ * CourseTaken is the data type used in requirement computation.
+ * It's a significantly simplified version of FirestoreSemesterCourse to make it easy to mock for
+ * the purpose of requirement computation.
+ */
 type CourseTaken = {
+  /** The course ID from course roster, or our dummy id to denote special courses like FWS equiv. */
   readonly courseId: number;
-  readonly subject: string;
-  readonly number: string;
+  /** Using the unique ID of firestore course for real course, and -1 for AP/IB/Swim */
+  readonly uniqueId: number;
+  /**
+   * Course code like 'CS 2112', 'AP CS'.
+   * It's mostly unused except for displaying completed courses, or calculating total credits.
+   */
+  readonly code: string;
+  /** The number of credits taken, which is used to calculate fulfillment progress. */
   readonly credits: number;
 };
 

--- a/src/requirements/data/exams/ExamCredit.ts
+++ b/src/requirements/data/exams/ExamCredit.ts
@@ -422,8 +422,8 @@ function userDataToCourses(
           const courseId = courseEquivalents[0];
           courses.push({
             courseId,
-            subject: examType,
-            number: exam.name,
+            uniqueId: -1,
+            code: `${examType} ${exam.name}`,
             credits: exam.fulfillment.credits,
           });
         } else {
@@ -431,15 +431,15 @@ function userDataToCourses(
           courseEquivalents.forEach(courseId => {
             courses.push({
               courseId,
-              subject: examType,
-              number: exam.name,
+              uniqueId: -1,
+              code: `${examType} ${exam.name}`,
               credits: 0,
             });
           });
           courses.push({
             courseId: 10,
-            subject: 'CREDITS',
-            number: exam.fulfillment.credits.toString(),
+            uniqueId: -1,
+            code: `CREDITS ${exam.fulfillment.credits}`,
             credits: exam.fulfillment.credits,
           });
         }
@@ -471,9 +471,8 @@ export default function getCourseEquivalentsFromUserExams(
   });
   user.major.forEach((major: string) =>
     getCourseEquivalentsFromOneMajor(user.college, major, userExamData).forEach(course => {
-      const syntheticCourseCode = `${course.subject} ${course.number}`;
-      if (!examCourseCodeSet.has(syntheticCourseCode)) {
-        examCourseCodeSet.add(syntheticCourseCode);
+      if (!examCourseCodeSet.has(course.code)) {
+        examCourseCodeSet.add(course.code);
         courses.push(course);
       }
     })

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -9,11 +9,13 @@ import requirementJson from './typed-requirement-json';
  * The function converts a FireStoreSemesterCourse, the course structure stored in Firebase
  * user data, into a CourseTaken type used throughout the requirements sidebar.
  */
-export function convertFirestoreSemesterCourseToCourseTaken(
-  course: FirestoreSemesterCourse
-): CourseTaken {
-  const [subject, number] = course.code.split(' ');
-  return { subject, courseId: course.crseId, number, credits: course.credits };
+export function convertFirestoreSemesterCourseToCourseTaken({
+  crseId,
+  uniqueID,
+  code,
+  credits,
+}: FirestoreSemesterCourse): CourseTaken {
+  return { courseId: crseId, uniqueId: uniqueID, code, credits };
 }
 
 export function requirementAllowDoubleCounting(
@@ -176,7 +178,6 @@ export function getRelatedUnfulfilledRequirements(
         const allEligibleCourses = requirementSpec.eligibleCourses.flat();
         if (allEligibleCourses.includes(courseID)) {
           directlyRelatedRequirements.push(subRequirement);
-          break;
         }
       }
     }


### PR DESCRIPTION
### Summary <!-- Required -->

This PR integrates user's requirement choice into the graph by implementing the `userChoiceOnDoubleCountingElimiation` function (I will fix the typo of `elimination`  in another PR). This is mostly straightforward since I just need to turn the object into a list of tuples.

I also did a related factoring of including `uniqueID` into the `CourseTaken` type, so that it can be uniquely traced back to the original course. This is not directly required to make this integration happen, but it's important for future work. Right now our requirement graph just thinks that two courses with the same course id as one single course, but this is inaccurate. e.g. You can take two `HIST 1200`, each accounting for one FWS slot. Therefore, it's important for the `CourseTaken` to keep track of both `courseID` and `uniqueID`, one for requirement matching and the other for differentiation. Although I didn't change the requirement algorithm in this PR, it will be the focus of another PR.

### Test Plan <!-- Required -->

Delete some of your courses that show double counted, readd it by selecting some requirement, and see the warning goes away.

### Notes

Note that the courses dragged from the requirement bar can still produce the warnings. That's because they don't go through the process of choosing requirement. We don't really need to choose a requirement for it in UI, because the chosen requirement is already implied by the source of drag and drop. However, that's a thing we haven't done it, and it needs to be done sometime before launch.