### PR TITLE
Fix drag and drop spacing issue

### DIFF
--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -160,7 +160,9 @@ export default Vue.extend({
 
       isDeleteSemesterOpen: false,
       isEditSemesterOpen: false,
-      isShadow: false,
+      // Keep track of how many levels has a card enters in the droppable zone.
+      // Inspired by https://stackoverflow.com/a/21002544
+      isShadowCounter: 0,
       isDraggedFrom: false,
       isCourseModalOpen: false,
 
@@ -193,13 +195,13 @@ export default Vue.extend({
     });
     const droppable = (this.$refs.droppable as Vue).$el as HTMLDivElement;
     droppable.addEventListener('dragenter', this.onDragEnter);
-    droppable.addEventListener('dragexit', this.onDragExit);
+    droppable.addEventListener('dragleave', this.onDragExit);
   },
   beforeDestroy() {
     this.$el.removeEventListener('touchmove', this.dragListener);
     const droppable = (this.$refs.droppable as Vue).$el as HTMLDivElement;
     droppable.removeEventListener('dragenter', this.onDragEnter);
-    droppable.removeEventListener('dragexit', this.onDragExit);
+    droppable.removeEventListener('dragleave', this.onDragExit);
   },
 
   computed: {
@@ -223,7 +225,7 @@ export default Vue.extend({
     courseContainerHeight(): number {
       let factor = 6.1;
       let extraIncrementer = 0;
-      if (this.isShadow) {
+      if (this.isShadowCounter > 0) {
         extraIncrementer += 1;
       }
       if (this.isDraggedFrom) {
@@ -262,19 +264,19 @@ export default Vue.extend({
     onDragStart() {
       this.isDraggedFrom = true;
       this.scrollable = true;
-      this.isShadow = false;
+      this.isShadowCounter = 0;
     },
     onDragEnter() {
-      this.isShadow = true;
+      this.isShadowCounter += 1;
     },
     onDragExit() {
-      this.isShadow = false;
+      this.isShadowCounter -= 1;
     },
     onDropped() {
-      this.isShadow = false;
+      this.isShadowCounter = 0;
     },
     onDragEnd() {
-      this.isShadow = false;
+      this.isShadowCounter = 0;
       this.scrollable = false;
       this.isDraggedFrom = false;
     },


### PR DESCRIPTION
### Summary <!-- Required -->

Notion item: https://www.notion.so/Dragging-issues-f6abb7f0d3f04ce992cfe85dbf1bba12
> If possible: when I drag a course over one semester (ex: Spring 2013) but don't end up dropping it there, it leaves a gap in the semester card. Would be nice for there not to be a gap

The current implementation has a problem where `ondropexit` event doesn't fire on chrome at all. In fact, this event is deprecated and we shouldn't depend on it. The correct way to detect whether there is a card on the droppable zone is to listen to `dragenter` and `dragleave`. However, `dragenter` and `dragleave` has the issue that it will fire whenever it appears on any droppable zone, whenever it's parent or child. See [this issue](https://stackoverflow.com/questions/7110353/html5-dragleave-fired-when-hovering-a-child-element) for more context.

In the same stackoverflow, it describes an solution to use a counter to keep track of how many levels have been entered leaved to decide whether the card is still inside the droppable region. I adopted the solution and now things just work.

### Test Plan <!-- Required -->

Drag course from one semester to another but doesn't drop and then drop back to original semester. There will be no gaps now.

### Notes <!-- Optional -->

The remaining issue on the notion item (If possible: While dragging over semesterView, card (drag object) should be same ver (compact/!compact) as semesterView) doesn't appear solvable now... The library we are using just doesn't support that...