### PR TITLE
Specialize requirement graph building to avoid unnecessary indirection

### DIFF
--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -16,24 +16,15 @@ const getAllCoursesThatCanPotentiallySatisfyRequirement = (
       throw new Error('Should not get here!');
   }
 };
-// If choice is 1, pick 3410 fulfillment strategy, else, choose 3420
-const getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy = (
-  choice: 1 | 2
-) => ({
-  correspondingRequirement: 'CS3410/CS3420',
-  coursesOfChosenFulfillmentStrategy: [choice === 1 ? 'CS3410' : 'CS3420'],
-});
 
 it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
   const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: [],
-    userChoiceOnDoubleCountingElimiation: [],
-    getRequirementUniqueID: getUniqueID,
+    userChoiceOnFulfillmentStrategy: {},
+    userChoiceOnDoubleCountingElimination: [],
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
     allowDoubleCounting: () => false,
   });
 
@@ -52,12 +43,10 @@ it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
   const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
     userCourses: ['CS3410', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: [],
-    userChoiceOnDoubleCountingElimiation: [],
-    getRequirementUniqueID: getUniqueID,
+    userChoiceOnFulfillmentStrategy: {},
+    userChoiceOnDoubleCountingElimination: [],
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
     allowDoubleCounting: () => false,
   });
 
@@ -68,19 +57,13 @@ it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
 
 // Following two tests test how we are removing edges depending on user choices on fulfillment strategy.
 it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<
-    string,
-    string,
-    1 | 2
-  >({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<string, string>({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: [1],
-    userChoiceOnDoubleCountingElimiation: [],
-    getRequirementUniqueID: getUniqueID,
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
+    userChoiceOnDoubleCountingElimination: [],
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
     allowDoubleCounting: () => false,
   });
 
@@ -95,19 +78,13 @@ it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
 });
 
 it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<
