### PR TITLE
Make requirement graph aware of courseId and uniqueId

### DIFF
--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -38,13 +38,13 @@ const getCourseCautions = (course: FirestoreSemesterCourse): CourseCautions => {
     derivedCoursesData: { duplicatedCourseCodeSet, courseToSemesterMap },
     userRequirementsMap,
     requirementFulfillmentGraph,
-    illegallyDoubleCountedCourseIDs,
+    illegallyDoubleCountedCourseUniqueIDs,
   } = store.state;
   let doubleCountingRequirementWarning: readonly string[] | undefined;
-  if (illegallyDoubleCountedCourseIDs.has(course.crseId)) {
-    illegallyDoubleCountedCourseIDs.forEach(courseId => {
+  if (illegallyDoubleCountedCourseUniqueIDs.has(course.uniqueID)) {
+    illegallyDoubleCountedCourseUniqueIDs.forEach(uniqueId => {
       doubleCountingRequirementWarning = requirementFulfillmentGraph
-        .getConnectedRequirementsFromCourse({ courseId, uniqueId: -1, code: '', credits: 0 })
+        .getConnectedRequirementsFromCourse({ uniqueId })
         .filter(id => !userRequirementsMap[id].allowCourseDoubleCounting)
         .map(id => userRequirementsMap[id].name);
     });

--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -43,7 +43,6 @@ import CourseSelector, {
 } from '@/components/Modals/NewCourse/CourseSelector.vue';
 
 import store from '@/store';
-import { chooseSelectableRequirementOption } from '@/global-firestore-data';
 import { getRelatedUnfulfilledRequirements } from '@/requirements/requirement-frontend-utils';
 
 export default Vue.extend({
@@ -130,22 +129,13 @@ export default Vue.extend({
           resultJSON.data.classes.forEach((resultJSONclass: CornellCourseRosterCourse) => {
             if (resultJSONclass.catalogNbr === number) {
               const course = { ...resultJSONclass, roster };
-              this.$emit('add-course', course);
-              this.chooseSelectableRequirementOption(course.crseId.toString(), requirementID);
+              this.$emit('add-course', course, requirementID);
             }
           });
         });
 
       this.reset();
       this.closeCurrentModal();
-    },
-    chooseSelectableRequirementOption(courseID: string, requirementID: string): void {
-      if (courseID && requirementID) {
-        chooseSelectableRequirementOption({
-          ...this.selectableRequirementChoices,
-          [courseID]: requirementID,
-        });
-      }
     },
     onSelectedChange(selected: string) {
       this.selectedRequirementID = selected;

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -128,7 +128,9 @@ import fall from '@/assets/images/fallEmoji.svg';
 import spring from '@/assets/images/springEmoji.svg';
 import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
+import { chooseSelectableRequirementOption } from '@/global-firestore-data';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
+import store from '@/store';
 
 const pageTour = introJs();
 pageTour.setOption('exitOnEsc', 'false');
@@ -308,8 +310,12 @@ export default Vue.extend({
     closeConfirmationModal() {
       this.isConfirmationOpen = false;
     },
-    addCourse(data: CornellCourseRosterCourse) {
+    addCourse(data: CornellCourseRosterCourse, requirementID: string) {
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourse(data);
+      chooseSelectableRequirementOption({
+        ...store.state.selectableRequirementChoices,
+        [newCourse.uniqueID]: requirementID,
+      });
       const courseCode = `${data.subject} ${data.catalogNbr}`;
 
       this.$emit(

--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -1,17 +1,21 @@
 import buildRequirementFulfillmentGraph from '../requirement-graph-builder';
 
+const CS3410 = { uniqueId: 3410, courseId: 1 };
+const CS3420 = { uniqueId: 3420, courseId: 2 };
+const MATH4710 = { uniqueId: 4710, courseId: 3 };
+
 const requirements = ['CS3410/CS3420', 'Probability', 'Elective'];
-const getUniqueID = (it: string) => it;
+
 const getAllCoursesThatCanPotentiallySatisfyRequirement = (
   requirement: string
-): readonly string[] => {
+): readonly number[] => {
   switch (requirement) {
     case 'CS3410/CS3420':
-      return ['CS3410', 'CS3420'];
+      return [CS3410.courseId, CS3420.courseId];
     case 'Probability':
-      return ['MATH4710'];
+      return [MATH4710.courseId];
     case 'Elective':
-      return ['CS3410', 'CS3420', 'MATH4710'];
+      return [CS3410.courseId, CS3420.courseId, MATH4710.courseId];
     default:
       throw new Error('Should not get here!');
   }
@@ -20,21 +24,16 @@ const getAllCoursesThatCanPotentiallySatisfyRequirement = (
 it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
   const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
+    userCourses: [CS3410, CS3420, MATH4710],
     userChoiceOnFulfillmentStrategy: {},
     userChoiceOnDoubleCountingElimination: [],
-    getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: () => false,
   });
 
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410', 'CS3420']);
-  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([
-    'CS3410',
-    'CS3420',
-    'MATH4710',
-  ]);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410, CS3420]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420, MATH4710]);
 });
 
 // This test ensures that we are actually using userCourses and drop any courses from pre-computed
@@ -42,112 +41,94 @@ it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
 it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
   const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'MATH4710'],
+    userCourses: [CS3410, MATH4710],
     userChoiceOnFulfillmentStrategy: {},
     userChoiceOnDoubleCountingElimination: [],
-    getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: () => false,
   });
 
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
-  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual(['CS3410', 'MATH4710']);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, MATH4710]);
 });
 
 // Following two tests test how we are removing edges depending on user choices on fulfillment strategy.
 it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<string, string>({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
+    userCourses: [CS3410, CS3420, MATH4710],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
     userChoiceOnDoubleCountingElimination: [],
-    getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: () => false,
   });
 
   // In this case, 3420 is removed since user chooses strategy 1.
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
-  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([
-    'CS3410',
-    'CS3420',
-    'MATH4710',
-  ]);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420, MATH4710]);
 });
 
 it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<string, string>({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3420'] },
+    userCourses: [CS3410, CS3420, MATH4710],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3420.courseId] },
     userChoiceOnDoubleCountingElimination: [],
