### PR TITLE
See all fixes

### DIFF
--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -1,5 +1,9 @@
 <template>
-  <div :class="{ 'course--min': compact, active: active }" class="course" @click="courseOnClick()">
+  <div
+    :class="{ 'course--min': compact, active: active, 'course--reqs': isReqCourse && !compact }"
+    class="course"
+    @click="courseOnClick()"
+  >
     <div class="course-color" :style="cssVars" :class="{ 'course-color--active': active }">
       <img src="@/assets/images/dots/sixDots.svg" alt="dots" />
     </div>
@@ -138,9 +142,16 @@ export default Vue.extend({
   box-shadow: 0px 0px 10px 4px $boxShadowGray;
   position: relative;
   height: 5.625rem;
+  touch-action: none;
+  cursor: grab;
 
   &:hover {
     background: rgba(255, 255, 255, 0.15);
+  }
+
+  &:active:hover {
+    touch-action: none;
+    cursor: grabbing;
   }
 
   &--min {
@@ -216,6 +227,7 @@ export default Vue.extend({
   }
 
   &-info {
+    max-width: 18rem;
     font-size: 14px;
     line-height: 17px;
     color: $lightPlaceholderGray;
@@ -276,7 +288,38 @@ export default Vue.extend({
       width: 14rem;
     }
 
+    &-info {
+      max-width: 14rem;
+    }
+
     &-menu {
+      right: -1rem;
+    }
+  }
+}
+
+@media only screen and (max-width: $large-breakpoint) {
+  .course--reqs {
+    width: 17rem;
+    .course--min {
+      width: 10rem;
+      height: 2.125rem;
+    }
+    .course-color {
+      &--active {
+        width: 1.188rem;
+      }
+    }
+
+    .course-name {
+      width: 14rem;
+    }
+
+    .course-info {
+      max-width: 14rem;
+    }
+
+    .course-menu {
       right: -1rem;
     }
   }

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -146,6 +146,8 @@ export default Vue.extend({
   }
   &-content {
     z-index: 2;
+    position: absolute;
+    width: 88%;
     background: $white;
     box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.25);
     border-radius: 7px;

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -116,6 +116,10 @@ export default Vue.extend({
     &:not(:first-child) {
       margin-top: 0.5rem;
     }
+
+    &-wrapper {
+      position: relative;
+    }
   }
   &-placeholder {
     height: 100%;
@@ -147,7 +151,7 @@ export default Vue.extend({
   &-content {
     z-index: 2;
     position: absolute;
-    width: 88%;
+    width: 100%;
     background: $white;
     box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.25);
     border-radius: 7px;

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -63,7 +63,6 @@ export default Vue.extend({
     courses: { type: Array as PropType<readonly FirestoreSemesterCourse[]>, required: true },
     showSeeAllLabel: { type: Boolean, required: true },
     displayDescription: { type: Boolean, required: true },
-    lastLoadedShowAllCourseId: { type: Number, required: true },
   },
   computed: {
     addCourseLabel() {

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -101,7 +101,7 @@ export default Vue.extend({
       return { ...courseWithDummyUniqueID, uniqueID: incrementUniqueID() };
     },
     onShowAllCourses() {
-      this.$emit('onShowAllCourses');
+      this.$emit('onShowAllCourses', this.subReqCourseId);
     },
   },
 });

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -25,7 +25,6 @@
             :toggleableRequirementChoice="toggleableRequirementChoices[subReq.requirement.id]"
             :color="reqGroupColorMap[req.groupName][0]"
             :isCompleted="false"
-            :lastLoadedShowAllCourseId="lastLoadedShowAllCourseId"
             @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
             @onShowAllCourses="onShowAllCourses"
             @deleteCourseFromSemesters="deleteCourseFromSemesters"
@@ -56,7 +55,6 @@
               :toggleableRequirementChoice="toggleableRequirementChoices[subReq.requirement.id]"
               :color="reqGroupColorMap[req.groupName][0]"
               :isCompleted="true"
-              :lastLoadedShowAllCourseId="lastLoadedShowAllCourseId"
               @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
               @onShowAllCourses="onShowAllCourses"
               @deleteCourseFromSemesters="deleteCourseFromSemesters"
@@ -103,7 +101,6 @@ export default Vue.extend({
     displayedMinorIndex: { type: Number, required: true },
     showMajorOrMinorRequirements: { type: Boolean, required: true },
     numOfColleges: { type: Number, required: true },
-    lastLoadedShowAllCourseId: { type: Number, required: true },
   },
   data() {
     return {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -81,7 +81,7 @@ Vue.use(VueCollapse);
 
 export type ShowAllCourses = {
   readonly name: string;
-  readonly courses: FirestoreSemesterCourse[];
+  readonly courses: CourseTaken[];
 };
 
 type Data = {
@@ -169,12 +169,10 @@ export default Vue.extend({
     },
     onShowAllCourses(showAllCourses: {
       requirementName: string;
-      subReqCoursesArray: SubReqCourseSlot[];
+      subReqCoursesArray: CourseTaken[];
     }) {
       this.shouldShowAllCourses = true;
-      const allPotentialCourses = showAllCourses.subReqCoursesArray
-        .flatMap(slot => (slot.isCompleted ? [] : slot.courses))
-        .slice(0, 24);
+      const allPotentialCourses = showAllCourses.subReqCoursesArray.slice(0, 24); // limited to 24 courses
       const lastCourse = allPotentialCourses[allPotentialCourses.length - 1];
       this.lastLoadedShowAllCourseId = lastCourse.crseId;
       this.showAllCourses = {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -80,7 +80,7 @@ Vue.use(VueCollapse);
 
 export type ShowAllCourses = {
   readonly name: string;
-  readonly courses: CourseTaken[];
+  readonly courses: FirestoreSemesterCourse[];
 };
 
 type Data = {
@@ -168,7 +168,7 @@ export default Vue.extend({
     },
     onShowAllCourses(showAllCourses: {
       requirementName: string;
-      subReqCoursesArray: CourseTaken[];
+      subReqCoursesArray: FirestoreSemesterCourse[];
     }) {
       this.shouldShowAllCourses = true;
 

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -90,7 +90,7 @@ Vue.use(VueCollapse);
 
 export type ShowAllCourses = {
   readonly name: string;
-  readonly shownCourses: FirestoreSemesterCourse[];
+  shownCourses: FirestoreSemesterCourse[];
   readonly allCourses: FirestoreSemesterCourse[];
 };
 
@@ -154,7 +154,7 @@ export default Vue.extend({
       return Math.ceil(this.showAllCourses.allCourses.length / this.maxSeeAllCoursesPerPage);
     },
     hasNextPage(): boolean {
-      return this.showAllPage * this.maxSeeAllCoursesPerPage < this.numPages;
+      return this.showAllPage + 1 < this.numPages;
     },
     hasPrevPage(): boolean {
       return this.showAllPage > 0;

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -69,7 +69,6 @@ import introJs from 'intro.js';
 
 import Course from '@/components/Course/Course.vue';
 import RequirementView from '@/components/Requirements/RequirementView.vue';
-import { SubReqCourseSlot } from '@/components/Requirements/SubRequirement.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 // emoji for clipboard
 import clipboard from '@/assets/images/clipboard.svg';
@@ -172,9 +171,20 @@ export default Vue.extend({
       subReqCoursesArray: CourseTaken[];
     }) {
       this.shouldShowAllCourses = true;
-      const allPotentialCourses = showAllCourses.subReqCoursesArray.slice(0, 24); // limited to 24 courses
-      const lastCourse = allPotentialCourses[allPotentialCourses.length - 1];
-      this.lastLoadedShowAllCourseId = lastCourse.crseId;
+
+      // limited to 24 courses
+      const allPotentialCourses = showAllCourses.subReqCoursesArray.slice(
+        this.lastLoadedShowAllCourseId,
+        this.lastLoadedShowAllCourseId + 24
+      );
+
+      // next time see all is open, show next 24 courses (unless already reached the end)
+      if (this.lastLoadedShowAllCourseId + 24 > showAllCourses.subReqCoursesArray.length) {
+        this.lastLoadedShowAllCourseId = 0;
+      } else {
+        this.lastLoadedShowAllCourseId += 24;
+      }
+
       this.showAllCourses = {
         name: showAllCourses.requirementName,
         courses: allPotentialCourses,

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -213,11 +213,14 @@ export default Vue.extend({
 }
 .requirements,
 .fixed {
+  z-index: 1;
   height: 100%;
   width: 25rem;
   background-color: $white;
 }
 .fixed {
+  position: fixed;
+  left: 4.5rem;
   top: 0;
   overflow-y: scroll;
   overflow-x: hidden;
@@ -283,7 +286,6 @@ h1.title {
     width: 100%;
     padding-left: 0.5rem;
     top: 4.5rem;
-    z-index: 1;
   }
 
   .fixed {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -279,8 +279,11 @@ h1.title {
 
 @media only screen and (max-width: $medium-breakpoint) {
   .requirements {
+    position: fixed;
     width: 100%;
     padding-left: 0.5rem;
+    top: 4.5rem;
+    z-index: 1;
   }
 
   .fixed {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -36,14 +36,24 @@
       </div>
       <div class="see-all-padding-x py-3">
         <h1 class="title">{{ showAllCourses.name }}</h1>
-        <div class="see-all-pages">
+        <div class="see-all-pages" v-if="numPages > 1">
           <span class="see-all-pageCount">{{ pageText }}</span>
           <div class="see-all-buttonWrapper">
-            <button class="see-all-button" :class="{ 'see-all-button--disabled': !hasPrevPage }">
-              <span class="see-all-button-text" @click="prevPage()">PREV</span>
+            <button
+              class="see-all-button"
+              :class="{ 'see-all-button--disabled': !hasPrevPage }"
+              :disabled="!hasPrevPage"
+              @click="prevPage()"
+            >
+              <span class="see-all-button-text">PREV</span>
             </button>
-            <button class="see-all-button" :class="{ 'see-all-button--disabled': !hasNextPage }">
-              <span class="see-all-button-text" @click="nextPage()">NEXT</span>
+            <button
+              class="see-all-button"
+              :class="{ 'see-all-button--disabled': !hasNextPage }"
+              :disabled="!hasNextPage"
+              @click="nextPage()"
+            >
+              <span class="see-all-button-text">NEXT</span>
             </button>
           </div>
         </div>
@@ -111,6 +121,9 @@ tour.setOption('skipLabel', 'Skip This Tutorial');
 tour.setOption('nextLabel', 'Next');
 tour.setOption('exitOnOverlayClick', 'false');
 
+// show 24 courses per page of the see all menu
+const maxSeeAllCoursesPerPage = 24;
+
 export default Vue.extend({
   components: { draggable, Course, DropDownArrow, RequirementView },
   props: {
@@ -147,11 +160,8 @@ export default Vue.extend({
     groupedRequirementFulfillmentReports(): readonly GroupedRequirementFulfillmentReport[] {
       return store.state.groupedRequirementFulfillmentReport;
     },
-    maxSeeAllCoursesPerPage(): number {
-      return 24;
-    },
     numPages(): number {
-      return Math.ceil(this.showAllCourses.allCourses.length / this.maxSeeAllCoursesPerPage);
+      return Math.ceil(this.showAllCourses.allCourses.length / maxSeeAllCoursesPerPage);
     },
     hasNextPage(): boolean {
       return this.showAllPage + 1 < this.numPages;
@@ -227,14 +237,15 @@ export default Vue.extend({
     // return an array consisting of the courses to display on the see all menu, depending on the showAllPage and maxSeeAllCoursesPerPage
     findPotentialSeeAllCourses(courses: FirestoreSemesterCourse[]): FirestoreSemesterCourse[] {
       const allPotentialCourses = courses.slice(
-        this.showAllPage * this.maxSeeAllCoursesPerPage,
-        (this.showAllPage + 1) * this.maxSeeAllCoursesPerPage
+        this.showAllPage * maxSeeAllCoursesPerPage,
+        (this.showAllPage + 1) * maxSeeAllCoursesPerPage
       );
       return allPotentialCourses;
     },
     backFromSeeAll() {
       this.shouldShowAllCourses = false;
       this.showAllCourses = { name: '', shownCourses: [], allCourses: [] };
+      this.showAllPage = 0;
     },
     cloneCourse(courseWithDummyUniqueID: FirestoreSemesterCourse): FirestoreSemesterCourse {
       return { ...courseWithDummyUniqueID, uniqueID: incrementUniqueID() };

--- a/src/components/Requirements/SeeAllSubReqCourses.vue
+++ b/src/components/Requirements/SeeAllSubReqCourses.vue
@@ -1,1 +1,0 @@
-<!-- Component for the See All panel for a SubReq's courses -->

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -90,7 +90,6 @@
               :courses="subReqCourseSlot.courses.slice(0, 4)"
               :displayDescription="displayDescription"
               :showSeeAllLabel="subReqCourseSlot.courses.length > 4"
-              :lastLoadedShowAllCourseId="lastLoadedShowAllCourseId"
               @onShowAllCourses="onShowAllCourses"
             />
           </div>
@@ -172,7 +171,6 @@ export default Vue.extend({
     isCompleted: { type: Boolean, required: true },
     toggleableRequirementChoice: { type: String, default: null },
     color: { type: String, required: true },
-    lastLoadedShowAllCourseId: { type: Number, required: true },
   },
   data(): Data {
     return {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -429,6 +429,8 @@ button.view {
     }
     &-content {
       z-index: 2;
+      position: absolute;
+      width: 80%;
       background: $white;
       box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.25);
       border-radius: 7px;

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -386,12 +386,18 @@ button.view {
     line-height: 17px;
     color: $darkPlaceholderGray;
     position: relative;
+
     &:not(:first-child) {
       margin-top: 0.5rem;
     }
+
     &--disabled {
       opacity: 0.3;
       pointer-events: none;
+    }
+
+    &-wrapper {
+      position: relative;
     }
   }
   &-dropdown {
@@ -430,7 +436,7 @@ button.view {
     &-content {
       z-index: 2;
       position: absolute;
-      width: 80%;
+      width: 100%;
       background: $white;
       box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.25);
       border-radius: 7px;

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -241,10 +241,10 @@ export default Vue.extend({
     getArrowColor() {
       return this.isCompleted ? '#979797CC' : '#979797';
     },
-    onShowAllCourses() {
+    onShowAllCourses(subReqIndex: number) {
       this.$emit('onShowAllCourses', {
         requirementName: this.subReq.requirement.name,
-        subReqCoursesArray: this.subReqCoursesSlots,
+        subReqCoursesArray: this.subReqCoursesSlots[subReqIndex].courses,
       });
     },
     toggleDescription() {

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -272,6 +272,10 @@ export default Vue.extend({
       position: fixed;
       z-index: 1;
     }
+
+    &-reqs {
+      margin-left: 0;
+    }
   }
 }
 </style>


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes a couple bugs with see all functionality on the requirements menu, reverts some previously introduced requirements menu bugs, and adds pagination to the see all menu.

- [x] Limit see all courses to only show courses from that specific self check slot, and not courses from other slots for the same requirement
- [x] Add functionality to shift between 24 courses at a time in the see all menu with new previous and next buttons
- [x] Fix mobile reqs menu styling
- [x]  Make courses in see all menu show up as smaller course versions at smaller breakpoints
- [x] Other styling fixes (reqs continues to the bottom of the screen, reqs dropdowns show above bar, course cards have draggable cursor, course cards triple dots sometimes displayed incorrectly)

Notion item: https://www.notion.so/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=127d9034dcab4f2fb369f0a8bc874d52 (first two already fixed by #323, last two are duplicate items)

Example of the first item: The 4th BME concentration requirement see all now does not show Chem 1570 or other courses it should not from the first 3 slots.
![image](https://user-images.githubusercontent.com/25535093/109401993-40eb2a00-7920-11eb-922e-5da3ef8b83d3.png)
![image](https://user-images.githubusercontent.com/25535093/109884821-9b9bc300-7c4b-11eb-9497-71eef0c2b6c9.png)

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] Mobile see all menu is not ideal. Courses are still draggable (with the new grabbing cursor), and on high breakpoints, look off as the entire menu is left oriented instead of center-oriented. Don't think this is worth spending time on though until/if we decide how we want courses to work on this mobile menu.

### Test Plan <!-- Required -->

1. Confirm clicking "see all" on a requirement with multiple req slots only displays courses that fulfill that specific slot (in contrast to the dev site that shows courses from all slots). An example would be for the Biological Sciences major in A&S, the "College Mathematics" requirement should not show MATH 1106 or MATH 1110.
2. Confirm that clicking on see all for a requirement with more than 24 courses lets you switch between previous and next pages. An example would be for the "DEA Thematic Courses" req in DEA in Human Ecology as it has 32 courses that can fulfill it, and thus 2 pages. Previous and Next buttons should be disabled when prev/next pages do not exist
3. Confirm requirements with much more requirements also let you cycle through a ton of pages (such as A&S or CALS credits)
4. Mobile requirements menu works as before, including see all, and adding a new course from self check modal
5. The requirements menu continues to the bottom of the screen when the semester view is both smaller and larger than the screen height (add and delete semesters/courses to make this happen)
6. Ensure that on smaller breakpoints, the see all courses are smaller in width than the ones in the semester plan
7.  Identified a new bug on master where courses the triple dot coloring shrunk in width when the info box was filled (Fall, Winter, Spring, Summer) on smaller breakpoints. Confirm this does not happen anymore.
![image](https://user-images.githubusercontent.com/25535093/109885907-4c569200-7c4d-11eb-8977-9ef3ceb2be3b.png)

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

- [x] (OUTDATED) Do we want this 24 course at a time functionality in see all? It seems better than the current functionality where only the first 24 courses are shown ever, but it is not that intuitive, especially with the wording "see all." Showing all of them at once however would be problematic for very broad requirements such as "CALS Credits" that have up to 2500 possible courses.
- [x] Should these new previous/next buttons show up for subreqs with only 1 page? See the above screenshot.
- [x] When a course is dragged from the see all menu to the plan, it shows back up in the see all menu after dropped, and does not disappear until the menu is reopened. Is this functionality ok?