### PR TITLE
No duped majors, No duped tests

### DIFF
--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -117,11 +117,15 @@ export default Vue.extend({
       const majors: Record<string, string> = {};
       const majorJSON = reqsData.major;
       Object.keys(majorJSON).forEach(key => {
-        // only show majors for schools the user is in
-        if (majorJSON[key].schools.includes(this.collegeAcronym)) {
+        // only show majors for schools the user is in and is not already selected
+        if (
+          majorJSON[key].schools.includes(this.collegeAcronym) &&
+          !this.majorAcronyms.includes(key)
+        ) {
           majors[key] = majorJSON[key].name;
         }
       });
+      console.log(this.majorAcronyms, majors);
       return majors;
     },
     minors(): Readonly<Record<string, string>> {

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -117,15 +117,11 @@ export default Vue.extend({
       const majors: Record<string, string> = {};
       const majorJSON = reqsData.major;
       Object.keys(majorJSON).forEach(key => {
-        // only show majors for schools the user is in and is not already selected
-        if (
-          majorJSON[key].schools.includes(this.collegeAcronym) &&
-          !this.majorAcronyms.includes(key)
-        ) {
+        // only show majors for schools the user is in
+        if (majorJSON[key].schools.includes(this.collegeAcronym)) {
           majors[key] = majorJSON[key].name;
         }
       });
-      console.log(this.majorAcronyms, majors);
       return majors;
     },
     minors(): Readonly<Record<string, string>> {

--- a/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
@@ -45,11 +45,14 @@ export default Vue.extend({
     },
     getSelectableOptions(choice: string) {
       const selectableOptions: Record<string, string> = {};
+      // copy availableChoices but don't include ones that are already selected
       for (const key of Object.keys(this.availableChoices)) {
+        // don't include selected ones
         if (!this.dropdownChoices.includes(key)) {
           selectableOptions[key] = this.availableChoices[key];
         }
       }
+      // add the current selection associated with this input into the availableChoices
       if (choice !== '') {
         selectableOptions[choice] = this.availableChoices[choice];
       }

--- a/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
@@ -50,7 +50,9 @@ export default Vue.extend({
           selectableOptions[key] = this.availableChoices[key];
         }
       }
-      selectableOptions[choice] = this.availableChoices[choice];
+      if (choice !== '') {
+        selectableOptions[choice] = this.availableChoices[choice];
+      }
       return selectableOptions;
     },
   },

--- a/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
@@ -3,7 +3,7 @@
     <onboarding-basic-single-dropdown
       v-for="(choice, index) in dropdownChoices"
       :key="choice"
-      :availableChoices="availableChoices"
+      :availableChoices="getRemainingChoicesAfterChoice(choice)"
       :choice="choice"
       :cannotBeRemoved="dropdownChoices.length === 1 && choice === ''"
       @on-select="choice => onSelect(choice, index)"
@@ -33,6 +33,12 @@ export default Vue.extend({
     dropdownChoices: { type: Array as PropType<readonly string[]>, required: true },
     addDropdownText: { type: String, required: true },
   },
+  data() {
+    const remainingAvailableChoices = { ...this.availableChoices };
+    return {
+      remainingAvailableChoices,
+    };
+  },
   methods: {
     onSelect(key: string, index: number) {
       this.$emit('on-select', key, index);
@@ -42,6 +48,11 @@ export default Vue.extend({
     },
     addDropdown() {
       this.$emit('on-add');
+    },
+    getRemainingChoicesAfterChoice(removeChoice: string) {
+      const returnValue = { ...this.remainingAvailableChoices };
+      delete this.remainingAvailableChoices[removeChoice];
+      return returnValue;
     },
   },
 });

--- a/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicMultiDropdown.vue
@@ -3,7 +3,7 @@
     <onboarding-basic-single-dropdown
       v-for="(choice, index) in dropdownChoices"
       :key="choice"
-      :availableChoices="getRemainingChoicesAfterChoice(choice)"
+      :availableChoices="getSelectableOptions(choice)"
       :choice="choice"
       :cannotBeRemoved="dropdownChoices.length === 1 && choice === ''"
       @on-select="choice => onSelect(choice, index)"
@@ -33,12 +33,6 @@ export default Vue.extend({
     dropdownChoices: { type: Array as PropType<readonly string[]>, required: true },
     addDropdownText: { type: String, required: true },
   },
-  data() {
-    const remainingAvailableChoices = { ...this.availableChoices };
-    return {
-      remainingAvailableChoices,
-    };
-  },
   methods: {
     onSelect(key: string, index: number) {
       this.$emit('on-select', key, index);
@@ -49,10 +43,15 @@ export default Vue.extend({
     addDropdown() {
       this.$emit('on-add');
     },
-    getRemainingChoicesAfterChoice(removeChoice: string) {
-      const returnValue = { ...this.remainingAvailableChoices };
-      delete this.remainingAvailableChoices[removeChoice];
-      return returnValue;
+    getSelectableOptions(choice: string) {
+      const selectableOptions: Record<string, string> = {};
+      for (const key of Object.keys(this.availableChoices)) {
+        if (!this.dropdownChoices.includes(key)) {
+          selectableOptions[key] = this.availableChoices[key];
+        }
+      }
+      selectableOptions[choice] = this.availableChoices[choice];
+      return selectableOptions;
     },
   },
 });

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -193,8 +193,10 @@ type Data = {
 const scoresAP = [1, 2, 3, 4, 5];
 const scoresIB = [1, 2, 3, 4, 5, 6, 7];
 const existingAP: Record<string, boolean> = {};
+const selectedAP: Record<string, boolean> = {};
+// filter duplicate exam names and ones already selected
 reqsData.AP = reqsData.AP.filter(ap => {
-  const inExisting = ap.name in existingAP;
+  const inExisting = ap.name in existingAP || ap.name in selectedAP;
   existingAP[ap.name] = true;
   return !inExisting;
 });
@@ -271,6 +273,9 @@ export default Vue.extend({
     },
     selectAPSubject(subject: string, i: number) {
       this.examsAP = this.examsAP.map((exam, index) => (index === i ? { ...exam, subject } : exam));
+      this.examsAP.forEach(exam => {
+        selectedAP[exam.subject] = true;
+      });
       this.updateTransfer();
     },
     selectIBSubject(subject: string, i: number) {

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -19,7 +19,7 @@
                 <onboarding-transfer-exam-property-dropdown
                   property-name="Subject"
                   :columnWide="true"
-                  :availableOptions="getSelectableOptions(examsAP,exam.subject)"
+                  :availableOptions="getSelectableOptions(examsAP, exam.subject)"
                   :choice="exam.subject"
                   @on-select="subject => selectAPSubject(subject, index)"
                 />
@@ -61,7 +61,7 @@
                 <onboarding-transfer-exam-property-dropdown
                   property-name="Subject"
                   :columnWide="true"
-                  :availableOptions="getSelectableOptions(examsIB,exam.subject)"
+                  :availableOptions="getSelectableOptions(examsIB, exam.subject)"
                   :choice="exam.subject"
                   @on-select="subject => selectIBSubject(subject, index)"
                 />
@@ -344,18 +344,18 @@ export default Vue.extend({
         });
     },
     getSelectableOptions(exams: FirestoreAPIBExam[], choice: string) {
-      const selectedExams = exams.map((exam) => exam.subject)
+      const selectedExams = exams.map(exam => exam.subject);
       const selectableOptions: string[] = [];
       // copy subjectsAP but don't include ones that are already selected
       for (const subject of subjectsAP) {
         // don't include selected ones
         if (!selectedExams.includes(subject)) {
-          selectableOptions.push(subject)
+          selectableOptions.push(subject);
         }
       }
       // add the current selection associated with this input into the availableChoices
       if (choice !== placeholderText) {
-        selectableOptions.push(choice)
+        selectableOptions.push(choice);
       }
       return selectableOptions;
     },

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -19,7 +19,7 @@
                 <onboarding-transfer-exam-property-dropdown
                   property-name="Subject"
                   :columnWide="true"
-                  :availableOptions="subjectsAP"
+                  :availableOptions="getSelectableOptions(examsAP,exam.subject)"
                   :choice="exam.subject"
                   @on-select="subject => selectAPSubject(subject, index)"
                 />
@@ -61,7 +61,7 @@
                 <onboarding-transfer-exam-property-dropdown
                   property-name="Subject"
                   :columnWide="true"
-                  :availableOptions="subjectsIB"
+                  :availableOptions="getSelectableOptions(examsIB,exam.subject)"
                   :choice="exam.subject"
                   @on-select="subject => selectIBSubject(subject, index)"
                 />
@@ -342,6 +342,22 @@ export default Vue.extend({
             }
           });
         });
+    },
+    getSelectableOptions(exams: FirestoreAPIBExam[], choice: string) {
+      const selectedExams = exams.map((exam) => exam.subject)
+      const selectableOptions: string[] = [];
+      // copy subjectsAP but don't include ones that are already selected
+      for (const subject of subjectsAP) {
+        // don't include selected ones
+        if (!selectedExams.includes(subject)) {
+          selectableOptions.push(subject)
+        }
+      }
+      // add the current selection associated with this input into the availableChoices
+      if (choice !== placeholderText) {
+        selectableOptions.push(choice)
+      }
+      return selectableOptions;
     },
   },
 });

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -19,7 +19,7 @@
                 <onboarding-transfer-exam-property-dropdown
                   property-name="Subject"
                   :columnWide="true"
-                  :availableOptions="getSelectableOptions(examsAP, exam.subject)"
+                  :availableOptions="getSelectableOptions(examsAP, subjectsAP, exam.subject)"
                   :choice="exam.subject"
                   @on-select="subject => selectAPSubject(subject, index)"
                 />
@@ -61,7 +61,7 @@
                 <onboarding-transfer-exam-property-dropdown
                   property-name="Subject"
                   :columnWide="true"
-                  :availableOptions="getSelectableOptions(examsIB, exam.subject)"
+                  :availableOptions="getSelectableOptions(examsIB, subjectsIB, exam.subject)"
                   :choice="exam.subject"
                   @on-select="subject => selectIBSubject(subject, index)"
                 />
@@ -343,13 +343,19 @@ export default Vue.extend({
           });
         });
     },
-    getSelectableOptions(exams: FirestoreAPIBExam[], choice: string) {
-      const selectedExams = exams.map(exam => exam.subject);
+    getSelectableOptions(
+      // exams already picked
+      selectedExams: FirestoreAPIBExam[],
+      // array of ap/ib exams
+      allSubjects: string[],
+      choice: string
+    ) {
+      const selectedExamsNames = selectedExams.map(exam => exam.subject);
       const selectableOptions: string[] = [];
-      // copy subjectsAP but don't include ones that are already selected
-      for (const subject of subjectsAP) {
+      // copy all of the possible options over but exclude already selected ones
+      for (const subject of allSubjects) {
         // don't include selected ones
-        if (!selectedExams.includes(subject)) {
+        if (!selectedExamsNames.includes(subject)) {
           selectableOptions.push(subject);
         }
       }

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -192,6 +192,12 @@ type Data = {
 
 const scoresAP = [1, 2, 3, 4, 5];
 const scoresIB = [1, 2, 3, 4, 5, 6, 7];
+const existingAP : Record<string, boolean> = {}
+reqsData.AP = reqsData.AP.filter((ap) => {
+  const inExisting = ap.name in existingAP;
+  existingAP[ap.name] = true;
+  return !inExisting;
+})
 const subjectsAP = reqsData.AP.map(it => it.name);
 const subjectsIB = reqsData.IB.map(it => it.name);
 

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -193,10 +193,9 @@ type Data = {
 const scoresAP = [1, 2, 3, 4, 5];
 const scoresIB = [1, 2, 3, 4, 5, 6, 7];
 const existingAP: Record<string, boolean> = {};
-const selectedAP: Record<string, boolean> = {};
 // filter duplicate exam names and ones already selected
 reqsData.AP = reqsData.AP.filter(ap => {
-  const inExisting = ap.name in existingAP || ap.name in selectedAP;
+  const inExisting = ap.name in existingAP;
   existingAP[ap.name] = true;
   return !inExisting;
 });
@@ -273,9 +272,6 @@ export default Vue.extend({
     },
     selectAPSubject(subject: string, i: number) {
       this.examsAP = this.examsAP.map((exam, index) => (index === i ? { ...exam, subject } : exam));
-      this.examsAP.forEach(exam => {
-        selectedAP[exam.subject] = true;
-      });
       this.updateTransfer();
     },
     selectIBSubject(subject: string, i: number) {

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -347,7 +347,7 @@ export default Vue.extend({
       // exams already picked
       selectedExams: FirestoreAPIBExam[],
       // array of ap/ib exams
-      allSubjects: string[],
+      allSubjects: readonly string[],
       choice: string
     ) {
       const selectedExamsNames = selectedExams.map(exam => exam.subject);

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -199,6 +199,13 @@ reqsData.AP = reqsData.AP.filter(ap => {
   existingAP[ap.name] = true;
   return !inExisting;
 });
+const existingIB: Record<string, boolean> = {};
+// filter duplicate exam names and ones already selected
+reqsData.IB = reqsData.IB.filter(ib => {
+  const inExisting = ib.name in existingIB;
+  existingIB[ib.name] = true;
+  return !inExisting;
+});
 const subjectsAP = reqsData.AP.map(it => it.name);
 const subjectsIB = reqsData.IB.map(it => it.name);
 

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -192,12 +192,12 @@ type Data = {
 
 const scoresAP = [1, 2, 3, 4, 5];
 const scoresIB = [1, 2, 3, 4, 5, 6, 7];
-const existingAP : Record<string, boolean> = {}
-reqsData.AP = reqsData.AP.filter((ap) => {
+const existingAP: Record<string, boolean> = {};
+reqsData.AP = reqsData.AP.filter(ap => {
   const inExisting = ap.name in existingAP;
   existingAP[ap.name] = true;
   return !inExisting;
-})
+});
 const subjectsAP = reqsData.AP.map(it => it.name);
 const subjectsIB = reqsData.IB.map(it => it.name);
 


### PR DESCRIPTION
### Summary <!-- Required -->

Users cannot add duplicate majors and minors in the frontend anymore
Deduped exam names in onboarding

https://www.notion.so/don-t-let-users-add-duplicate-majors-and-minors-d5ef59eb63634e6c886fbe281c43407c
https://www.notion.so/De-dupe-exam-names-in-Onboarding-d657f675b5be4e7a85ef357ea088144c

### Test Plan <!-- Required -->

Try to add duplicate majors and notice you cannot do so.
![image](https://user-images.githubusercontent.com/33106747/109443730-4c665000-7a09-11eb-962d-a2472c849d87.png)


Notice certain exams like stats are not showing up twice anymore.
![image](https://user-images.githubusercontent.com/33106747/109443712-42445180-7a09-11eb-8975-fec3a6dd7231.png)


### Notes
The duplicate majors fix does not apply to AP tests, which use a different kind of dropdown? Not sure if that needs to be addressed as well.
