### PR TITLE
Disallow drag courses into requirement courses container

### DIFF
--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -16,6 +16,8 @@
         v-if="courses.length > 0"
         class="draggable-requirements-courses"
         group="draggable-semester-courses"
+        :move="onDraggedCourseMove"
+        data-not-droppable="true"
         :value="courses"
         :clone="cloneCourse"
         @start="onDrag"
@@ -40,6 +42,7 @@ import Vue, { PropType } from 'vue';
 import draggable from 'vuedraggable';
 import Course from '@/components/Course/Course.vue';
 import { incrementUniqueID } from '@/global-firestore-data';
+import { onDraggedCourseMove } from '@/utilities';
 
 export default Vue.extend({
   components: { draggable, Course },
@@ -84,6 +87,7 @@ export default Vue.extend({
     },
   },
   methods: {
+    onDraggedCourseMove,
     onDrag() {
       this.scrollable = true;
     },

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -40,6 +40,8 @@
         <draggable
           :value="showAllCourses.courses"
           :clone="cloneCourse"
+          :move="onDraggedCourseMove"
+          data-not-droppable="true"
           group="draggable-semester-courses"
         >
           <div v-for="(courseData, index) in showAllCourses.courses" :key="index">
@@ -73,6 +75,7 @@ import DropDownArrow from '@/components/DropDownArrow.vue';
 import clipboard from '@/assets/images/clipboard.svg';
 import store from '@/store';
 import { chooseToggleableRequirementOption, incrementUniqueID } from '@/global-firestore-data';
+import { onDraggedCourseMove } from '@/utilities';
 
 Vue.use(VueCollapse);
 
@@ -136,6 +139,7 @@ export default Vue.extend({
     },
   },
   methods: {
+    onDraggedCourseMove,
     showMajorOrMinorRequirements(id: number, group: string): boolean {
       if (group === 'Major') {
         return id === this.displayedMajorIndex + this.numOfColleges;

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -69,6 +69,7 @@
           group="draggable-semester-courses"
           v-model="coursesForDraggable"
           :style="{ height: courseContainerHeight + 'rem' }"
+          :move="onDraggedCourseMove"
           @start="onDragStart"
           @sort="onDropped"
           @end="onDragEnd"
@@ -121,7 +122,7 @@ import DeleteSemester from '@/components/Modals/DeleteSemester.vue';
 import EditSemester from '@/components/Modals/EditSemester.vue';
 import AddCourseButton from '@/components/AddCourseButton.vue';
 
-import { clickOutside } from '@/utilities';
+import { onDraggedCourseMove, clickOutside } from '@/utilities';
 
 import fall from '@/assets/images/fallEmoji.svg';
 import spring from '@/assets/images/springEmoji.svg';
@@ -255,6 +256,7 @@ export default Vue.extend({
     },
   },
   methods: {
+    onDraggedCourseMove,
     onDragStart() {
       this.isDraggedFrom = true;
       this.scrollable = true;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -43,6 +43,19 @@ export function getMinorFullName(acronym: string): string {
   return requirementJSON.minor[acronym].name;
 }
 
+/**
+ * The function to be passed to move prop for <draggable /> to prevent a course being dropped into
+ * requirement course container.
+ */
+export function onDraggedCourseMove(event: { to?: HTMLElement }): boolean {
+  const target = event.to;
+  if (target == null) return true;
+  // Use this data on the DOM to denote that it's not a droppable target.
+  // This is the recommended way according to
+  // https://github.com/SortableJS/Vue.Draggable/issues/897
+  return target.getAttribute('data-not-droppable') !== 'true';
+}
+
 export const clickOutside = {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
   bind(el: any, binding: any, vnode: any): void {


### PR DESCRIPTION
### Summary <!-- Required -->

Following the tutorial in https://github.com/SortableJS/Vue.Draggable/issues/897, now the course card won't even appear droppable in the slot.

### Test Plan <!-- Required -->

Incorrect master behavior:
<img width="1412" alt="master" src="https://user-images.githubusercontent.com/4290500/109080597-e0b17980-76ce-11eb-9855-61cf7654fb04.png">

Fixed local behavior:
<img width="1410" alt="local" src="https://user-images.githubusercontent.com/4290500/109080598-e14a1000-76ce-11eb-974c-62314f4b01f9.png">