-    string,
-    string,
-    1 | 2
-  >({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<string, string>({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: [2],
-    userChoiceOnDoubleCountingElimiation: [],
-    getRequirementUniqueID: getUniqueID,
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3420'] },
+    userChoiceOnDoubleCountingElimination: [],
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
     allowDoubleCounting: () => false,
   });
 
@@ -123,19 +100,13 @@ it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
 
 // The following two tests test that we will remove edges incompatible with user supplied choices.
 it('buildRequirementFulfillmentGraph phase 3 test 1', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<
-    string,
-    string,
-    1 | 2
-  >({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<string, string>({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: [1],
-    userChoiceOnDoubleCountingElimiation: [['Probability', 'MATH4710']],
-    getRequirementUniqueID: getUniqueID,
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
+    userChoiceOnDoubleCountingElimination: [['Probability', 'MATH4710']],
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
     allowDoubleCounting: () => false,
   });
 
@@ -146,19 +117,13 @@ it('buildRequirementFulfillmentGraph phase 3 test 1', () => {
 });
 
 it('buildRequirementFulfillmentGraph phase 3 test 2', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<
-    string,
-    string,
-    1 | 2
-  >({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<string, string>({
     requirements,
     userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: [1],
-    userChoiceOnDoubleCountingElimiation: [['Elective', 'MATH4710']],
-    getRequirementUniqueID: getUniqueID,
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
+    userChoiceOnDoubleCountingElimination: [['Elective', 'MATH4710']],
     getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
     allowDoubleCounting: () => false,
   });
 
@@ -174,41 +139,33 @@ it('buildRequirementFulfillmentGraph phase 3 test 2', () => {
 
 // The following 3 tests test that we will detect all double counted courses.
 it('buildRequirementFulfillmentGraph phase 4 test 1', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string, 1 | 2>(
-    {
-      requirements,
-      userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-      userChoiceOnFulfillmentStrategy: [1],
-      userChoiceOnDoubleCountingElimiation: [
-        ['CS3410/CS3420', 'CS3410'],
-        ['Probability', 'MATH4710'],
-      ],
-      getRequirementUniqueID: getUniqueID,
-      getCourseUniqueID: getUniqueID,
-      getAllCoursesThatCanPotentiallySatisfyRequirement,
-      getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
-      allowDoubleCounting: () => false,
-    }
-  );
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string>({
+    requirements,
+    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
+    userChoiceOnDoubleCountingElimination: [
+      ['CS3410/CS3420', 'CS3410'],
+      ['Probability', 'MATH4710'],
+    ],
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    allowDoubleCounting: () => false,
+  });
 
   // User specified how to break tie for every double-counted courses, so we are happy here.
   expect(illegallyDoubleCountedCourses).toEqual([]);
 });
 
 it('buildRequirementFulfillmentGraph phase 4 test 2', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string, 1 | 2>(
-    {
-      requirements,
-      userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-      userChoiceOnFulfillmentStrategy: [1],
-      userChoiceOnDoubleCountingElimiation: [['CS3410/CS3420', 'CS3410']],
-      getRequirementUniqueID: getUniqueID,
-      getCourseUniqueID: getUniqueID,
-      getAllCoursesThatCanPotentiallySatisfyRequirement,
-      getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
-      allowDoubleCounting: () => false,
-    }
-  );
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string>({
+    requirements,
+    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
+    userChoiceOnDoubleCountingElimination: [['CS3410/CS3420', 'CS3410']],
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    allowDoubleCounting: () => false,
+  });
 
   // User doesn't specify whether to use MATH4710 to fulfill elective or probability, so MATH4710
   // appears in the double counted list.
@@ -216,19 +173,15 @@ it('buildRequirementFulfillmentGraph phase 4 test 2', () => {
 });
 
 it('buildRequirementFulfillmentGraph phase 4 test 3', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string, 1 | 2>(
-    {
-      requirements,
-      userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-      userChoiceOnFulfillmentStrategy: [1],
-      userChoiceOnDoubleCountingElimiation: [['CS3410/CS3420', 'CS3410']],
-      getRequirementUniqueID: getUniqueID,
-      getCourseUniqueID: getUniqueID,
-      getAllCoursesThatCanPotentiallySatisfyRequirement,
-      getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
-      allowDoubleCounting: requirement => requirement === 'Probability',
-    }
-  );
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string>({
+    requirements,
+    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
+    userChoiceOnDoubleCountingElimination: [['CS3410/CS3420', 'CS3410']],
+    getCourseUniqueID: getUniqueID,
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    allowDoubleCounting: requirement => requirement === 'Probability',
+  });
 
   // Similar to the test case above, but we allowed Probability to be double-counted, so the list is
   // empty.

--- a/src/requirements/__test__/requirement-graph.test.ts
+++ b/src/requirements/__test__/requirement-graph.test.ts
@@ -2,18 +2,13 @@ import RequirementFulfillmentGraph from '../requirement-graph';
 
 it('RequirementFulfillmentGraph works.', () => {
   // We mock a requirement graph built using plain strings to represents requirement and courses.
-  const graph = new RequirementFulfillmentGraph<string, string>(
-    s => s,
-    s => s
-  );
+  const graph = new RequirementFulfillmentGraph<string, string>(s => s);
 
   graph.addEdge('CS3410/CS3420', 'CS 3410');
   graph.addEdge('CS3410/CS3420', 'CS 3420');
   graph.addEdge('Probability', 'MATH 4710');
   graph.addEdge('Elective', 'MATH 4710');
 
-  expect(graph.getAllRequirements()).toEqual(['CS3410/CS3420', 'Probability', 'Elective']);
-  expect(graph.getAllCourses()).toEqual(['CS 3410', 'CS 3420', 'MATH 4710']);
   expect(graph.getAllEdges()).toEqual([
     ['CS3410/CS3420', 'CS 3410'],
     ['CS3410/CS3420', 'CS 3420'],
@@ -29,10 +24,6 @@ it('RequirementFulfillmentGraph works.', () => {
     'Probability',
     'Elective',
   ]);
-  expect(graph.existsEdge('CS3410/CS3420', 'CS 3410')).toBeTruthy();
-  expect(graph.existsEdge('CS3410/CS3420', 'CS 3420')).toBeTruthy();
-  expect(graph.existsEdge('Probability', 'MATH 4710')).toBeTruthy();
-  expect(graph.existsEdge('Elective', 'MATH 4710')).toBeTruthy();
 
   graph.removeEdge('CS3410/CS3420', 'CS 3420');
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS 3410']);
@@ -44,10 +35,6 @@ it('RequirementFulfillmentGraph works.', () => {
     'Probability',
     'Elective',
   ]);
-  expect(graph.existsEdge('CS3410/CS3420', 'CS 3410')).toBeTruthy();
-  expect(graph.existsEdge('CS3410/CS3420', 'CS 3420')).toBeFalsy();
-  expect(graph.existsEdge('Probability', 'MATH 4710')).toBeTruthy();
-  expect(graph.existsEdge('Elective', 'MATH 4710')).toBeTruthy();
 
   graph.removeEdge('Probability', 'MATH 4710');
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS 3410']);
@@ -56,19 +43,11 @@ it('RequirementFulfillmentGraph works.', () => {
   expect(graph.getConnectedRequirementsFromCourse('CS 3410')).toEqual(['CS3410/CS3420']);
   expect(graph.getConnectedRequirementsFromCourse('CS 3420')).toEqual([]);
   expect(graph.getConnectedRequirementsFromCourse('MATH 4710')).toEqual(['Elective']);
-  expect(graph.existsEdge('CS3410/CS3420', 'CS 3410')).toBeTruthy();
-  expect(graph.existsEdge('CS3410/CS3420', 'CS 3420')).toBeFalsy();
-  expect(graph.existsEdge('Probability', 'MATH 4710')).toBeFalsy();
-  expect(graph.existsEdge('Elective', 'MATH 4710')).toBeTruthy();
 });
 
 it('RequirementFulfillmentGraph.addRequirementNode() works', () => {
-  const graph = new RequirementFulfillmentGraph<string, string>(
-    s => s,
-    s => s
-  );
+  const graph = new RequirementFulfillmentGraph<string, string>(s => s);
   graph.addRequirementNode('foo');
-  expect(graph.getAllRequirements()).toEqual(['foo']);
 
   // Test that adding node already exist doesn't erase edges connection.
   graph.addEdge('foo', 'bar');

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -1,11 +1,7 @@
 import RequirementFulfillmentGraph from './requirement-graph';
 import { HashMap } from './util/collections';
 
-type BuildRequirementFulfillmentGraphParameters<
-  Requirement,
-  Course,
-  UserChoiceOnFulfillmentStrategy
-> = {
+type BuildRequirementFulfillmentGraphParameters<Requirement extends string, Course> = {
   /**
    * A list of applicable requirements in the system. e.g. if the user is CS major
    * in COE, then the list should contain all university requirements, COE requirements, and CS major
@@ -15,23 +11,20 @@ type BuildRequirementFulfillmentGraphParameters<
   /** A list of courses user inputted into course plan, regardless of semesters. */
   readonly userCourses: readonly Course[];
   /**
-   * Some requirements might have several different ways to fulfill them. This is a list of objects
-   * that describe user's choices. The exact shape of the object is opaque to function. The only way
-   * for this function to use objects in this array is via
-   * `getAllRelevantCoursesUnderFulfillmentStrategy`.
+   * Some requirements might have several different ways to fulfill them. This is a map from
+   * toggleable requirements to a list of courses that could be applied to the requirement under
+   * the user's choice.
    */
-  readonly userChoiceOnFulfillmentStrategy: readonly UserChoiceOnFulfillmentStrategy[];
+  readonly userChoiceOnFulfillmentStrategy: Readonly<Record<Requirement, readonly Course[]>>;
   /**
    * A list of (requirement, course) tuple that describe how the user decides how a course is used to
    * satisfy requirements. Suppose a course c can be used to satisfy both r1 and r2, but the
    * requirements do not allow double counting, then a tuple (r1, c) means that we should keep the
    * (r1, c) edge in the graph and drop the (r2, c) edge.
    */
-  readonly userChoiceOnDoubleCountingElimiation: readonly (readonly [Requirement, Course])[];
+  readonly userChoiceOnDoubleCountingElimination: readonly (readonly [Requirement, Course])[];
   /** See RequirementFulfillmentGraph for its usage. */
-  readonly getRequirementUniqueID: (r: Requirement) => string;
-  /** See RequirementFulfillmentGraph for its usage. */
-  readonly getCourseUniqueID: (c: Course) => string;
+  readonly getCourseUniqueID: (c: Course) => string | number;
   /**
    * Naively give a list of courses that can satisfy a requirement. Most of the time this function
    * should just return the pre-computed course list. For requirements have multiple fulfillment
@@ -41,41 +34,25 @@ type BuildRequirementFulfillmentGraphParameters<
     requirement: Requirement
   ) => readonly Course[];
   /**
-   * For a requirement with multiple fulfillment strategies, this function should return the list of
-   * courses bind to one fulfillment strategies.
-   */
-  readonly getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy: (
-    choice: UserChoiceOnFulfillmentStrategy
-  ) => {
-    readonly correspondingRequirement: Requirement;
-    readonly coursesOfChosenFulfillmentStrategy: readonly Course[];
-  };
-  /**
    * Report whether a requirement allows a course connected to it to also be used to fulfill some
    * other requirement.
    */
   readonly allowDoubleCounting: (requirement: Requirement) => boolean;
 };
 
-const buildRequirementFulfillmentGraph = <Requirement, Course, UserChoiceOnFulfillmentStrategy>({
+const buildRequirementFulfillmentGraph = <Requirement extends string, Course>({
   requirements,
   userCourses,
   userChoiceOnFulfillmentStrategy,
-  userChoiceOnDoubleCountingElimiation,
-  getRequirementUniqueID,
+  userChoiceOnDoubleCountingElimination,
   getCourseUniqueID,
   getAllCoursesThatCanPotentiallySatisfyRequirement,
-  getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy,
   allowDoubleCounting,
-}: BuildRequirementFulfillmentGraphParameters<
-  Requirement,
-  Course,
-  UserChoiceOnFulfillmentStrategy
->): {
+}: BuildRequirementFulfillmentGraphParameters<Requirement, Course>): {
   readonly requirementFulfillmentGraph: RequirementFulfillmentGraph<Requirement, Course>;
   readonly illegallyDoubleCountedCourses: readonly Course[];
 } => {
-  const graph = new RequirementFulfillmentGraph(getRequirementUniqueID, getCourseUniqueID);
+  const graph = new RequirementFulfillmentGraph<Requirement, Course>(getCourseUniqueID);
   const userCourseSet = new HashMap<Course, Course>(getCourseUniqueID);
   userCourses.forEach(course => userCourseSet.set(course, course));
 
@@ -91,41 +68,38 @@ const buildRequirementFulfillmentGraph = <Requirement, Course, UserChoiceOnFulfi
   });
 
   // Phase 2: Respect user's choices on fulfillment strategies.
-  userChoiceOnFulfillmentStrategy.forEach(choice => {
-    const {
-      correspondingRequirement,
-      coursesOfChosenFulfillmentStrategy,
-    } = getCorrespondingRequirementAndAllRelevantCoursesUnderFulfillmentStrategy(choice);
-    const coursesToKeepSet = new HashMap<Course, null>(getCourseUniqueID);
-    coursesOfChosenFulfillmentStrategy.forEach(course => coursesToKeepSet.set(course, null));
+  Object.entries<readonly Course[]>(userChoiceOnFulfillmentStrategy).forEach(
+    ([key, coursesOfChosenFulfillmentStrategy]) => {
+      const correspondingRequirement = key as Requirement;
+      const coursesToKeepSet = new HashMap<Course, null>(getCourseUniqueID);
+      coursesOfChosenFulfillmentStrategy.forEach(course => coursesToKeepSet.set(course, null));
 
-    graph.getConnectedCoursesFromRequirement(correspondingRequirement).forEach(connectedCourse => {
-      if (!coursesToKeepSet.has(connectedCourse)) {
-        graph.removeEdge(correspondingRequirement, connectedCourse);
-      }
-    });
-  });
+      graph
+        .getConnectedCoursesFromRequirement(correspondingRequirement)
+        .forEach(connectedCourse => {
+          if (!coursesToKeepSet.has(connectedCourse)) {
+            graph.removeEdge(correspondingRequirement, connectedCourse);
+          }
+        });
+    }
+  );
 
   // Phase 3: Respect user's choices on double-counted courses.
-  userChoiceOnDoubleCountingElimiation.forEach(([chosenRequirement, course]) => {
-    const chosenRequirementUniqueID = getRequirementUniqueID(chosenRequirement);
-
+  userChoiceOnDoubleCountingElimination.forEach(([chosenRequirement, course]) => {
     graph.getConnectedRequirementsFromCourse(course).forEach(connectedRequirement => {
       if (allowDoubleCounting(connectedRequirement)) return;
-      if (getRequirementUniqueID(connectedRequirement) !== chosenRequirementUniqueID) {
+      if (connectedRequirement !== chosenRequirement) {
         graph.removeEdge(connectedRequirement, course);
       }
     });
   });
 
   // Phase 4: Detect illegally double counted courses.
-  const illegallyDoubleCountedCourses = graph
-    .getAllCourses()
-    .filter(
-      course =>
-        graph.getConnectedRequirementsFromCourse(course).filter(it => !allowDoubleCounting(it))
-          .length > 1
-    );
+  const illegallyDoubleCountedCourses = userCourses.filter(
+    course =>
+      graph.getConnectedRequirementsFromCourse(course).filter(it => !allowDoubleCounting(it))
+        .length > 1
+  );
 
   // Phase MAX_INT: PROFIT!
   return { requirementFulfillmentGraph: graph, illegallyDoubleCountedCourses };

--- a/src/requirements/requirement-graph.ts
+++ b/src/requirements/requirement-graph.ts
@@ -10,28 +10,16 @@ import { HashMap, HashSet } from './util/collections';
  * We keep type of `Requirement` and `Course` generic, so that they can be easily mocked during
  * testing and make this basic graph implementation not tied to anything specific representation.
  */
-export default class RequirementFulfillmentGraph<Requirement, Course> {
+export default class RequirementFulfillmentGraph<Requirement extends string, Course> {
   // Internally, we use a two hash map to represent the bidirection relation
   // between requirement and courses.
 
-  private readonly requirementToCoursesMap: HashMap<Requirement, HashSet<Course>>;
+  private readonly requirementToCoursesMap: Map<Requirement, HashSet<Course>> = new Map();
 
-  private readonly courseToRequirementsMap: HashMap<Course, HashSet<Requirement>>;
+  private readonly courseToRequirementsMap: HashMap<Course, Set<Requirement>>;
 
-  constructor(
-    private readonly getRequirementUniqueID: (r: Requirement) => string,
-    private readonly getCourseUniqueID: (c: Course) => string
-  ) {
-    this.requirementToCoursesMap = new HashMap(getRequirementUniqueID);
+  constructor(private readonly getCourseUniqueID: (c: Course) => string | number) {
     this.courseToRequirementsMap = new HashMap(getCourseUniqueID);
-  }
-
-  public getAllRequirements(): readonly Requirement[] {
-    return this.requirementToCoursesMap.keys();
-  }
-
-  public getAllCourses(): readonly Course[] {
-    return this.courseToRequirementsMap.keys();
   }
 
   public getAllEdges(): readonly (readonly [Requirement, Course])[] {
@@ -58,7 +46,7 @@ export default class RequirementFulfillmentGraph<Requirement, Course> {
 
     let existingRequirementsLinkedToCourse = this.courseToRequirementsMap.get(course);
     if (existingRequirementsLinkedToCourse == null) {
-      existingRequirementsLinkedToCourse = new HashSet(this.getRequirementUniqueID);
+      existingRequirementsLinkedToCourse = new Set();
       this.courseToRequirementsMap.set(course, existingRequirementsLinkedToCourse);
     }
     existingRequirementsLinkedToCourse.add(requirement);
@@ -85,13 +73,6 @@ export default class RequirementFulfillmentGraph<Requirement, Course> {
   public getConnectedRequirementsFromCourse(course: Course): readonly Requirement[] {
     const requirementSet = this.courseToRequirementsMap.get(course);
     if (requirementSet == null) return [];
-    return requirementSet.toArray();
-  }
-
-  public existsEdge(requirement: Requirement, course: Course): boolean {
-    const existingCoursesLinkedToRequirement = this.requirementToCoursesMap.get(requirement);
-    return (
-      existingCoursesLinkedToRequirement != null && existingCoursesLinkedToRequirement.has(course)
-    );
+    return Array.from(requirementSet);
   }
 }

--- a/src/requirements/util/collections.ts
+++ b/src/requirements/util/collections.ts
@@ -1,7 +1,7 @@
 export class HashMap<K, V> {
-  private readonly backingMap: Map<string, readonly [K, V]>;
+  private readonly backingMap: Map<string | number, readonly [K, V]>;
 
-  constructor(private readonly getUniqueHash: (key: K) => string) {
+  constructor(private readonly getUniqueHash: (key: K) => string | number) {
     this.backingMap = new Map();
   }
 
@@ -49,9 +49,9 @@ export class HashMap<K, V> {
 }
 
 export class HashSet<T> {
-  private readonly backingMap: Map<string, T>;
+  private readonly backingMap: Map<string | number, T>;
 
-  constructor(private readonly getUniqueHash: (value: T) => string) {
+  constructor(private readonly getUniqueHash: (value: T) => string | number) {
     this.backingMap = new Map();
   }
 


### PR DESCRIPTION
### Summary <!-- Required -->

When I initially designed the requirement graph building algorithm, I kept it more general and parameterized so that the core of the algorithm doesn't need to change when we undergo huge refactoring of the representation of requirement, courses, and fulfillment strategy. Now that we settled down on most of the format, it's the time to review whether these indirections are still needed.

- Requirement type in the graph is parameterized. 

  This is completely unnecessary and even harmful now. The actual requirement object we are using is huge and difficult to mock. It's much better to use an ID for requirement for the graph construction, because it's easily to mock and pass around. It also allows the ID to be used as key to allow more efficient representation of things like toggleable requirement choices.

- `userChoiceOnFulfillmentStrategy` is opaque. 

  This is also not very useful, since the function that gives information about the choices already require a specific data format: `(requirement, corresponding courses)`. Therefore, it's much better to stick to the format `{ [reqId: string]: Courses[] }` directly without the indirection.

After this change, the code should be more readable since there are less indirections.

### Test Plan <!-- Required -->

Still compute the same requirement progress:
local:
<img width="1680" alt="local" src="https://user-images.githubusercontent.com/4290500/109201253-9df3ae00-776f-11eb-8c73-1a03676def56.png">
master:
<img width="1680" alt="master" src="https://user-images.githubusercontent.com/4290500/109201256-9e8c4480-776f-11eb-904d-5035a7ac5eca.png">

### Notes

Also fixed the typo `userChoiceOnDoubleCountingElimiation => userChoiceOnDoubleCountingElimination`