### PR TITLE
Fix incorrect double counting warning issue

### DIFF
--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -42,12 +42,10 @@ const getCourseCautions = (course: FirestoreSemesterCourse): CourseCautions => {
   } = store.state;
   let doubleCountingRequirementWarning: readonly string[] | undefined;
   if (illegallyDoubleCountedCourseUniqueIDs.has(course.uniqueID)) {
-    illegallyDoubleCountedCourseUniqueIDs.forEach(uniqueId => {
-      doubleCountingRequirementWarning = requirementFulfillmentGraph
-        .getConnectedRequirementsFromCourse({ uniqueId })
-        .filter(id => !userRequirementsMap[id].allowCourseDoubleCounting)
-        .map(id => userRequirementsMap[id].name);
-    });
+    doubleCountingRequirementWarning = requirementFulfillmentGraph
+      .getConnectedRequirementsFromCourse({ uniqueId: course.uniqueID })
+      .filter(id => !userRequirementsMap[id].allowCourseDoubleCounting)
+      .map(id => userRequirementsMap[id].name);
   }
   const semesterOfUserCourse = courseToSemesterMap[course.uniqueID];
   const typicallyOfferedWarning =


### PR DESCRIPTION
### Summary <!-- Required -->

Recently I found that I'm going some weird double counting warnings like:

<img width="445" alt="error" src="https://user-images.githubusercontent.com/4290500/109713690-87829380-7b6f-11eb-9780-2a9c63bde118.png">

Digging deep into it, it appears that the current code (written by me 😅) is horribly wrong. It will cause us to always fetch the double counted requirement of the last `illegallyDoubleCountedCourseUniqueIDs`. Now I fixed it by fetching the relevant one from the course id.

### Test Plan <!-- Required -->

Now fixed: (it shows the warning, because it's added from drop from req courses, which doesn't remember req choice yet)
<img width="453" alt="fixed" src="https://user-images.githubusercontent.com/4290500/109713728-936e5580-7b6f-11eb-86cc-f503641d94ac.png">
