### PR TITLE
Update TrackUsers() using user-name and user-semesters Firestore collections

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4,9 +4,8 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 admin.initializeApp();
 const db = admin.firestore();
-const userDataCollection = db.collection('userData');
-
-const fs = require('fs');
+const usernameCollection = db.collection('user-name');
+const semestersCollection = db.collection('user-semesters');
 
 let average = array => array.reduce((a, b) => a + b) / array.length;
 function typeToMonth(type) {
@@ -38,53 +37,69 @@ function isOld(semester) {
     }
   }
 }
+/**
+ * TrackUsers returns user metrics based on
+ * data from the user-name and user-semesters Firestore collections.
+ *
+ * It returns the first names of every user (people),
+ * the total number of users (total-users),
+ * the total number of semesters across all users (total-semesters),
+ * the average number of semesters per user (avg-semester),
+ * the average number of older semesters that are/before the current semester
+ * per user (avg-old-semester),
+ * and the average number of newer semesters that are
+ * after the current semester (avg-new-semester).
+ */
 
 exports.TrackUsers = functions.https.onRequest(async (req, res) => {
-  const arr = [];
-  let count = 0;
-  const semester = [];
-  const oldSemester = [];
-  const newSemester = [];
-  const semesterCount = 0;
-  userDataCollection
-    .get()
-    .then(function (querySnapshot) {
-      querySnapshot.forEach(function (doc) {
-        arr.push(doc.data().name.firstName);
+  const firstNames = [];
+  let totalUsersCount = 0;
+  const semesters = [];
+  const oldSemesters = [];
+  const newSemesters = [];
+  let semesterCount = 0;
 
-        let oldCount = 0;
-        let newCount = 0;
-        doc.data().semesters.forEach(function (semester) {
-          if (isOld(semester)) {
-            oldCount++;
-          } else {
-            newCount++;
-          }
-          semesterCount++;
-        });
-        semester.push(doc.data().semesters.length);
-        oldSemester.push(oldCount);
-        newSemester.push(newCount);
-        count++;
-      });
-
-      const response = {
-        people: arr,
-        'total-users': count,
-        'total-semesters': semesterCount,
-        'avg-semester': average(semester),
-        'avg-old-semester': average(oldSemester),
-        'avg-new-semster': average(newSemester),
-      };
-      return response;
-    })
-    .then(function (response) {
-      console.log(response);
-      res.send(response);
-      return response;
-    })
-    .catch(error => {
-      console.log('Error getting document:', error);
-      throw new Error("Profile doesn't exist");
+  const usernamePromise = usernameCollection.get().then(usernameQuerySnapshot => {
+    usernameQuerySnapshot.forEach(doc => {
+      firstNames.push(doc.data().firstName);
+      totalUsersCount += 1;
     });
+    const usernameResponse = {
+      people: firstNames,
+      'total-users': totalUsersCount,
+    };
+    return usernameResponse;
+  });
+
+  const semesterPromise = semestersCollection.get().then(semesterQuerySnapshot => {
+    semesterQuerySnapshot.forEach(doc => {
+      let oldSemesterCount = 0;
+      let newSemesterCount = 0;
+      doc.data().semesters.forEach(semester => {
+        if (isOld(semester)) {
+          oldSemesterCount += 1;
+        } else {
+          newSemesterCount += 1;
+        }
+        semesterCount += 1;
+      });
+      semesters.push(doc.data().semesters.length);
+      oldSemesters.push(oldSemesterCount);
+      newSemesters.push(newSemesterCount);
+    });
+    const semesterResponse = {
+      'total-semesters': semesterCount,
+      'avg-semester': average(semesters),
+      'avg-old-semester': average(oldSemesters),
+      'avg-new-semster': average(newSemesters),
+    };
+    return semesterResponse;
+  });
+
+  Promise.all([usernamePromise, semesterPromise]).then(promiseResponses => {
+    const response = Object.assign({}, ...promiseResponses);
+    console.log(response);
+    res.send(response);
+    return response;
+  });
 });


### PR DESCRIPTION
### Summary <!-- Required -->
This pull request updates the `TrackUsers()` Firebase function so that it uses the collections (i.e. `user-name` and `user-semesters`) that are currently used in the CoursePlan Dev Firebase instance. Ultimately the CoursePlan prod Firebase Firestore will be migrated so that its `userData` collection is divided into `user-name`, `user-onboarding-data`, `user-semesters`, etc., as the collections are divided in CoursePlan Dev Firestore. Then, this updated `TrackUsers()` Firebase function can be pushed to prod and we can use it to get user metrics from our prod data!

- [x] Updated `TrackUsers()` function in `functions/index.js`
- [x] Deployed `TrackUsers()` to **staging (dev)** not prod

Remaining TODOs:
- [ ] Back-up CoursePlan prod Firebase Firestore
- [ ] Data migration for CoursePlan prod Firebase Firestore
- [ ] Deploy `TrackUsers()` to prod

### Test Plan <!-- Required -->
1. Test the most recently deployed `TrackUsers()` on CoursePlan Dev by clicking the **Test the Function** button and seeing the output: https://console.cloud.google.com/functions/details/us-central1/TrackUsers?project=cornelldti-courseplan-dev&tab=testing

https://user-images.githubusercontent.com/54298311/110217130-6cba6280-7e80-11eb-81ee-c9cf26e39dc1.mov


2. Can compare against what is seen in CoursePlan Dev Firebase Firestore
