### PR TITLE
Refactor firestore modifiers and gtag events

### DIFF
--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -50,20 +50,13 @@
       data-disable-interaction="1"
     >
       <div class="semester-top" :class="{ 'semester-top--compact': compact }">
-        <div
-          class="semester-left"
-          :class="{ 'semester-left--compact': compact }"
-        >
+        <div class="semester-left" :class="{ 'semester-left--compact': compact }">
           <span class="semester-name"
-            ><img class="season-emoji" :src="seasonImg[type]" alt="" />
-            {{ type }} {{ year }}</span
+            ><img class="season-emoji" :src="seasonImg[type]" alt="" /> {{ type }} {{ year }}</span
           >
           <span class="semester-credits">{{ creditString }}</span>
         </div>
-        <div
-          class="semester-right"
-          :class="{ 'semester-right--compact': compact }"
-        >
+        <div class="semester-right" :class="{ 'semester-right--compact': compact }">
           <div class="semester-dotRow" @click="openSemesterMenu">
             <img src="@/assets/images/dots/threeDots.svg" alt="dots" />
           </div>
@@ -338,9 +331,7 @@ export default Vue.extend({
     deleteCourse(courseCode: string, uniqueID: number) {
       deleteCourseFromSemester(this.type, this.year, uniqueID);
       // Update requirements menu
-      this.openConfirmationModal(
-        `Removed ${courseCode} from ${this.type} ${this.year}`
-      );
+      this.openConfirmationModal(`Removed ${courseCode} from ${this.type} ${this.year}`);
     },
     colorCourse(color: string, uniqueID: number) {
       editSemester(
@@ -364,9 +355,7 @@ export default Vue.extend({
         (semester: FirestoreSemester): FirestoreSemester => ({
           ...semester,
           courses: this.courses.map(course =>
-            course.uniqueID === uniqueID
-              ? { ...course, credits: credit }
-              : course
+            course.uniqueID === uniqueID ? { ...course, credits: credit } : course
           ),
         })
       );
@@ -404,10 +393,7 @@ export default Vue.extend({
     openEditSemesterModal() {
       this.isEditSemesterOpen = true;
     },
-    editSemester(
-      seasonInput: 'Fall' | 'Spring' | 'Winter' | 'Summer',
-      yearInput: number
-    ) {
+    editSemester(seasonInput: 'Fall' | 'Spring' | 'Winter' | 'Summer', yearInput: number) {
       editSemester(
         this.year,
         this.type,

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -15,15 +15,8 @@
       @add-semester="addSemester"
       @close-semester-modal="closeSemesterModal"
     />
-    <div
-      class="semesterView-settings"
-      :class="{ 'semesterView-settings--two': noSemesters }"
-    >
-      <button
-        v-if="noSemesters"
-        class="semesterView-addSemesterButton"
-        @click="openSemesterModal"
-      >
+    <div class="semesterView-settings" :class="{ 'semesterView-settings--two': noSemesters }">
+      <button v-if="noSemesters" class="semesterView-addSemesterButton" @click="openSemesterModal">
         + New Semester
       </button>
       <div class="semesterView-switch">
@@ -105,11 +98,7 @@ import NewSemesterModal from '@/components/Modals/NewSemesterModal.vue';
 
 import store from '@/store';
 import { GTagEvent } from '@/gtag';
-import {
-  addSemester,
-  deleteSemester,
-  addCourseToSemester,
-} from '@/global-firestore-data';
+import { addSemester, deleteSemester, addCourseToSemester } from '@/global-firestore-data';
 import { closeBottomBar } from '@/components/BottomBar/BottomBarState';
 
 export default Vue.extend({
@@ -143,10 +132,7 @@ export default Vue.extend({
   },
   methods: {
     checkIfFirstSem(semester: FirestoreSemester) {
-      return (
-        this.semesters[0].year === semester.year &&
-        this.semesters[0].type === semester.type
-      );
+      return this.semesters[0].year === semester.year && this.semesters[0].type === semester.type;
     },
     setCompact() {
       if (!this.compact) {
@@ -160,11 +146,7 @@ export default Vue.extend({
         GTagEvent(this.$gtag, 'to-not-compact');
       }
     },
-    openSemesterConfirmationModal(
-      type: FirestoreSemesterType,
-      year: number,
-      isAdd: boolean
-    ) {
+    openSemesterConfirmationModal(type: FirestoreSemesterType, year: number, isAdd: boolean) {
       if (isAdd) {
         this.confirmationText = `Added ${type} ${year} to plan`;
       } else {
@@ -191,11 +173,7 @@ export default Vue.extend({
     closeSemesterModal() {
       this.isSemesterModalOpen = false;
     },
-    addNewCourse(
-      season: FirestoreSemesterType,
-      year: number,
-      course: FirestoreSemesterCourse
-    ) {
+    addNewCourse(season: FirestoreSemesterType, year: number, course: FirestoreSemesterCourse) {
       addCourseToSemester(season, year, course);
     },
     addSemester(type: FirestoreSemesterType, year: number) {

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -104,6 +104,7 @@ import SemesterCaution from '@/components/Semester/SemesterCaution.vue';
 import NewSemesterModal from '@/components/Modals/NewSemesterModal.vue';
 
 import store from '@/store';
+import { GTagEvent } from '@/gtag';
 import {
   addSemester,
   deleteSemester,
@@ -150,21 +151,13 @@ export default Vue.extend({
     setCompact() {
       if (!this.compact) {
         this.$emit('compact-updated', !this.compact);
-        this.$gtag.event('to-compact', {
-          event_category: 'views',
-          event_label: 'compact',
-          value: 1,
-        });
+        GTagEvent(this.$gtag, 'to-compact');
       }
     },
     setNotCompact() {
       if (this.compact) {
         this.$emit('compact-updated', !this.compact);
-        this.$gtag.event('to-not-compact', {
-          event_category: 'views',
-          event_label: 'not-compact',
-          value: 1,
-        });
+        GTagEvent(this.$gtag, 'to-not-compact');
       }
     },
     openSemesterConfirmationModal(

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -15,8 +15,15 @@
       @add-semester="addSemester"
       @close-semester-modal="closeSemesterModal"
     />
-    <div class="semesterView-settings" :class="{ 'semesterView-settings--two': noSemesters }">
-      <button v-if="noSemesters" class="semesterView-addSemesterButton" @click="openSemesterModal">
+    <div
+      class="semesterView-settings"
+      :class="{ 'semesterView-settings--two': noSemesters }"
+    >
+      <button
+        v-if="noSemesters"
+        class="semesterView-addSemesterButton"
+        @click="openSemesterModal"
+      >
         + New Semester
       </button>
       <div class="semesterView-switch">
@@ -64,7 +71,6 @@
           @course-onclick="courseOnClick"
           @new-semester="openSemesterModal"
           @delete-semester="deleteSemester"
-          @edit-semester="editSemester"
           @open-caution-modal="openCautionModal"
           @add-course-to-semester="addNewCourse"
         />
@@ -99,10 +105,9 @@ import NewSemesterModal from '@/components/Modals/NewSemesterModal.vue';
 
 import store from '@/store';
 import {
+  addSemester,
+  deleteSemester,
   addCourseToSemester,
-  compareFirestoreSemesters,
-  createSemester,
-  editSemesters,
 } from '@/global-firestore-data';
 import { closeBottomBar } from '@/components/BottomBar/BottomBarState';
 
@@ -137,7 +142,10 @@ export default Vue.extend({
   },
   methods: {
     checkIfFirstSem(semester: FirestoreSemester) {
-      return this.semesters[0].year === semester.year && this.semesters[0].type === semester.type;
+      return (
+        this.semesters[0].year === semester.year &&
+        this.semesters[0].type === semester.type
+      );
     },
     setCompact() {
       if (!this.compact) {
@@ -159,7 +167,11 @@ export default Vue.extend({
         });
       }
     },
-    openSemesterConfirmationModal(type: FirestoreSemesterType, year: number, isAdd: boolean) {
+    openSemesterConfirmationModal(
+      type: FirestoreSemesterType,
+      year: number,
+      isAdd: boolean
+    ) {
       if (isAdd) {
         this.confirmationText = `Added ${type} ${year} to plan`;
       } else {
@@ -186,50 +198,20 @@ export default Vue.extend({
     closeSemesterModal() {
       this.isSemesterModalOpen = false;
     },
-    addNewCourse(season: FirestoreSemesterType, year: number, course: FirestoreSemesterCourse) {
+    addNewCourse(
+      season: FirestoreSemesterType,
+      year: number,
+      course: FirestoreSemesterCourse
+    ) {
       addCourseToSemester(season, year, course);
     },
     addSemester(type: FirestoreSemesterType, year: number) {
-      this.$gtag.event('add-semester', {
-        event_category: 'semester',
-        event_label: 'add',
-        value: 1,
-      });
-
-      editSemesters(oldSemesters =>
-        [...oldSemesters, createSemester([], type, year)].sort(compareFirestoreSemesters)
-      );
+      addSemester(type, year);
       this.openSemesterConfirmationModal(type, year, true);
     },
     deleteSemester(type: FirestoreSemesterType, year: number) {
-      this.$gtag.event('delete-semester', {
-        event_category: 'semester',
-        event_label: 'delete',
-        value: 1,
-      });
-
-      // Confirm success with alert
+      deleteSemester(type, year);
       this.openSemesterConfirmationModal(type, year, false);
-
-      // Update requirements menu from dashboard
-      editSemesters(oldSemesters =>
-        oldSemesters.filter(semester => semester.type !== type || semester.year !== year)
-      );
-    },
-    editSemester(
-      year: number,
-      type: FirestoreSemesterType,
-      updater: (oldSemester: FirestoreSemester) => FirestoreSemester
-    ) {
-      editSemesters(oldSemesters =>
-        oldSemesters
-          .map(currentSemester =>
-            currentSemester.year === year && currentSemester.type === type
-              ? updater(currentSemester)
-              : currentSemester
-          )
-          .sort(compareFirestoreSemesters)
-      );
     },
     courseOnClick(course: FirestoreSemesterCourse) {
       this.activatedCourse = course;

--- a/src/containers/Login.vue
+++ b/src/containers/Login.vue
@@ -34,9 +34,7 @@
               </div>
             </div>
           </div>
-          <div
-            class="col-12 col-md-6 top-section image-wrapper image-wrapper--laptop"
-          >
+          <div class="col-12 col-md-6 top-section image-wrapper image-wrapper--laptop">
             <img
               style="position: relative"
               class="laptop"
@@ -57,9 +55,7 @@
                 <img src="@/assets/images/Task1.svg" alt="checklist" />
               </div>
               <div class="col-11">
-                <p class="sub sub--task">
-                  Fully personalized to track your requirements
-                </p>
+                <p class="sub sub--task">Fully personalized to track your requirements</p>
               </div>
             </div>
             <div class="row tasks">
@@ -67,9 +63,7 @@
                 <img src="@/assets/images/Task2.svg" alt="browser" />
               </div>
               <div class="col-11">
-                <p class="sub sub--task">
-                  Customizable interface to view your courses
-                </p>
+                <p class="sub sub--task">Customizable interface to view your courses</p>
               </div>
             </div>
             <div class="row tasks">
@@ -77,9 +71,7 @@
                 <img src="@/assets/images/Task3.svg" alt="Network" />
               </div>
               <div class="col-11">
-                <p class="sub sub--task">
-                  Built-in system to check your progress
-                </p>
+                <p class="sub sub--task">Built-in system to check your progress</p>
               </div>
             </div>
             <div class="row tasks">
@@ -87,9 +79,7 @@
                 <img src="@/assets/images/Task4.svg" alt="Starred comment" />
               </div>
               <div class="col-11">
-                <p class="sub sub--task">
-                  Recommends courses based on your needs
-                </p>
+                <p class="sub sub--task">Recommends courses based on your needs</p>
               </div>
             </div>
           </div>
@@ -117,9 +107,8 @@
           <div class="col-12 col-md-6 comment">
             <h1 class="head">Drag Your Course In</h1>
             <p class="sub">
-              CoursePlan’s intuitive interface recommends courses based on
-              unfulfilled requirements and allows you to easily drag and drop
-              them into your planner
+              CoursePlan’s intuitive interface recommends courses based on unfulfilled requirements
+              and allows you to easily drag and drop them into your planner
             </p>
           </div>
         </div>
@@ -131,16 +120,12 @@
           <div class="col-12 col-md-5 comment">
             <h1 class="head">Plan Your Semesters</h1>
             <p class="sub">
-              Use CoursePlan’s semesterly planner to choose courses well in
-              advance and ensure that you never miss a requirement
+              Use CoursePlan’s semesterly planner to choose courses well in advance and ensure that
+              you never miss a requirement
             </p>
           </div>
           <div class="col-md-7 image-wrapper image-wrapper--semester">
-            <img
-              class="hide schedule"
-              src="@/assets/images/schedule.svg"
-              alt="Plan preview"
-            />
+            <img class="hide schedule" src="@/assets/images/schedule.svg" alt="Plan preview" />
           </div>
         </div>
       </div>
@@ -150,12 +135,10 @@
         <div class="container inside">
           <div class="row justify-content-center">
             <div class="col justify-content-center">
-              <h1 class="head-center text-center">
-                Be The First One To Use It
-              </h1>
+              <h1 class="head-center text-center">Be The First One To Use It</h1>
               <p class="sub text-center" style="padding: 30px">
-                Gain early access by filling out your email below and help us
-                grow into what you need!
+                Gain early access by filling out your email below and help us grow into what you
+                need!
               </p>
             </div>
           </div>
@@ -280,14 +263,9 @@ export default Vue.extend({
       return major.trim().length > 0;
     },
     addUser() {
-      if (
-        this.validateEmail(this.waitlist.email) &&
-        this.validateMajor(this.waitlist.major)
-      ) {
+      if (this.validateEmail(this.waitlist.email) && this.validateMajor(this.waitlist.major)) {
         // eslint-disable-next-line no-alert
-        alert(
-          "You have been added to the waitlist. We'll be in touch shortly!"
-        );
+        alert("You have been added to the waitlist. We'll be in touch shortly!");
 
         // Add timestamp to data in YYYY-MM-DD hh:mm:ss
         const dt = new Date();

--- a/src/containers/Login.vue
+++ b/src/containers/Login.vue
@@ -34,7 +34,9 @@
               </div>
             </div>
           </div>
-          <div class="col-12 col-md-6 top-section image-wrapper image-wrapper--laptop">
+          <div
+            class="col-12 col-md-6 top-section image-wrapper image-wrapper--laptop"
+          >
             <img
               style="position: relative"
               class="laptop"
@@ -51,21 +53,33 @@
         <div class="row new no-gutters">
           <div class="col-12 col-md-6 tasks-wrapper">
             <div class="row tasks">
-              <div class="col-1 tasks"><img src="@/assets/images/Task1.svg" alt="checklist" /></div>
+              <div class="col-1 tasks">
+                <img src="@/assets/images/Task1.svg" alt="checklist" />
+              </div>
               <div class="col-11">
-                <p class="sub sub--task">Fully personalized to track your requirements</p>
+                <p class="sub sub--task">
+                  Fully personalized to track your requirements
+                </p>
               </div>
             </div>
             <div class="row tasks">
-              <div class="col-1 tasks"><img src="@/assets/images/Task2.svg" alt="browser" /></div>
+              <div class="col-1 tasks">
+                <img src="@/assets/images/Task2.svg" alt="browser" />
+              </div>
               <div class="col-11">
-                <p class="sub sub--task">Customizable interface to view your courses</p>
+                <p class="sub sub--task">
+                  Customizable interface to view your courses
+                </p>
               </div>
             </div>
             <div class="row tasks">
-              <div class="col-1 tasks"><img src="@/assets/images/Task3.svg" alt="Network" /></div>
+              <div class="col-1 tasks">
+                <img src="@/assets/images/Task3.svg" alt="Network" />
+              </div>
               <div class="col-11">
-                <p class="sub sub--task">Built-in system to check your progress</p>
+                <p class="sub sub--task">
+                  Built-in system to check your progress
+                </p>
               </div>
             </div>
             <div class="row tasks">
@@ -73,7 +87,9 @@
                 <img src="@/assets/images/Task4.svg" alt="Starred comment" />
               </div>
               <div class="col-11">
-                <p class="sub sub--task">Recommends courses based on your needs</p>
+                <p class="sub sub--task">
+                  Recommends courses based on your needs
+                </p>
               </div>
             </div>
           </div>
@@ -101,8 +117,9 @@
           <div class="col-12 col-md-6 comment">
             <h1 class="head">Drag Your Course In</h1>
             <p class="sub">
-              CoursePlan’s intuitive interface recommends courses based on unfulfilled requirements
-              and allows you to easily drag and drop them into your planner
+              CoursePlan’s intuitive interface recommends courses based on
+              unfulfilled requirements and allows you to easily drag and drop
+              them into your planner
             </p>
           </div>
         </div>
@@ -114,12 +131,16 @@
           <div class="col-12 col-md-5 comment">
             <h1 class="head">Plan Your Semesters</h1>
             <p class="sub">
-              Use CoursePlan’s semesterly planner to choose courses well in advance and ensure that
-              you never miss a requirement
+              Use CoursePlan’s semesterly planner to choose courses well in
+              advance and ensure that you never miss a requirement
             </p>
           </div>
           <div class="col-md-7 image-wrapper image-wrapper--semester">
-            <img class="hide schedule" src="@/assets/images/schedule.svg" alt="Plan preview" />
+            <img
+              class="hide schedule"
+              src="@/assets/images/schedule.svg"
+              alt="Plan preview"
+            />
           </div>
         </div>
       </div>
@@ -129,10 +150,12 @@
         <div class="container inside">
           <div class="row justify-content-center">
             <div class="col justify-content-center">
-              <h1 class="head-center text-center">Be The First One To Use It</h1>
+              <h1 class="head-center text-center">
+                Be The First One To Use It
+              </h1>
               <p class="sub text-center" style="padding: 30px">
-                Gain early access by filling out your email below and help us grow into what you
-                need!
+                Gain early access by filling out your email below and help us
+                grow into what you need!
               </p>
             </div>
           </div>
@@ -175,6 +198,7 @@ import firebase from 'firebase/app';
 import CustomFooter from '@/components/Footer.vue';
 import TopBar from '@/components/TopBar.vue';
 
+import { GTagLoginEvent } from '@/gtag';
 import * as fb from '@/firebaseConfig';
 
 const { whitelistCollection, landingEmailsCollection } = fb;
@@ -232,7 +256,7 @@ export default Vue.extend({
           if (doc.exists) {
             this.performingRequest = false;
             this.$router.push('/');
-            this.$gtag.event('login', { method: 'Google' });
+            GTagLoginEvent(this.$gtag, 'Google');
           } else {
             this.handleUserWithoutAccess();
           }
@@ -256,9 +280,14 @@ export default Vue.extend({
       return major.trim().length > 0;
     },
     addUser() {
-      if (this.validateEmail(this.waitlist.email) && this.validateMajor(this.waitlist.major)) {
+      if (
+        this.validateEmail(this.waitlist.email) &&
+        this.validateMajor(this.waitlist.major)
+      ) {
         // eslint-disable-next-line no-alert
-        alert("You have been added to the waitlist. We'll be in touch shortly!");
+        alert(
+          "You have been added to the waitlist. We'll be in touch shortly!"
+        );
 
         // Add timestamp to data in YYYY-MM-DD hh:mm:ss
         const dt = new Date();

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -73,14 +73,14 @@ export const addSemester = (
   gtag?: GTag,
   courses: readonly FirestoreSemesterCourse[] = []
 ): void => {
-  GTagEvent(gtag, "add-semester");
+  GTagEvent(gtag, 'add-semester');
   editSemesters(oldSemesters =>
     [...oldSemesters, createSemester(type, year, courses)].sort(compareFirestoreSemesters)
   );
 };
 
 export const deleteSemester = (type: FirestoreSemesterType, year: number, gtag?: GTag): void => {
-  GTagEvent(gtag, "add-semester");
+  GTagEvent(gtag, 'add-semester');
   editSemesters(oldSemesters =>
     oldSemesters.filter(semester => semester.type !== type || semester.year !== year)
   );
@@ -92,7 +92,7 @@ export const addCourseToSemester = (
   newCourse: FirestoreSemesterCourse,
   gtag?: GTag
 ): void => {
-  GTagEvent(gtag, "add-course");
+  GTagEvent(gtag, 'add-course');
   editSemesters(oldSemesters => {
     let semesterFound = false;
     const newSemestersWithCourse = oldSemesters.map(sem => {
@@ -115,7 +115,7 @@ export const deleteCourseFromSemester = (
   courseUniqueID: number,
   gtag?: GTag
 ): void => {
-  GTagEvent(gtag, "delete-course");
+  GTagEvent(gtag, 'delete-course');
   editSemesters(oldSemesters => {
     let semesterFound = false;
     const newSemestersWithoutCourse = oldSemesters.map(sem => {

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -19,14 +19,6 @@ export const SeasonsEnum = Object.freeze({
   Fall: 3,
 });
 
-export const editSemesters = (
-  updater: (oldSemesters: readonly FirestoreSemester[]) => readonly FirestoreSemester[]
-): void => {
-  const newSemesters = updater(store.state.semesters);
-  store.commit('setSemesters', newSemesters);
-  semestersCollection.doc(store.state.currentFirebaseUser.email).set({ semesters: newSemesters });
-};
-
 // compare function for FirestoreSemester to determine which comes first by year and type/season
 export const compareFirestoreSemesters = (a: FirestoreSemester, b: FirestoreSemester): number => {
   if (a.type === b.type && a.year === b.year) {
@@ -44,21 +36,72 @@ export const compareFirestoreSemesters = (a: FirestoreSemester, b: FirestoreSeme
   return -1;
 };
 
-export const createSemester = (
-  courses: readonly FirestoreSemesterCourse[],
+export const editSemesters = (
+  updater: (oldSemesters: readonly FirestoreSemester[]) => readonly FirestoreSemester[]
+): void => {
+  const newSemesters = updater(store.state.semesters);
+  store.commit('setSemesters', newSemesters);
+  semestersCollection.doc(store.state.currentFirebaseUser.email).set({ semesters: newSemesters });
+};
+
+export const editSemester = (
+  year: number,
   type: FirestoreSemesterType,
-  year: number
-): { courses: readonly FirestoreSemesterCourse[]; type: FirestoreSemesterType; year: number } => ({
+  updater: (oldSemester: FirestoreSemester) => FirestoreSemester
+): void => {
+  editSemesters(oldSemesters =>
+    oldSemesters
+      .map(sem => (sem.year === year && sem.type === type ? updater(sem) : sem))
+      .sort(compareFirestoreSemesters)
+  );
+};
+
+const createSemester = (
+  type: FirestoreSemesterType,
+  year: number,
+  courses: readonly FirestoreSemesterCourse[]
+): { type: FirestoreSemesterType; year: number; courses: readonly FirestoreSemesterCourse[] } => ({
   courses,
   type,
   year,
 });
+
+export const addSemester = (
+  type: FirestoreSemesterType,
+  year: number,
+  courses: readonly FirestoreSemesterCourse[] = []
+): void => {
+  // this.$gtag.event('add-semester', {
+  //   event_category: 'semester',
+  //   event_label: 'add',
+  //   value: 1,
+  // });
+  editSemesters(oldSemesters =>
+    [...oldSemesters, createSemester(type, year, courses)].sort(compareFirestoreSemesters)
+  );
+};
+
+export const deleteSemester = (type: FirestoreSemesterType, year: number): void => {
+  // this.$gtag.event('delete-semester', {
+  //   event_category: 'semester',
+  //   event_label: 'delete',
+  //   value: 1,
+  // });
+  editSemesters(oldSemesters =>
+    oldSemesters.filter(semester => semester.type !== type || semester.year !== year)
+  );
+};
 
 export const addCourseToSemester = (
   season: FirestoreSemesterType,
   year: number,
   newCourse: FirestoreSemesterCourse
 ): void => {
+  // this.$gtag.event('add-course', {
+  //   event_category: 'course',
+  //   event_label: 'add',
+  //   value: 1,
+  // });
   editSemesters(oldSemesters => {
     let semesterFound = false;
     const newSemestersWithCourse = oldSemesters.map(sem => {
@@ -69,9 +112,36 @@ export const addCourseToSemester = (
       return sem;
     });
     if (semesterFound) return newSemestersWithCourse;
-    return [...oldSemesters, createSemester([newCourse], season, year)].sort(
+    return [...oldSemesters, createSemester(season, year, [newCourse])].sort(
       compareFirestoreSemesters
     );
+  });
+};
+
+export const deleteCourseFromSemester = (
+  season: FirestoreSemesterType,
+  year: number,
+  courseUniqueID: number
+): void => {
+  // this.$gtag.event('delete-course', {
+  //   event_category: 'course',
+  //   event_label: 'delete',
+  //   value: 1,
+  // });
+  editSemesters(oldSemesters => {
+    let semesterFound = false;
+    const newSemestersWithoutCourse = oldSemesters.map(sem => {
+      if (sem.type === season && sem.year === year) {
+        semesterFound = true;
+        return {
+          ...sem,
+          courses: sem.courses.filter(course => course.uniqueID !== courseUniqueID),
+        };
+      }
+      return sem;
+    });
+    if (semesterFound) return newSemestersWithoutCourse;
+    return oldSemesters;
   });
 };
 

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -10,6 +10,7 @@ import {
   uniqueIncrementerCollection,
 } from './firebaseConfig';
 import store from './store';
+import { GTag, GTagEvent } from './gtag';
 
 // enum to define seasons as integers in season order
 export const SeasonsEnum = Object.freeze({
@@ -69,24 +70,17 @@ const createSemester = (
 export const addSemester = (
   type: FirestoreSemesterType,
   year: number,
+  gtag?: GTag,
   courses: readonly FirestoreSemesterCourse[] = []
 ): void => {
-  // this.$gtag.event('add-semester', {
-  //   event_category: 'semester',
-  //   event_label: 'add',
-  //   value: 1,
-  // });
+  GTagEvent(gtag, "add-semester");
   editSemesters(oldSemesters =>
     [...oldSemesters, createSemester(type, year, courses)].sort(compareFirestoreSemesters)
   );
 };
 
-export const deleteSemester = (type: FirestoreSemesterType, year: number): void => {
-  // this.$gtag.event('delete-semester', {
-  //   event_category: 'semester',
-  //   event_label: 'delete',
-  //   value: 1,
-  // });
+export const deleteSemester = (type: FirestoreSemesterType, year: number, gtag?: GTag): void => {
+  GTagEvent(gtag, "add-semester");
   editSemesters(oldSemesters =>
     oldSemesters.filter(semester => semester.type !== type || semester.year !== year)
   );
@@ -95,13 +89,10 @@ export const deleteSemester = (type: FirestoreSemesterType, year: number): void 
 export const addCourseToSemester = (
   season: FirestoreSemesterType,
   year: number,
-  newCourse: FirestoreSemesterCourse
+  newCourse: FirestoreSemesterCourse,
+  gtag?: GTag
 ): void => {
-  // this.$gtag.event('add-course', {
-  //   event_category: 'course',
-  //   event_label: 'add',
-  //   value: 1,
-  // });
+  GTagEvent(gtag, "add-course");
   editSemesters(oldSemesters => {
     let semesterFound = false;
     const newSemestersWithCourse = oldSemesters.map(sem => {
@@ -121,13 +112,10 @@ export const addCourseToSemester = (
 export const deleteCourseFromSemester = (
   season: FirestoreSemesterType,
   year: number,
-  courseUniqueID: number
+  courseUniqueID: number,
+  gtag?: GTag
 ): void => {
-  // this.$gtag.event('delete-course', {
-  //   event_category: 'course',
-  //   event_label: 'delete',
-  //   value: 1,
-  // });
+  GTagEvent(gtag, "delete-course");
   editSemesters(oldSemesters => {
     let semesterFound = false;
     const newSemestersWithoutCourse = oldSemesters.map(sem => {

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -80,7 +80,7 @@ export const addSemester = (
 };
 
 export const deleteSemester = (type: FirestoreSemesterType, year: number, gtag?: GTag): void => {
-  GTagEvent(gtag, 'add-semester');
+  GTagEvent(gtag, 'delete-semester');
   editSemesters(oldSemesters =>
     oldSemesters.filter(semester => semester.type !== type || semester.year !== year)
   );

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -1,0 +1,64 @@
+/* eslint-disable camelcase */
+type EventPayload = { event_category: string; event_label: string; value: number };
+type LoginEventPayload = { method: string };
+
+export type GTag = {
+  event(eventType: string, eventPayload: LoginEventPayload | EventPayload): void;
+};
+
+export const GTagLoginEvent = (gtag: GTag | undefined, method: string): void => {
+  if (!gtag) return;
+  gtag.event('login', { method });
+};
+
+export const GTagEvent = (gtag: GTag | undefined, eventType: string): void => {
+  if (!gtag) return;
+  let eventPayload: EventPayload | undefined;
+  switch (eventType) {
+    case 'to-compact':
+      eventPayload = {
+        event_category: 'views',
+        event_label: 'compact',
+        value: 1,
+      };
+      break;
+    case 'to-not-compact':
+      eventPayload = {
+        event_category: 'views',
+        event_label: 'not-compact',
+        value: 1,
+      };
+      break;
+    case 'add-semester':
+      eventPayload = {
+        event_category: 'semester',
+        event_label: 'add',
+        value: 1,
+      };
+      break;
+    case 'delete-semester':
+      eventPayload = {
+        event_category: 'semester',
+        event_label: 'delete',
+        value: 1,
+      };
+      break;
+    case 'add-course':
+      eventPayload = {
+        event_category: 'course',
+        event_label: 'add',
+        value: 1,
+      };
+      break;
+    case 'delete-course':
+      eventPayload = {
+        event_category: 'course',
+        event_label: 'delete',
+        value: 1,
+      };
+      break;
+    default:
+      return;
+  }
+  gtag.event(eventType, eventPayload);
+};


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request cleans up some of the data modifier code after the VueX migration.

- [x] refactor firestore modifiers to be directly called from `global-firestore-data.ts` (opposed to having convoluted and repeated logic in the components)
- [x] refactor firestore-related gtag events from the semester components to `global-firestore-data.ts`
- [x] refactor all gtag events; they are now handled in `gtag.ts`

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] Test that gtag still works properly

<!--- Note dependencies on other PRs if any. -->


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Make sure add course, delete course, add semester, delete semester still work properly. Now that the requirements bar listens to firestore changes, the important thing to test is that the `user-semesters` data is being stored properly in firestore.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

When using or working with firestore modifiers (or any global functions), we should try to move the function call closer to the source of the trigger. This is to try to clean up the long $emit chains when possible.
