### PR TITLE
Change mechanism of disallowing dropping to fix drop cancel issue

### DIFF
--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -15,9 +15,7 @@
       <draggable
         v-if="courses.length > 0"
         class="draggable-requirements-courses"
-        group="draggable-semester-courses"
-        :move="onDraggedCourseMove"
-        data-not-droppable="true"
+        :group="{ name: 'draggable-semester-courses', put: false }"
         :value="courses"
         :clone="cloneCourse"
         @start="onDrag"
@@ -42,7 +40,6 @@ import Vue, { PropType } from 'vue';
 import draggable from 'vuedraggable';
 import Course from '@/components/Course/Course.vue';
 import { incrementUniqueID } from '@/global-firestore-data';
-import { onDraggedCourseMove } from '@/utilities';
 
 export default Vue.extend({
   components: { draggable, Course },
@@ -87,7 +84,6 @@ export default Vue.extend({
     },
   },
   methods: {
-    onDraggedCourseMove,
     onDrag() {
       this.scrollable = true;
     },

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -40,9 +40,7 @@
         <draggable
           :value="showAllCourses.courses"
           :clone="cloneCourse"
-          :move="onDraggedCourseMove"
-          data-not-droppable="true"
-          group="draggable-semester-courses"
+          :group="{ name: 'draggable-semester-courses', put: false }"
         >
           <div v-for="(courseData, index) in showAllCourses.courses" :key="index">
             <div class="mt-3">
@@ -75,7 +73,6 @@ import DropDownArrow from '@/components/DropDownArrow.vue';
 import clipboard from '@/assets/images/clipboard.svg';
 import store from '@/store';
 import { chooseToggleableRequirementOption, incrementUniqueID } from '@/global-firestore-data';
-import { onDraggedCourseMove } from '@/utilities';
 
 Vue.use(VueCollapse);
 
@@ -139,7 +136,6 @@ export default Vue.extend({
     },
   },
   methods: {
-    onDraggedCourseMove,
     showMajorOrMinorRequirements(id: number, group: string): boolean {
       if (group === 'Major') {
         return id === this.displayedMajorIndex + this.numOfColleges;

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -69,7 +69,6 @@
           group="draggable-semester-courses"
           v-model="coursesForDraggable"
           :style="{ height: courseContainerHeight + 'rem' }"
-          :move="onDraggedCourseMove"
           @start="onDragStart"
           @sort="onDropped"
           @end="onDragEnd"
@@ -122,7 +121,7 @@ import DeleteSemester from '@/components/Modals/DeleteSemester.vue';
 import EditSemester from '@/components/Modals/EditSemester.vue';
 import AddCourseButton from '@/components/AddCourseButton.vue';
 
-import { onDraggedCourseMove, clickOutside } from '@/utilities';
+import { clickOutside } from '@/utilities';
 
 import fall from '@/assets/images/fallEmoji.svg';
 import spring from '@/assets/images/springEmoji.svg';
@@ -260,7 +259,6 @@ export default Vue.extend({
     },
   },
   methods: {
-    onDraggedCourseMove,
     onDragStart() {
       this.isDraggedFrom = true;
       this.scrollable = true;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -43,19 +43,6 @@ export function getMinorFullName(acronym: string): string {
   return requirementJSON.minor[acronym].name;
 }
 
-/**
- * The function to be passed to move prop for <draggable /> to prevent a course being dropped into
- * requirement course container.
- */
-export function onDraggedCourseMove(event: { to?: HTMLElement }): boolean {
-  const target = event.to;
-  if (target == null) return true;
-  // Use this data on the DOM to denote that it's not a droppable target.
-  // This is the recommended way according to
-  // https://github.com/SortableJS/Vue.Draggable/issues/897
-  return target.getAttribute('data-not-droppable') !== 'true';
-}
-
 export const clickOutside = {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
   bind(el: any, binding: any, vnode: any): void {


### PR DESCRIPTION
## Summary

We don't need to rely on the move function's return value. Instead, we can use the [`group` option](https://github.com/SortableJS/Sortable#group-option) to disallow items being put into the list.

Surprisingly, this change also partially fixes the issue of [not dropping the req course into the semester still causing it to be added](https://www.notion.so/Cancel-Drag-Req-Course-8f5d03f44cb14cdf8576e13e19f3e21a). However, **it's not a full fix**, since you still need to drop the req course into the original req course slot. I don't believe a full fix is possible since it seems to be the fundamental assumption of the library that the card will stuck in the previous eligible slot until it finds a new slot.

## Test Plan

- Try to drop semester class into req courses and see it fail.
- Try to drag a req course into semester but not drop, then drag it back to the req course slot and drop. No change in semester data.