### PR TITLE
[easy] Treat requirement with warnings as self-check

### DIFF
--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -80,7 +80,11 @@
         </div>
       </div>
       <div
-        v-if="displayDescription && subReq.requirement.fulfilledBy !== 'self-check'"
+        v-if="
+          displayDescription &&
+          subReq.requirement.fulfilledBy !== 'self-check' &&
+          subReq.requirement.checkerWarning == null
+        "
         class="subreqcourse-wrapper"
       >
         <div v-for="(subReqCourseSlot, id) in subReqCoursesSlots" :key="id">
@@ -105,7 +109,11 @@
         </div>
       </div>
       <div
-        v-if="displayDescription && subReq.requirement.fulfilledBy === 'self-check'"
+        v-if="
+          displayDescription &&
+          (subReq.requirement.fulfilledBy === 'self-check' ||
+            subReq.requirement.checkerWarning != null)
+        "
         class="subreqcourse-wrapper"
       >
         <div v-for="(selfCheckCourse, id) in fulfilledSelfCheckCourses" :key="id">

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -171,10 +171,13 @@ export function getRelatedUnfulfilledRequirements(
         toggleableRequirementChoices
       );
       // potential self-check requirements
-      if (requirementSpec == null && !subRequirement.allowCourseDoubleCounting) {
+      if (
+        (requirementSpec == null || subRequirement.checkerWarning != null) &&
+        !subRequirement.allowCourseDoubleCounting
+      ) {
         selfCheckRequirements.push(subRequirement);
       }
-      if (requirementSpec != null) {
+      if (requirementSpec != null && subRequirement.checkerWarning == null) {
         const allEligibleCourses = requirementSpec.eligibleCourses.flat();
         if (allEligibleCourses.includes(courseID)) {
           directlyRelatedRequirements.push(subRequirement);


### PR DESCRIPTION
### Summary <!-- Required -->

We can easily treat requirement with warnings as self-check by checking whether the `checkerWarning` field exist on requirement. If it exists, we treat it as self-check.

### Test Plan <!-- Required -->

In the add modal, `technical elective` is still considered as self-check.
<img width="499" alt="Screen Shot 2021-02-27 at 16 36 36" src="https://user-images.githubusercontent.com/4290500/109401053-64ab7180-791a-11eb-97e2-11f2968eb364.png">

In the sidebar, `technical elective` is still considered as self-check with dropdown, but has correct number of courses shown.
<img width="376" alt="Screen Shot 2021-02-27 at 16 36 42" src="https://user-images.githubusercontent.com/4290500/109401054-64ab7180-791a-11eb-886a-3574b8159553.png">

### Notes <!-- Optional -->

The warning text is not shown yet because I don't see the design.