-    getCourseUniqueID: getUniqueID,
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: () => false,
   });
 
   // In this case, 3410 is removed since user chooses strategy 2.
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3420']);
-  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([
-    'CS3410',
-    'CS3420',
-    'MATH4710',
-  ]);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3420]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420, MATH4710]);
 });
 
 // The following two tests test that we will remove edges incompatible with user supplied choices.
 it('buildRequirementFulfillmentGraph phase 3 test 1', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<string, string>({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
-    userChoiceOnDoubleCountingElimination: [['Probability', 'MATH4710']],
-    getCourseUniqueID: getUniqueID,
+    userCourses: [CS3410, CS3420, MATH4710],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+    userChoiceOnDoubleCountingElimination: { [MATH4710.uniqueId]: 'Probability' },
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: () => false,
   });
 
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
-  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH4710']);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
   // We need a functional phase 3-2 to eliminate CS3410 here.
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual(['CS3410', 'CS3420']);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420]);
 });
 
 it('buildRequirementFulfillmentGraph phase 3 test 2', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph<string, string>({
+  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
-    userChoiceOnDoubleCountingElimination: [['Elective', 'MATH4710']],
-    getCourseUniqueID: getUniqueID,
+    userCourses: [CS3410, CS3420, MATH4710],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+    userChoiceOnDoubleCountingElimination: { [MATH4710.uniqueId]: 'Elective' },
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: () => false,
   });
 
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS3410']);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
   expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([]);
   // We need a functional phase 3-2 to eliminate CS3410 here.
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([
-    'CS3410',
-    'CS3420',
-    'MATH4710',
-  ]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420, MATH4710]);
 });
 
 // The following 3 tests test that we will detect all double counted courses.
 it('buildRequirementFulfillmentGraph phase 4 test 1', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string>({
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
-    userChoiceOnDoubleCountingElimination: [
-      ['CS3410/CS3420', 'CS3410'],
-      ['Probability', 'MATH4710'],
-    ],
-    getCourseUniqueID: getUniqueID,
+    userCourses: [CS3410, CS3420, MATH4710],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+    userChoiceOnDoubleCountingElimination: {
+      [CS3410.uniqueId]: 'CS3410/CS3420',
+      [MATH4710.uniqueId]: 'Probability',
+    },
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: () => false,
   });
@@ -157,28 +138,26 @@ it('buildRequirementFulfillmentGraph phase 4 test 1', () => {
 });
 
 it('buildRequirementFulfillmentGraph phase 4 test 2', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string>({
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
-    userChoiceOnDoubleCountingElimination: [['CS3410/CS3420', 'CS3410']],
-    getCourseUniqueID: getUniqueID,
+    userCourses: [CS3410, CS3420, MATH4710],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+    userChoiceOnDoubleCountingElimination: { [CS3410.uniqueId]: 'CS3410/CS3420' },
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: () => false,
   });
 
   // User doesn't specify whether to use MATH4710 to fulfill elective or probability, so MATH4710
   // appears in the double counted list.
-  expect(illegallyDoubleCountedCourses).toEqual(['MATH4710']);
+  expect(illegallyDoubleCountedCourses).toEqual([MATH4710]);
 });
 
 it('buildRequirementFulfillmentGraph phase 4 test 3', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph<string, string>({
+  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph({
     requirements,
-    userCourses: ['CS3410', 'CS3420', 'MATH4710'],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': ['CS3410'] },
-    userChoiceOnDoubleCountingElimination: [['CS3410/CS3420', 'CS3410']],
-    getCourseUniqueID: getUniqueID,
+    userCourses: [CS3410, CS3420, MATH4710],
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+    userChoiceOnDoubleCountingElimination: { [CS3410.uniqueId]: 'CS3410/CS3420' },
     getAllCoursesThatCanPotentiallySatisfyRequirement,
     allowDoubleCounting: requirement => requirement === 'Probability',
   });

--- a/src/requirements/__test__/requirement-graph.test.ts
+++ b/src/requirements/__test__/requirement-graph.test.ts
@@ -1,56 +1,54 @@
-import RequirementFulfillmentGraph from '../requirement-graph';
+import RequirementFulfillmentGraph, { CourseWithUniqueId } from '../requirement-graph';
+
+const CS3410 = { uniqueId: 3410 };
+const CS3420 = { uniqueId: 3420 };
+const MATH4710 = { uniqueId: 4710 };
 
 it('RequirementFulfillmentGraph works.', () => {
   // We mock a requirement graph built using plain strings to represents requirement and courses.
-  const graph = new RequirementFulfillmentGraph<string, string>(s => s);
+  const graph = new RequirementFulfillmentGraph<string, CourseWithUniqueId>();
 
-  graph.addEdge('CS3410/CS3420', 'CS 3410');
-  graph.addEdge('CS3410/CS3420', 'CS 3420');
-  graph.addEdge('Probability', 'MATH 4710');
-  graph.addEdge('Elective', 'MATH 4710');
+  graph.addEdge('CS3410/CS3420', CS3410);
+  graph.addEdge('CS3410/CS3420', CS3420);
+  graph.addEdge('Probability', MATH4710);
+  graph.addEdge('Elective', MATH4710);
 
   expect(graph.getAllEdges()).toEqual([
-    ['CS3410/CS3420', 'CS 3410'],
-    ['CS3410/CS3420', 'CS 3420'],
-    ['Probability', 'MATH 4710'],
-    ['Elective', 'MATH 4710'],
+    ['CS3410/CS3420', CS3410],
+    ['CS3410/CS3420', CS3420],
+    ['Probability', MATH4710],
+    ['Elective', MATH4710],
   ]);
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS 3410', 'CS 3420']);
-  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH 4710']);
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual(['MATH 4710']);
-  expect(graph.getConnectedRequirementsFromCourse('CS 3410')).toEqual(['CS3410/CS3420']);
-  expect(graph.getConnectedRequirementsFromCourse('CS 3420')).toEqual(['CS3410/CS3420']);
-  expect(graph.getConnectedRequirementsFromCourse('MATH 4710')).toEqual([
-    'Probability',
-    'Elective',
-  ]);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410, CS3420]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([MATH4710]);
+  expect(graph.getConnectedRequirementsFromCourse(CS3410)).toEqual(['CS3410/CS3420']);
+  expect(graph.getConnectedRequirementsFromCourse(CS3420)).toEqual(['CS3410/CS3420']);
+  expect(graph.getConnectedRequirementsFromCourse(MATH4710)).toEqual(['Probability', 'Elective']);
 
-  graph.removeEdge('CS3410/CS3420', 'CS 3420');
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS 3410']);
-  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual(['MATH 4710']);
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual(['MATH 4710']);
-  expect(graph.getConnectedRequirementsFromCourse('CS 3410')).toEqual(['CS3410/CS3420']);
-  expect(graph.getConnectedRequirementsFromCourse('CS 3420')).toEqual([]);
-  expect(graph.getConnectedRequirementsFromCourse('MATH 4710')).toEqual([
-    'Probability',
-    'Elective',
-  ]);
+  graph.removeEdge('CS3410/CS3420', CS3420);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([MATH4710]);
+  expect(graph.getConnectedRequirementsFromCourse(CS3410)).toEqual(['CS3410/CS3420']);
+  expect(graph.getConnectedRequirementsFromCourse(CS3420)).toEqual([]);
+  expect(graph.getConnectedRequirementsFromCourse(MATH4710)).toEqual(['Probability', 'Elective']);
 
-  graph.removeEdge('Probability', 'MATH 4710');
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual(['CS 3410']);
+  graph.removeEdge('Probability', MATH4710);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
   expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([]);
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual(['MATH 4710']);
-  expect(graph.getConnectedRequirementsFromCourse('CS 3410')).toEqual(['CS3410/CS3420']);
-  expect(graph.getConnectedRequirementsFromCourse('CS 3420')).toEqual([]);
-  expect(graph.getConnectedRequirementsFromCourse('MATH 4710')).toEqual(['Elective']);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([MATH4710]);
+  expect(graph.getConnectedRequirementsFromCourse(CS3410)).toEqual(['CS3410/CS3420']);
+  expect(graph.getConnectedRequirementsFromCourse(CS3420)).toEqual([]);
+  expect(graph.getConnectedRequirementsFromCourse(MATH4710)).toEqual(['Elective']);
 });
 
 it('RequirementFulfillmentGraph.addRequirementNode() works', () => {
-  const graph = new RequirementFulfillmentGraph<string, string>(s => s);
+  const graph = new RequirementFulfillmentGraph<string, CourseWithUniqueId>();
   graph.addRequirementNode('foo');
 
   // Test that adding node already exist doesn't erase edges connection.
-  graph.addEdge('foo', 'bar');
+  graph.addEdge('foo', { uniqueId: 234 });
   graph.addRequirementNode('foo');
-  expect(graph.getConnectedCoursesFromRequirement('foo')).toEqual(['bar']);
+  expect(graph.getConnectedCoursesFromRequirement('foo')).toEqual([{ uniqueId: 234 }]);
 });

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -269,7 +269,7 @@ export default function computeGroupedRequirementFulfillmentReports(
 ): {
   readonly userRequirementsMap: Readonly<Record<string, RequirementWithIDSourceType>>;
   readonly requirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
-  readonly illegallyDoubleCountedCourseIDs: ReadonlySet<number>;
+  readonly illegallyDoubleCountedCourseUniqueIDs: ReadonlySet<number>;
   readonly groupedRequirementFulfillmentReport: readonly GroupedRequirementFulfillmentReport[];
 } {
   const coursesTaken = getCourseCodesArray(semesters, onboardingData);
@@ -278,7 +278,7 @@ export default function computeGroupedRequirementFulfillmentReports(
   const {
     userRequirements,
     requirementFulfillmentGraph,
-    illegallyDoubleCountedCourseIDs,
+    illegallyDoubleCountedCourseUniqueIDs,
   } = buildRequirementFulfillmentGraphFromUserData(
     coursesTaken,
     onboardingData,
@@ -353,7 +353,7 @@ export default function computeGroupedRequirementFulfillmentReports(
   return {
     userRequirementsMap: Object.fromEntries(userRequirements.map(it => [it.id, it])),
     requirementFulfillmentGraph,
-    illegallyDoubleCountedCourseIDs,
+    illegallyDoubleCountedCourseUniqueIDs,
     groupedRequirementFulfillmentReport,
   };
 }

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -1,7 +1,13 @@
-import RequirementFulfillmentGraph from './requirement-graph';
-import { HashMap } from './util/collections';
+import RequirementFulfillmentGraph, { CourseWithUniqueId } from './requirement-graph';
 
-type BuildRequirementFulfillmentGraphParameters<Requirement extends string, Course> = {
+interface CourseForRequirementGraph extends CourseWithUniqueId {
+  readonly courseId: number;
+}
+
+type BuildRequirementFulfillmentGraphParameters<
+  Requirement extends string,
+  Course extends CourseForRequirementGraph
+> = {
   /**
    * A list of applicable requirements in the system. e.g. if the user is CS major
    * in COE, then the list should contain all university requirements, COE requirements, and CS major
@@ -12,27 +18,27 @@ type BuildRequirementFulfillmentGraphParameters<Requirement extends string, Cour
   readonly userCourses: readonly Course[];
   /**
    * Some requirements might have several different ways to fulfill them. This is a map from
-   * toggleable requirements to a list of courses that could be applied to the requirement under
+   * toggleable requirements to a list of course IDs that could be applied to the requirement under
    * the user's choice.
+   * (Note: it has to be course id because we want to match course id against eligible course id list.)
    */
-  readonly userChoiceOnFulfillmentStrategy: Readonly<Record<Requirement, readonly Course[]>>;
+  readonly userChoiceOnFulfillmentStrategy: Readonly<Record<Requirement, readonly number[]>>;
   /**
-   * A list of (requirement, course) tuple that describe how the user decides how a course is used to
-   * satisfy requirements. Suppose a course c can be used to satisfy both r1 and r2, but the
-   * requirements do not allow double counting, then a tuple (r1, c) means that we should keep the
+   * The mapping from course's unique ID to requirement.
+   * It describes how the user decides how a course is used to satisfy requirements.
+   * Suppose a course with unique ID c can be used to satisfy both r1 and r2, but the
+   * requirements do not allow double counting, then a mapping `c => r1` means that we should keep the
    * (r1, c) edge in the graph and drop the (r2, c) edge.
    */
-  readonly userChoiceOnDoubleCountingElimination: readonly (readonly [Requirement, Course])[];
-  /** See RequirementFulfillmentGraph for its usage. */
-  readonly getCourseUniqueID: (c: Course) => string | number;
+  readonly userChoiceOnDoubleCountingElimination: Readonly<Record<number, Requirement>>;
   /**
-   * Naively give a list of courses that can satisfy a requirement. Most of the time this function
-   * should just return the pre-computed course list. For requirements have multiple fulfillment
-   * strategies, it will return the union of all pre-computed course list.
+   * Naively give a list of courses ID that can satisfy a requirement. Most of the time this function
+   * should just return the pre-computed eligible course id list. For requirements have multiple
+   * fulfillment strategies, it will return the union of all pre-computed course list.
    */
   readonly getAllCoursesThatCanPotentiallySatisfyRequirement: (
     requirement: Requirement
-  ) => readonly Course[];
+  ) => readonly number[];
   /**
    * Report whether a requirement allows a course connected to it to also be used to fulfill some
    * other requirement.
@@ -40,44 +46,53 @@ type BuildRequirementFulfillmentGraphParameters<Requirement extends string, Cour
   readonly allowDoubleCounting: (requirement: Requirement) => boolean;
 };
 
-const buildRequirementFulfillmentGraph = <Requirement extends string, Course>({
+const buildRequirementFulfillmentGraph = <
+  Requirement extends string,
+  Course extends CourseForRequirementGraph
+>({
   requirements,
   userCourses,
   userChoiceOnFulfillmentStrategy,
   userChoiceOnDoubleCountingElimination,
-  getCourseUniqueID,
   getAllCoursesThatCanPotentiallySatisfyRequirement,
   allowDoubleCounting,
 }: BuildRequirementFulfillmentGraphParameters<Requirement, Course>): {
   readonly requirementFulfillmentGraph: RequirementFulfillmentGraph<Requirement, Course>;
   readonly illegallyDoubleCountedCourses: readonly Course[];
 } => {
-  const graph = new RequirementFulfillmentGraph<Requirement, Course>(getCourseUniqueID);
-  const userCourseSet = new HashMap<Course, Course>(getCourseUniqueID);
-  userCourses.forEach(course => userCourseSet.set(course, course));
+  const graph = new RequirementFulfillmentGraph<Requirement, Course>();
+  const userCourseCourseIDToCourseMap = new Map<number, Course[]>();
+  userCourses.forEach(course => {
+    let existing = userCourseCourseIDToCourseMap.get(course.courseId);
+    if (existing == null) {
+      existing = [];
+      userCourseCourseIDToCourseMap.set(course.courseId, existing);
+    }
+    existing.push(course);
+  });
 
   // Phase 1:
   //   Building a rough graph by naively connecting requirements and courses based on
   //   `getAllCoursesThatCanPotentiallySatisfyRequirement`.
   requirements.forEach(requirement => {
     graph.addRequirementNode(requirement);
-    getAllCoursesThatCanPotentiallySatisfyRequirement(requirement).forEach(course => {
-      const userCourse = userCourseSet.get(course);
-      if (userCourse != null) graph.addEdge(requirement, userCourse);
+    getAllCoursesThatCanPotentiallySatisfyRequirement(requirement).forEach(courseId => {
+      (userCourseCourseIDToCourseMap.get(courseId) || []).forEach(userCourse =>
+        graph.addEdge(requirement, userCourse)
+      );
     });
   });
 
   // Phase 2: Respect user's choices on fulfillment strategies.
-  Object.entries<readonly Course[]>(userChoiceOnFulfillmentStrategy).forEach(
+  Object.entries<readonly number[]>(userChoiceOnFulfillmentStrategy).forEach(
     ([key, coursesOfChosenFulfillmentStrategy]) => {
       const correspondingRequirement = key as Requirement;
-      const coursesToKeepSet = new HashMap<Course, null>(getCourseUniqueID);
-      coursesOfChosenFulfillmentStrategy.forEach(course => coursesToKeepSet.set(course, null));
+      const coursesToKeepSet = new Set(coursesOfChosenFulfillmentStrategy);
 
       graph
         .getConnectedCoursesFromRequirement(correspondingRequirement)
         .forEach(connectedCourse => {
-          if (!coursesToKeepSet.has(connectedCourse)) {
+          if (!coursesToKeepSet.has(connectedCourse.courseId)) {
             graph.removeEdge(correspondingRequirement, connectedCourse);
           }
         });
@@ -85,13 +100,16 @@ const buildRequirementFulfillmentGraph = <Requirement extends string, Course>({
   );
 
   // Phase 3: Respect user's choices on double-counted courses.
-  userChoiceOnDoubleCountingElimination.forEach(([chosenRequirement, course]) => {
-    graph.getConnectedRequirementsFromCourse(course).forEach(connectedRequirement => {
-      if (allowDoubleCounting(connectedRequirement)) return;
-      if (connectedRequirement !== chosenRequirement) {
-        graph.removeEdge(connectedRequirement, course);
-      }
-    });
+  Object.entries(userChoiceOnDoubleCountingElimination).forEach(([key, chosenRequirement]) => {
+    const courseUniqueID = parseInt(key, 10);
+    graph
+      .getConnectedRequirementsFromCourse({ uniqueId: courseUniqueID })
+      .forEach(connectedRequirement => {
+        if (allowDoubleCounting(connectedRequirement)) return;
+        if (connectedRequirement !== chosenRequirement) {
+          graph.removeEdge(connectedRequirement, { uniqueId: courseUniqueID });
+        }
+      });
   });
 
   // Phase 4: Detect illegally double counted courses.

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,7 +33,7 @@ export type VuexStoreState = {
   userRequirementsMap: Readonly<Record<string, RequirementWithIDSourceType>>;
   requirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
   groupedRequirementFulfillmentReport: readonly GroupedRequirementFulfillmentReport[];
-  illegallyDoubleCountedCourseIDs: ReadonlySet<number>;
+  illegallyDoubleCountedCourseUniqueIDs: ReadonlySet<number>;
   subjectColors: Readonly<Record<string, string>>;
   uniqueIncrementer: number;
 };
@@ -69,7 +69,7 @@ const store: TypedVuexStore = new TypedVuexStore({
     // It won't be null once the app loads.
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     requirementFulfillmentGraph: null!,
-    illegallyDoubleCountedCourseIDs: new Set(),
+    illegallyDoubleCountedCourseUniqueIDs: new Set(),
     groupedRequirementFulfillmentReport: [],
     subjectColors: {},
     uniqueIncrementer: 0,
@@ -109,13 +109,13 @@ const store: TypedVuexStore = new TypedVuexStore({
         VuexStoreState,
         | 'userRequirementsMap'
         | 'requirementFulfillmentGraph'
-        | 'illegallyDoubleCountedCourseIDs'
+        | 'illegallyDoubleCountedCourseUniqueIDs'
         | 'groupedRequirementFulfillmentReport'
       >
     ) {
       state.userRequirementsMap = data.userRequirementsMap;
       state.requirementFulfillmentGraph = data.requirementFulfillmentGraph;
-      state.illegallyDoubleCountedCourseIDs = data.illegallyDoubleCountedCourseIDs;
+      state.illegallyDoubleCountedCourseUniqueIDs = data.illegallyDoubleCountedCourseUniqueIDs;
       state.groupedRequirementFulfillmentReport = data.groupedRequirementFulfillmentReport;
     },
     setSubjectColors(state: VuexStoreState, colors: Readonly<Record<string, string>>) {

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -120,8 +120,8 @@ type AppBottomBarCourse = {
   workload: number;
 };
 
-// map from requirement ID to option chosen
+/** Map from requirement ID to option chosen */
 type AppToggleableRequirementChoices = Readonly<Record<string, string>>;
 
-// map from course ID to requirement ID
+/** Map from course's unique ID to requirement ID */
 type AppSelectableRequirementChoices = Readonly<Record<string, string>>;


### PR DESCRIPTION
### Summary <!-- Required -->

Depends on #326.

In the past, our requirement algorithm is essentially a bipartite graph between requirement ID and course ID. This works pretty well in most cases, but not all. It's important to note that we were assuming course ID uniquely denotes a course taken by the user. We know this is not true, since cross-listed courses have the same ID, but it doesn't cause any issues most of the time.

However, it does cause issues sometimes. For example, the FWS requirement can be fulfilled by HIST 1200, and HIST 1200 has multiple sections, each denoting a different actual class. You can take `HIST 1200 - SEC 201` in the first semester and `HIST 1200 - SEC 202` in the second semester, and then the requirement should just be fulfilled without issue. It is not the case right now, because our requirement graph thinks that they are the same course, and of course, one course can only be used for one slot.

This PR changes this situation by making the requirement graph building algorithm aware of the distinction between `courseId` and `uniqueId`. The requirement graph should be a graph between requirements and **unique ID**, because it's legit to make one class fulfill requirement A and requirement B. `courseId` is still needed, because we need `courseId` to match against eligible courses in requirements json.

After this PR, each course, even repeated ones, can choose its own requirement. Therefore, I also changed the double counted course courseId set to be unique ID set.

The changes in production code itself is mostly straightforward. A lot of changes are coming from the tests.

### Test Plan <!-- Required -->

Normal requirement computation is not changed:
local:
<img width="1680" alt="local" src="https://user-images.githubusercontent.com/4290500/109201253-9df3ae00-776f-11eb-8c73-1a03676def56.png">
master:
<img width="1680" alt="master" src="https://user-images.githubusercontent.com/4290500/109201256-9e8c4480-776f-11eb-904d-5035a7ac5eca.png">

Now duplicate courses can be used to count towards different requirements:
(Example: Two different FWS both under HIST 1200)
<img width="995" alt="Screen Shot 2021-02-25 at 16 11 33" src="https://user-images.githubusercontent.com/4290500/109217875-680cf480-7784-11eb-9286-741ee389c637.png">
