### PR TITLE
Save user choice for self check, clean up some semester-related firestore modifiers

### DIFF
--- a/src/components/BottomBar/BottomBarCourseReview.vue
+++ b/src/components/BottomBar/BottomBarCourseReview.vue
@@ -108,7 +108,7 @@ export default Vue.extend({
       return noneIfEmpty(this.courseObj.prereqs);
     },
     CURLink(): string {
-      const [subject, number] = this.courseObj.code.split(" ");
+      const [subject, number] = this.courseObj.code.split(' ');
       return `https://www.cureviews.org/course/${subject}/${number}`;
     },
     CUROverallRating() {

--- a/src/components/BottomBar/BottomBarCourseReview.vue
+++ b/src/components/BottomBar/BottomBarCourseReview.vue
@@ -108,7 +108,7 @@ export default Vue.extend({
       return noneIfEmpty(this.courseObj.prereqs);
     },
     CURLink(): string {
-      const [subject, number] = this.courseObj.code;
+      const [subject, number] = this.courseObj.code.split(" ");
       return `https://www.cureviews.org/course/${subject}/${number}`;
     },
     CUROverallRating() {

--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -13,7 +13,7 @@
     <course-selector
       search-box-class-name="newCourse-dropdown"
       :key="courseSelectorKey"
-      placeholder='"CS1110", "Multivariable Calculus", etc'
+      placeholder='"CS 1110", "Multivariable Calculus", etc'
       :autoFocus="true"
       @on-escape="closeCurrentModal"
       @on-select="selectCourse"

--- a/src/components/Modals/NewCourse/NewSelfCheckCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewSelfCheckCourseModal.vue
@@ -13,7 +13,7 @@
     <course-selector
       search-box-class-name="newCourse-dropdown"
       :key="courseSelectorKey"
-      placeholder='"CS1110", "Multivariable Calculus", etc'
+      placeholder='"CS 1110", "Multivariable Calculus", etc'
       :autoFocus="true"
       @on-escape="closeCurrentModal"
       @on-select="setCourse"

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -34,6 +34,7 @@
 import Vue, { PropType } from 'vue';
 import ReqCourse from '@/components/Requirements/ReqCourse.vue';
 import store from '@/store';
+import {deleteCourseFromSemesters} from '@/global-firestore-data';
 import getCurrentSeason, { getCurrentYear } from '@/utilities';
 
 const transferCreditColor = 'DA4A4A'; // Arbitrary color for transfer credit
@@ -73,7 +74,7 @@ export default Vue.extend({
   },
   methods: {
     onReset() {
-      this.$emit('deleteCourseFromSemesters', this.courseTaken.uniqueId);
+      deleteCourseFromSemesters(this.courseTaken.uniqueId, this.gtag);
     },
   },
 });

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -34,7 +34,7 @@
 import Vue, { PropType } from 'vue';
 import ReqCourse from '@/components/Requirements/ReqCourse.vue';
 import store from '@/store';
-import {deleteCourseFromSemesters} from '@/global-firestore-data';
+import { deleteCourseFromSemesters } from '@/global-firestore-data';
 import getCurrentSeason, { getCurrentYear } from '@/utilities';
 
 const transferCreditColor = 'DA4A4A'; // Arbitrary color for transfer credit

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -74,7 +74,7 @@ export default Vue.extend({
   },
   methods: {
     onReset() {
-      deleteCourseFromSemesters(this.courseTaken.uniqueId, this.gtag);
+      deleteCourseFromSemesters(this.courseTaken.uniqueId, this.$gtag);
     },
   },
 });

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -50,7 +50,9 @@ export default Vue.extend({
   components: {
     NewSelfCheckCourseModal,
   },
-  props: {},
+  props: {
+    subReqId: { type: String, required: true },
+  },
   data(): Data {
     return {
       showDropdown: false,
@@ -78,13 +80,13 @@ export default Vue.extend({
     },
     addExistingCourse(option: string) {
       this.showDropdown = false;
-      this.$emit('addCourse', this.selfCheckCourses[option]);
+      this.$emit('addCourse', this.selfCheckCourses[option], this.subReqId);
     },
     addNewCourse(course: CornellCourseRosterCourse, season: FirestoreSemesterType, year: number) {
       this.showDropdown = false;
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourse(course);
       addCourseToSemester(season, year, newCourse);
-      this.$emit('addCourse', newCourse);
+      this.$emit('addCourse', newCourse, this.subReqId);
     },
     openCourseModal() {
       this.isCourseModalOpen = true;

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -36,7 +36,7 @@ import Vue from 'vue';
 
 import { clickOutside } from '@/utilities';
 import store from '@/store';
-import { addCourseToSemester, chooseSelectableRequirementOption } from '@/global-firestore-data';
+import { addCourseToSemester, addCourseToSelectableRequirements } from '@/global-firestore-data';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
 
 import NewSelfCheckCourseModal from '@/components/Modals/NewCourse/NewSelfCheckCourseModal.vue';
@@ -83,23 +83,12 @@ export default Vue.extend({
     },
     addExistingCourse(option: string) {
       this.showDropdown = false;
-      if (this.subReqId) {
-        chooseSelectableRequirementOption({
-          ...store.state.selectableRequirementChoices,
-          [this.selfCheckCourses[option].uniqueID]: this.subReqId,
-        });
-      }
+      addCourseToSelectableRequirements(this.selfCheckCourses[option].uniqueID, this.subReqId);
     },
     addNewCourse(course: CornellCourseRosterCourse, season: FirestoreSemesterType, year: number) {
       this.showDropdown = false;
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourse(course);
-      addCourseToSemester(season, year, newCourse);
-      if (this.subReqId) {
-        chooseSelectableRequirementOption({
-          ...store.state.selectableRequirementChoices,
-          [course.uniqueID]: this.subReqId,
-        });
-      }
+      addCourseToSemester(season, year, newCourse, this.subReqId, this.gtag);
     },
     openCourseModal() {
       this.isCourseModalOpen = true;

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -65,7 +65,10 @@ export default Vue.extend({
       const courses: Record<string, FirestoreSemesterCourse> = {};
       store.state.semesters.forEach(semester => {
         semester.courses.forEach(course => {
-          courses[course.code] = course;
+          const selectableRequirementCourses =
+            store.state.derivedSelectableRequirementData.requirementToCoursesMap[this.subReqId];
+          if (!(selectableRequirementCourses && selectableRequirementCourses.includes(course)))
+            courses[course.code] = course;
         });
       });
       return courses;
@@ -80,7 +83,12 @@ export default Vue.extend({
     },
     addExistingCourse(option: string) {
       this.showDropdown = false;
-      this.$emit('addCourse', this.selfCheckCourses[option], this.subReqId);
+      if (this.subReqId) {
+        chooseSelectableRequirementOption({
+          ...store.state.selectableRequirementChoices,
+          [this.selfCheckCourses[option].uniqueID]: this.subReqId,
+        });
+      }
     },
     addNewCourse(course: CornellCourseRosterCourse, season: FirestoreSemesterType, year: number) {
       this.showDropdown = false;

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -88,7 +88,7 @@ export default Vue.extend({
     addNewCourse(course: CornellCourseRosterCourse, season: FirestoreSemesterType, year: number) {
       this.showDropdown = false;
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourse(course);
-      addCourseToSemester(season, year, newCourse, this.subReqId, this.gtag);
+      addCourseToSemester(season, year, newCourse, this.subReqId, this.$gtag);
     },
     openCourseModal() {
       this.isCourseModalOpen = true;

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -36,7 +36,7 @@ import Vue from 'vue';
 
 import { clickOutside } from '@/utilities';
 import store from '@/store';
-import { addCourseToSemester } from '@/global-firestore-data';
+import { addCourseToSemester, chooseSelectableRequirementOption } from '@/global-firestore-data';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
 
 import NewSelfCheckCourseModal from '@/components/Modals/NewCourse/NewSelfCheckCourseModal.vue';
@@ -86,7 +86,12 @@ export default Vue.extend({
       this.showDropdown = false;
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourse(course);
       addCourseToSemester(season, year, newCourse);
-      this.$emit('addCourse', newCourse, this.subReqId);
+      if (this.subReqId) {
+        chooseSelectableRequirementOption({
+          ...store.state.selectableRequirementChoices,
+          [course.uniqueID]: this.subReqId,
+        });
+      }
     },
     openCourseModal() {
       this.isCourseModalOpen = true;

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -27,7 +27,6 @@
             :isCompleted="false"
             @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
             @onShowAllCourses="onShowAllCourses"
-            @deleteCourseFromSemesters="deleteCourseFromSemesters"
           />
           <div class="separator"></div>
         </div>
@@ -57,7 +56,6 @@
               :isCompleted="true"
               @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
               @onShowAllCourses="onShowAllCourses"
-              @deleteCourseFromSemesters="deleteCourseFromSemesters"
             />
           </div>
         </div>
@@ -149,9 +147,6 @@ export default Vue.extend({
     },
     turnCompleted(bool: boolean) {
       this.displayCompleted = bool;
-    },
-    deleteCourseFromSemesters(uniqueId: number) {
-      this.$emit('deleteCourseFromSemesters', uniqueId);
     },
   },
 });

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -23,7 +23,6 @@
           @activateMajor="activateMajor"
           @activateMinor="activateMinor"
           @onShowAllCourses="onShowAllCourses"
-          @deleteCourseFromSemesters="deleteCourseFromSemesters"
         />
       </div>
     </div>
@@ -245,9 +244,6 @@ export default Vue.extend({
     },
     cloneCourse(courseWithDummyUniqueID: FirestoreSemesterCourse): FirestoreSemesterCourse {
       return { ...courseWithDummyUniqueID, uniqueID: incrementUniqueID() };
-    },
-    deleteCourseFromSemesters(uniqueId: number) {
-      this.$emit('deleteCourseFromSemesters', uniqueId);
     },
   },
 });

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -26,7 +26,10 @@
         </div>
       </div>
       <div class="col">
-        <p v-if="!isCompleted" class="sup-req-progress text-right incomplete-ptext">
+        <p
+          v-if="!isCompleted"
+          class="sup-req-progress text-right incomplete-ptext"
+        >
           {{ subReqProgress }}
         </p>
         <p v-if="isFulfilled" class="text-right completed-ptext">
@@ -37,7 +40,10 @@
         </p>
       </div>
     </button>
-    <div v-if="displayDescription" :class="[{ 'completed-ptext': isFulfilled }, 'description']">
+    <div
+      v-if="displayDescription"
+      :class="[{ 'completed-ptext': isFulfilled }, 'description']"
+    >
       <div>
         {{ subReq.requirement.description }}
         <a
@@ -49,7 +55,10 @@
           <strong>Learn More</strong></a
         >
       </div>
-      <div v-if="subReq.requirement.checkerWarning" class="requirement-checker-warning">
+      <div
+        v-if="subReq.requirement.checkerWarning"
+        class="requirement-checker-warning"
+      >
         <img
           class="requirement-checker-warning-icon"
           src="@/assets/images/warning.svg"
@@ -65,7 +74,9 @@
           >
             <div
               class="toggleable-requirements-dropdown-placeholder toggleable-requirements-dropdown-wrapper"
-              @click="showFulfillmentOptionsDropdown = !showFulfillmentOptionsDropdown"
+              @click="
+                showFulfillmentOptionsDropdown = !showFulfillmentOptionsDropdown
+              "
             >
               <span>{{ selectedFulfillmentOption }}</span>
             </div>
@@ -78,7 +89,9 @@
             v-if="showFulfillmentOptionsDropdown"
           >
             <div
-              v-for="optionName in Object.keys(subReq.requirement.fulfillmentOptions)"
+              v-for="optionName in Object.keys(
+                subReq.requirement.fulfillmentOptions
+              )"
               :key="optionName"
               class="toggleable-requirements-dropdown-content-item"
               @click="chooseFulfillmentOption(optionName)"
@@ -86,7 +99,10 @@
               <span>{{ optionName }}</span>
             </div>
           </div>
-          {{ subReq.requirement.fulfillmentOptions[selectedFulfillmentOption].description }}
+          {{
+            subReq.requirement.fulfillmentOptions[selectedFulfillmentOption]
+              .description
+          }}
         </div>
       </div>
       <div
@@ -98,14 +114,20 @@
         class="subreqcourse-wrapper"
       >
         <div v-for="(subReqCourseSlot, id) in subReqCoursesSlots" :key="id">
-          <div v-if="subReqCourseSlot.isCompleted" class="completedsubreqcourse-wrapper">
+          <div
+            v-if="subReqCourseSlot.isCompleted"
+            class="completedsubreqcourse-wrapper"
+          >
             <completed-sub-req-course
               :subReqCourseId="id"
               :courseTaken="subReqCourseSlot.courses[0]"
               @deleteCourseFromSemesters="deleteCourseFromSemesters"
             />
           </div>
-          <div v-if="!subReqCourseSlot.isCompleted" class="incompletesubreqcourse-wrapper">
+          <div
+            v-if="!subReqCourseSlot.isCompleted"
+            class="incompletesubreqcourse-wrapper"
+          >
             <incomplete-sub-req-course
               :subReq="subReq"
               :subReqCourseId="id"
@@ -125,7 +147,10 @@
         "
         class="subreqcourse-wrapper"
       >
-        <div v-for="(selfCheckCourse, id) in fulfilledSelfCheckCourses" :key="id">
+        <div
+          v-for="(selfCheckCourse, id) in fulfilledSelfCheckCourses"
+          :key="id"
+        >
           <completed-sub-req-course
             :subReqCourseId="id"
             :courseTaken="convertCourse(selfCheckCourse)"
@@ -133,7 +158,10 @@
           />
         </div>
         <!-- TODO: only show incomplete-self-check if all courses not added -->
-        <incomplete-self-check :subReqId="subReq.requirement.id" @addCourse="addSelfCheckCourse" />
+        <incomplete-self-check
+          :subReqId="subReq.requirement.id"
+          @addCourse="addSelfCheckCourse"
+        />
       </div>
     </div>
   </div>
@@ -154,7 +182,10 @@ import {
 } from '@/requirements/requirement-frontend-utils';
 import { cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor } from '@/user-data-converter';
 import fullCoursesJson from '@/assets/courses/typed-full-courses';
-import { allocateSubjectColors, chooseSelectableRequirementOption } from '@/global-firestore-data';
+import {
+  allocateSubjectColors,
+  chooseSelectableRequirementOption,
+} from '@/global-firestore-data';
 
 type CompletedSubReqCourseSlot = {
   readonly isCompleted: true;
@@ -166,12 +197,13 @@ type IncompleteSubReqCourseSlot = {
   readonly courses: readonly FirestoreSemesterCourse[];
 };
 
-export type SubReqCourseSlot = CompletedSubReqCourseSlot | IncompleteSubReqCourseSlot;
+export type SubReqCourseSlot =
+  | CompletedSubReqCourseSlot
+  | IncompleteSubReqCourseSlot;
 
 type Data = {
   showFulfillmentOptionsDropdown: boolean;
   displayDescription: boolean;
-  fulfilledSelfCheckCourses: FirestoreSemesterCourse[];
 };
 
 const generateSubReqIncompleteCourses = (
@@ -181,7 +213,9 @@ const generateSubReqIncompleteCourses = (
   const rosterCourses = eligibleCourseIds
     .filter(courseID => !allTakenCourseIds.has(courseID))
     .flatMap(courseID => fullCoursesJson[courseID] || []);
-  const subjectColors = allocateSubjectColors(new Set(rosterCourses.map(it => it.subject)));
+  const subjectColors = allocateSubjectColors(
+    new Set(rosterCourses.map(it => it.subject))
+  );
   return rosterCourses.map(rosterCourse =>
     cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor(
       rosterCourse,
@@ -192,9 +226,17 @@ const generateSubReqIncompleteCourses = (
 };
 
 export default Vue.extend({
-  components: { CompletedSubReqCourse, DropDownArrow, IncompleteSubReqCourse, IncompleteSelfCheck },
+  components: {
+    CompletedSubReqCourse,
+    DropDownArrow,
+    IncompleteSubReqCourse,
+    IncompleteSelfCheck,
+  },
   props: {
-    subReq: { type: Object as PropType<RequirementFulfillment>, required: true },
+    subReq: {
+      type: Object as PropType<RequirementFulfillment>,
+      required: true,
+    },
     isCompleted: { type: Boolean, required: true },
     toggleableRequirementChoice: { type: String, default: null },
     color: { type: String, required: true },
@@ -203,7 +245,6 @@ export default Vue.extend({
     return {
       showFulfillmentOptionsDropdown: false,
       displayDescription: false,
-      fulfilledSelfCheckCourses: [],
     };
   },
   computed: {
@@ -220,13 +261,18 @@ export default Vue.extend({
       );
     },
     subReqCoursesSlots(): SubReqCourseSlot[] {
-      const subReqSpec = getMatchedRequirementFulfillmentSpecification(this.subReq.requirement, {
-        [this.subReq.requirement.id]: this.toggleableRequirementChoice,
-      });
+      const subReqSpec = getMatchedRequirementFulfillmentSpecification(
+        this.subReq.requirement,
+        {
+          [this.subReq.requirement.id]: this.toggleableRequirementChoice,
+        }
+      );
       if (subReqSpec === null) return [];
       const subReqEligibleCourses = subReqSpec.eligibleCourses;
 
-      const allTakenCourseIds = new Set(this.subReq.courses.flat().map(course => course.courseId));
+      const allTakenCourseIds = new Set(
+        this.subReq.courses.flat().map(course => course.courseId)
+      );
       const slots: SubReqCourseSlot[] = [];
 
       const coursesTaken = this.subReq.courses;
@@ -241,13 +287,19 @@ export default Vue.extend({
           if (coursesTaken.length === 1 && !this.isCompleted) {
             slots.push({
               isCompleted: false,
-              courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[i]),
+              courses: generateSubReqIncompleteCourses(
+                allTakenCourseIds,
+                subReqEligibleCourses[i]
+              ),
             });
           }
         } else {
           slots.push({
             isCompleted: false,
-            courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[i]),
+            courses: generateSubReqIncompleteCourses(
+              allTakenCourseIds,
+              subReqEligibleCourses[i]
+            ),
           });
         }
       });
@@ -257,6 +309,17 @@ export default Vue.extend({
       return this.subReq.fulfilledBy !== 'self-check'
         ? `${this.subReq.minCountFulfilled}/${this.subReq.minCountRequired} ${this.subReq.fulfilledBy}`
         : 'self check';
+    },
+    fulfilledSelfCheckCourses(): FirestoreSemesterCourse[] {
+      const reqId = this.subReq.requirement.id;
+      const temp = Object.entries(store.state.selectableRequirementChoices)
+        .filter(([_, v]) => v === reqId)
+        .map(
+          ([k, _]) => store.state.derivedCoursesData.courseMap[parseInt(k, 10)]
+        )
+        .filter(course => !!course);
+      console.log(temp);
+      return temp;
     },
   },
   directives: {
@@ -280,10 +343,14 @@ export default Vue.extend({
     },
     chooseFulfillmentOption(option: string) {
       this.showFulfillmentOptionsDropdown = false;
-      this.$emit('changeToggleableRequirementChoice', this.subReq.requirement.id, option);
+      this.$emit(
+        'changeToggleableRequirementChoice',
+        this.subReq.requirement.id,
+        option
+      );
     },
     addSelfCheckCourse(course: FirestoreSemesterCourse, requirementID: string) {
-      this.fulfilledSelfCheckCourses.push(course);
+      // TODO this.fulfilledSelfCheckCourses.push(course);
       if (requirementID) {
         chooseSelectableRequirementOption({
           ...store.state.selectableRequirementChoices,
@@ -295,6 +362,8 @@ export default Vue.extend({
       return convertFirestoreSemesterCourseToCourseTaken(course);
     },
     deleteCourseFromSemesters(uniqueId: number) {
+      // TODO
+      /*
       // find and remove self-check course on sidebar
       let indexToRemove = -1;
       if (this.subReq.requirement.fulfilledBy === 'self-check') {
@@ -307,6 +376,7 @@ export default Vue.extend({
       if (indexToRemove !== -1) {
         this.fulfilledSelfCheckCourses.splice(indexToRemove, 1);
       }
+      */
       this.$emit('deleteCourseFromSemesters', uniqueId);
     },
   },

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -121,7 +121,6 @@
             <completed-sub-req-course
               :subReqCourseId="id"
               :courseTaken="subReqCourseSlot.courses[0]"
-              @deleteCourseFromSemesters="deleteCourseFromSemesters"
             />
           </div>
           <div
@@ -154,7 +153,6 @@
           <completed-sub-req-course
             :subReqCourseId="id"
             :courseTaken="convertCourse(selfCheckCourse)"
-            @deleteCourseFromSemesters="deleteCourseFromSemesters"
           />
         </div>
         <!-- TODO: only show incomplete-self-check if all courses not added -->
@@ -353,24 +351,6 @@ export default Vue.extend({
     },
     convertCourse(course: FirestoreSemesterCourse): CourseTaken {
       return convertFirestoreSemesterCourseToCourseTaken(course);
-    },
-    deleteCourseFromSemesters(uniqueId: number) {
-      // TODO
-      /*
-      // find and remove self-check course on sidebar
-      let indexToRemove = -1;
-      if (this.subReq.requirement.fulfilledBy === 'self-check') {
-        for (let i = 0; i < this.fulfilledSelfCheckCourses.length; i += 1) {
-          if (this.fulfilledSelfCheckCourses[i].uniqueID === uniqueId) {
-            indexToRemove = i;
-          }
-        }
-      }
-      if (indexToRemove !== -1) {
-        this.fulfilledSelfCheckCourses.splice(indexToRemove, 1);
-      }
-      */
-      this.$emit('deleteCourseFromSemesters', uniqueId);
     },
   },
 });

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -26,10 +26,7 @@
         </div>
       </div>
       <div class="col">
-        <p
-          v-if="!isCompleted"
-          class="sup-req-progress text-right incomplete-ptext"
-        >
+        <p v-if="!isCompleted" class="sup-req-progress text-right incomplete-ptext">
           {{ subReqProgress }}
         </p>
         <p v-if="isFulfilled" class="text-right completed-ptext">
@@ -40,10 +37,7 @@
         </p>
       </div>
     </button>
-    <div
-      v-if="displayDescription"
-      :class="[{ 'completed-ptext': isFulfilled }, 'description']"
-    >
+    <div v-if="displayDescription" :class="[{ 'completed-ptext': isFulfilled }, 'description']">
       <div>
         {{ subReq.requirement.description }}
         <a
@@ -55,10 +49,7 @@
           <strong>Learn More</strong></a
         >
       </div>
-      <div
-        v-if="subReq.requirement.checkerWarning"
-        class="requirement-checker-warning"
-      >
+      <div v-if="subReq.requirement.checkerWarning" class="requirement-checker-warning">
         <img
           class="requirement-checker-warning-icon"
           src="@/assets/images/warning.svg"
@@ -74,9 +65,7 @@
           >
             <div
               class="toggleable-requirements-dropdown-placeholder toggleable-requirements-dropdown-wrapper"
-              @click="
-                showFulfillmentOptionsDropdown = !showFulfillmentOptionsDropdown
-              "
+              @click="showFulfillmentOptionsDropdown = !showFulfillmentOptionsDropdown"
             >
               <span>{{ selectedFulfillmentOption }}</span>
             </div>
@@ -89,9 +78,7 @@
             v-if="showFulfillmentOptionsDropdown"
           >
             <div
-              v-for="optionName in Object.keys(
-                subReq.requirement.fulfillmentOptions
-              )"
+              v-for="optionName in Object.keys(subReq.requirement.fulfillmentOptions)"
               :key="optionName"
               class="toggleable-requirements-dropdown-content-item"
               @click="chooseFulfillmentOption(optionName)"
@@ -99,10 +86,7 @@
               <span>{{ optionName }}</span>
             </div>
           </div>
-          {{
-            subReq.requirement.fulfillmentOptions[selectedFulfillmentOption]
-              .description
-          }}
+          {{ subReq.requirement.fulfillmentOptions[selectedFulfillmentOption].description }}
         </div>
       </div>
       <div
@@ -114,19 +98,13 @@
         class="subreqcourse-wrapper"
       >
         <div v-for="(subReqCourseSlot, id) in subReqCoursesSlots" :key="id">
-          <div
-            v-if="subReqCourseSlot.isCompleted"
-            class="completedsubreqcourse-wrapper"
-          >
+          <div v-if="subReqCourseSlot.isCompleted" class="completedsubreqcourse-wrapper">
             <completed-sub-req-course
               :subReqCourseId="id"
               :courseTaken="subReqCourseSlot.courses[0]"
             />
           </div>
-          <div
-            v-if="!subReqCourseSlot.isCompleted"
-            class="incompletesubreqcourse-wrapper"
-          >
+          <div v-if="!subReqCourseSlot.isCompleted" class="incompletesubreqcourse-wrapper">
             <incomplete-sub-req-course
               :subReq="subReq"
               :subReqCourseId="id"
@@ -146,20 +124,14 @@
         "
         class="subreqcourse-wrapper"
       >
-        <div
-          v-for="(selfCheckCourse, id) in fulfilledSelfCheckCourses"
-          :key="id"
-        >
+        <div v-for="(selfCheckCourse, id) in fulfilledSelfCheckCourses" :key="id">
           <completed-sub-req-course
             :subReqCourseId="id"
             :courseTaken="convertCourse(selfCheckCourse)"
           />
         </div>
         <!-- TODO: only show incomplete-self-check if all courses not added -->
-        <incomplete-self-check
-          :subReqId="subReq.requirement.id"
-          @addCourse="addSelfCheckCourse"
-        />
+        <incomplete-self-check :subReqId="subReq.requirement.id" />
       </div>
     </div>
   </div>
@@ -180,10 +152,7 @@ import {
 } from '@/requirements/requirement-frontend-utils';
 import { cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor } from '@/user-data-converter';
 import fullCoursesJson from '@/assets/courses/typed-full-courses';
-import {
-  allocateSubjectColors,
-  chooseSelectableRequirementOption,
-} from '@/global-firestore-data';
+import { allocateSubjectColors, chooseSelectableRequirementOption } from '@/global-firestore-data';
 
 type CompletedSubReqCourseSlot = {
   readonly isCompleted: true;
@@ -195,9 +164,7 @@ type IncompleteSubReqCourseSlot = {
   readonly courses: readonly FirestoreSemesterCourse[];
 };
 
-export type SubReqCourseSlot =
-  | CompletedSubReqCourseSlot
-  | IncompleteSubReqCourseSlot;
+export type SubReqCourseSlot = CompletedSubReqCourseSlot | IncompleteSubReqCourseSlot;
 
 type Data = {
   showFulfillmentOptionsDropdown: boolean;
@@ -211,9 +178,7 @@ const generateSubReqIncompleteCourses = (
   const rosterCourses = eligibleCourseIds
     .filter(courseID => !allTakenCourseIds.has(courseID))
     .flatMap(courseID => fullCoursesJson[courseID] || []);
-  const subjectColors = allocateSubjectColors(
-    new Set(rosterCourses.map(it => it.subject))
-  );
+  const subjectColors = allocateSubjectColors(new Set(rosterCourses.map(it => it.subject)));
   return rosterCourses.map(rosterCourse =>
     cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor(
       rosterCourse,
@@ -259,18 +224,13 @@ export default Vue.extend({
       );
     },
     subReqCoursesSlots(): SubReqCourseSlot[] {
-      const subReqSpec = getMatchedRequirementFulfillmentSpecification(
-        this.subReq.requirement,
-        {
-          [this.subReq.requirement.id]: this.toggleableRequirementChoice,
-        }
-      );
+      const subReqSpec = getMatchedRequirementFulfillmentSpecification(this.subReq.requirement, {
+        [this.subReq.requirement.id]: this.toggleableRequirementChoice,
+      });
       if (subReqSpec === null) return [];
       const subReqEligibleCourses = subReqSpec.eligibleCourses;
 
-      const allTakenCourseIds = new Set(
-        this.subReq.courses.flat().map(course => course.courseId)
-      );
+      const allTakenCourseIds = new Set(this.subReq.courses.flat().map(course => course.courseId));
       const slots: SubReqCourseSlot[] = [];
 
       const coursesTaken = this.subReq.courses;
@@ -285,19 +245,13 @@ export default Vue.extend({
           if (coursesTaken.length === 1 && !this.isCompleted) {
             slots.push({
               isCompleted: false,
-              courses: generateSubReqIncompleteCourses(
-                allTakenCourseIds,
-                subReqEligibleCourses[i]
-              ),
+              courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[i]),
             });
           }
         } else {
           slots.push({
             isCompleted: false,
-            courses: generateSubReqIncompleteCourses(
-              allTakenCourseIds,
-              subReqEligibleCourses[i]
-            ),
+            courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[i]),
           });
         }
       });
@@ -334,20 +288,7 @@ export default Vue.extend({
     },
     chooseFulfillmentOption(option: string) {
       this.showFulfillmentOptionsDropdown = false;
-      this.$emit(
-        'changeToggleableRequirementChoice',
-        this.subReq.requirement.id,
-        option
-      );
-    },
-    addSelfCheckCourse(course: FirestoreSemesterCourse, requirementID: string) {
-      // TODO this.fulfilledSelfCheckCourses.push(course);
-      if (requirementID) {
-        chooseSelectableRequirementOption({
-          ...store.state.selectableRequirementChoices,
-          [course.uniqueID]: requirementID,
-        });
-      }
+      this.$emit('changeToggleableRequirementChoice', this.subReq.requirement.id, option);
     },
     convertCourse(course: FirestoreSemesterCourse): CourseTaken {
       return convertFirestoreSemesterCourseToCourseTaken(course);

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -312,14 +312,7 @@ export default Vue.extend({
     },
     fulfilledSelfCheckCourses(): FirestoreSemesterCourse[] {
       const reqId = this.subReq.requirement.id;
-      const temp = Object.entries(store.state.selectableRequirementChoices)
-        .filter(([_, v]) => v === reqId)
-        .map(
-          ([k, _]) => store.state.derivedCoursesData.courseMap[parseInt(k, 10)]
-        )
-        .filter(course => !!course);
-      console.log(temp);
-      return temp;
+      return store.state.derivedSelectableRequirementData.requirementToCoursesMap[reqId];
     },
   },
   directives: {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -152,7 +152,7 @@ import {
 } from '@/requirements/requirement-frontend-utils';
 import { cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor } from '@/user-data-converter';
 import fullCoursesJson from '@/assets/courses/typed-full-courses';
-import { allocateSubjectColors, chooseSelectableRequirementOption } from '@/global-firestore-data';
+import { allocateSubjectColors } from '@/global-firestore-data';
 
 type CompletedSubReqCourseSlot = {
   readonly isCompleted: true;

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -133,7 +133,7 @@
           />
         </div>
         <!-- TODO: only show incomplete-self-check if all courses not added -->
-        <incomplete-self-check @addCourse="addSelfCheckCourse" />
+        <incomplete-self-check :subReqId="subReq.requirement.id" @addCourse="addSelfCheckCourse" />
       </div>
     </div>
   </div>
@@ -146,6 +146,7 @@ import IncompleteSubReqCourse from '@/components/Requirements/IncompleteSubReqCo
 import IncompleteSelfCheck from '@/components/Requirements/IncompleteSelfCheck.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 
+import store from '@/store';
 import { clickOutside } from '@/utilities';
 import {
   convertFirestoreSemesterCourseToCourseTaken,
@@ -153,7 +154,7 @@ import {
 } from '@/requirements/requirement-frontend-utils';
 import { cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor } from '@/user-data-converter';
 import fullCoursesJson from '@/assets/courses/typed-full-courses';
-import { allocateSubjectColors } from '@/global-firestore-data';
+import { allocateSubjectColors, chooseSelectableRequirementOption } from '@/global-firestore-data';
 
 type CompletedSubReqCourseSlot = {
   readonly isCompleted: true;
@@ -281,8 +282,14 @@ export default Vue.extend({
       this.showFulfillmentOptionsDropdown = false;
       this.$emit('changeToggleableRequirementChoice', this.subReq.requirement.id, option);
     },
-    addSelfCheckCourse(course: FirestoreSemesterCourse) {
+    addSelfCheckCourse(course: FirestoreSemesterCourse, requirementID: string) {
       this.fulfilledSelfCheckCourses.push(course);
+      if (requirementID) {
+        chooseSelectableRequirementOption({
+          ...store.state.selectableRequirementChoices,
+          [course.uniqueID]: requirementID,
+        });
+      }
     },
     convertCourse(course: FirestoreSemesterCourse): CourseTaken {
       return convertFirestoreSemesterCourseToCourseTaken(course);

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -17,7 +17,7 @@
         <div class="subreq-name">
           <p
             :class="[
-              { 'sup-req': !isFulfilled },
+              { 'sub-req': !isFulfilled },
               isFulfilled ? 'completed-ptext' : 'incomplete-ptext',
             ]"
           >
@@ -26,7 +26,7 @@
         </div>
       </div>
       <div class="col">
-        <p v-if="!isCompleted" class="sup-req-progress text-right incomplete-ptext">
+        <p v-if="!isCompleted" class="sub-req-progress text-right incomplete-ptext">
           {{ subReqProgress }}
         </p>
         <p v-if="isFulfilled" class="text-right completed-ptext">
@@ -384,7 +384,7 @@ button.view {
     color: $lightPlaceholderGray;
   }
 }
-.sup-req {
+.sub-req {
   font-style: normal;
   font-weight: normal;
   font-size: 14px;

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -262,7 +262,7 @@ export default Vue.extend({
         ? `${this.subReq.minCountFulfilled}/${this.subReq.minCountRequired} ${this.subReq.fulfilledBy}`
         : 'self check';
     },
-    fulfilledSelfCheckCourses(): FirestoreSemesterCourse[] {
+    fulfilledSelfCheckCourses(): readonly FirestoreSemesterCourse[] {
       const reqId = this.subReq.requirement.id;
       return store.state.derivedSelectableRequirementData.requirementToCoursesMap[reqId];
     },

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -324,7 +324,7 @@ export default Vue.extend({
       this.openConfirmationModal(`Added ${courseCode} to ${this.type} ${this.year}`);
     },
     deleteCourse(courseCode: string, uniqueID: number) {
-      deleteCourseFromSemester(this.type, this.year, uniqueID);
+      deleteCourseFromSemester(this.type, this.year, uniqueID, this.gtag);
       // Update requirements menu
       this.openConfirmationModal(`Removed ${courseCode} from ${this.type} ${this.year}`);
     },

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -131,7 +131,6 @@ import {
   editSemester,
   addCourseToSemester,
   deleteCourseFromSemester,
-  chooseSelectableRequirementOption,
 } from '@/global-firestore-data';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
 import store from '@/store';
@@ -319,13 +318,7 @@ export default Vue.extend({
     },
     addCourse(data: CornellCourseRosterCourse, requirementID: string) {
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourse(data);
-      addCourseToSemester(this.type, this.year, newCourse);
-      if (requirementID) {
-        chooseSelectableRequirementOption({
-          ...store.state.selectableRequirementChoices,
-          [newCourse.uniqueID]: requirementID,
-        });
-      }
+      addCourseToSemester(this.type, this.year, newCourse, requirementID, this.gtag);
 
       const courseCode = `${data.subject} ${data.catalogNbr}`;
       this.openConfirmationModal(`Added ${courseCode} to ${this.type} ${this.year}`);

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -181,7 +181,7 @@ export default Vue.extend({
   props: {
     semesterIndex: { type: Number, required: true },
     type: {
-      type: String as PropType<'Fall' | 'Spring' | 'Winter' | 'Summer'>,
+      type: String as PropType<FirestoreSemesterType>,
       required: true,
     },
     year: { type: Number, required: true },
@@ -320,10 +320,12 @@ export default Vue.extend({
     addCourse(data: CornellCourseRosterCourse, requirementID: string) {
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourse(data);
       addCourseToSemester(this.type, this.year, newCourse);
-      chooseSelectableRequirementOption({
-        ...store.state.selectableRequirementChoices,
-        [newCourse.uniqueID]: requirementID,
-      });
+      if (requirementID) {
+        chooseSelectableRequirementOption({
+          ...store.state.selectableRequirementChoices,
+          [newCourse.uniqueID]: requirementID,
+        });
+      }
 
       const courseCode = `${data.subject} ${data.catalogNbr}`;
       this.openConfirmationModal(`Added ${courseCode} to ${this.type} ${this.year}`);
@@ -393,7 +395,7 @@ export default Vue.extend({
     openEditSemesterModal() {
       this.isEditSemesterOpen = true;
     },
-    editSemester(seasonInput: 'Fall' | 'Spring' | 'Winter' | 'Summer', yearInput: number) {
+    editSemester(seasonInput: FirestoreSemesterType, yearInput: number) {
       editSemester(
         this.year,
         this.type,

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -318,13 +318,13 @@ export default Vue.extend({
     },
     addCourse(data: CornellCourseRosterCourse, requirementID: string) {
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourse(data);
-      addCourseToSemester(this.type, this.year, newCourse, requirementID, this.gtag);
+      addCourseToSemester(this.type, this.year, newCourse, requirementID, this.$gtag);
 
       const courseCode = `${data.subject} ${data.catalogNbr}`;
       this.openConfirmationModal(`Added ${courseCode} to ${this.type} ${this.year}`);
     },
     deleteCourse(courseCode: string, uniqueID: number) {
-      deleteCourseFromSemester(this.type, this.year, uniqueID, this.gtag);
+      deleteCourseFromSemester(this.type, this.year, uniqueID, this.$gtag);
       // Update requirements menu
       this.openConfirmationModal(`Removed ${courseCode} from ${this.type} ${this.year}`);
     },

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -133,7 +133,6 @@ import {
   deleteCourseFromSemester,
 } from '@/global-firestore-data';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
-import store from '@/store';
 
 const pageTour = introJs();
 pageTour.setOption('exitOnEsc', 'false');

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -65,7 +65,6 @@
           @new-semester="openSemesterModal"
           @delete-semester="deleteSemester"
           @open-caution-modal="openCautionModal"
-          @add-course-to-semester="addNewCourse"
         />
       </div>
       <div v-if="!compact" class="semesterView-empty" aria-hidden="true"></div>
@@ -98,7 +97,7 @@ import NewSemesterModal from '@/components/Modals/NewSemesterModal.vue';
 
 import store from '@/store';
 import { GTagEvent } from '@/gtag';
-import { addSemester, deleteSemester, addCourseToSemester } from '@/global-firestore-data';
+import { addSemester, deleteSemester } from '@/global-firestore-data';
 import { closeBottomBar } from '@/components/BottomBar/BottomBarState';
 
 export default Vue.extend({
@@ -173,11 +172,8 @@ export default Vue.extend({
     closeSemesterModal() {
       this.isSemesterModalOpen = false;
     },
-    addNewCourse(season: FirestoreSemesterType, year: number, course: FirestoreSemesterCourse) {
-      addCourseToSemester(season, year, course);
-    },
     addSemester(type: FirestoreSemesterType, year: number) {
-      addSemester(type, year);
+      addSemester(type, year, this.gtag);
       this.openSemesterConfirmationModal(type, year, true);
     },
     deleteSemester(type: FirestoreSemesterType, year: number) {

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -177,7 +177,7 @@ export default Vue.extend({
       this.openSemesterConfirmationModal(type, year, true);
     },
     deleteSemester(type: FirestoreSemesterType, year: number) {
-      deleteSemester(type, year);
+      deleteSemester(type, year, this.gtag);
       this.openSemesterConfirmationModal(type, year, false);
     },
     courseOnClick(course: FirestoreSemesterCourse) {

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -173,11 +173,11 @@ export default Vue.extend({
       this.isSemesterModalOpen = false;
     },
     addSemester(type: FirestoreSemesterType, year: number) {
-      addSemester(type, year, this.gtag);
+      addSemester(type, year, this.$gtag);
       this.openSemesterConfirmationModal(type, year, true);
     },
     deleteSemester(type: FirestoreSemesterType, year: number) {
-      deleteSemester(type, year, this.gtag);
+      deleteSemester(type, year, this.$gtag);
       this.openSemesterConfirmationModal(type, year, false);
     },
     courseOnClick(course: FirestoreSemesterCourse) {

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -21,7 +21,6 @@
           v-if="loaded && (!isTablet || (isOpeningRequirements && isTablet))"
           :startTour="startTour"
           @showTourEndWindow="showTourEnd"
-          @deleteCourseFromSemesters="deleteCourseFromSemesters"
         />
       </div>
       <semester-view
@@ -78,7 +77,6 @@ import TourWindow from '@/components/Modals/TourWindow.vue';
 import surfing from '@/assets/images/surfing.svg';
 
 import store, { initializeFirestoreListeners } from '@/store';
-// import { deleteCourseFromSemesters } from '@/global-firestore-data';
 import { immutableBottomBarState } from '@/components/BottomBar/BottomBarState';
 
 const tour = introJs();
@@ -198,17 +196,6 @@ export default Vue.extend({
     editProfile() {
       this.isOnboarding = true;
       this.isEditingProfile = true;
-    },
-
-    deleteCourseFromSemesters(uniqueID: number) {
-      editSemesters(oldSemesters =>
-        oldSemesters.map(semester => {
-          const coursesWithoutDeleted = semester.courses.filter(
-            course => course.uniqueID !== uniqueID
-          );
-          return { ...semester, courses: coursesWithoutDeleted };
-        })
-      );
     },
   },
 });

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -78,7 +78,7 @@ import TourWindow from '@/components/Modals/TourWindow.vue';
 import surfing from '@/assets/images/surfing.svg';
 
 import store, { initializeFirestoreListeners } from '@/store';
-import { editSemesters } from '@/global-firestore-data';
+// import { deleteCourseFromSemesters } from '@/global-firestore-data';
 import { immutableBottomBarState } from '@/components/BottomBar/BottomBarState';
 
 const tour = introJs();

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -90,6 +90,7 @@ export const addCourseToSemester = (
   season: FirestoreSemesterType,
   year: number,
   newCourse: FirestoreSemesterCourse,
+  requirementID?: string,
   gtag?: GTag
 ): void => {
   GTagEvent(gtag, 'add-course');
@@ -107,6 +108,9 @@ export const addCourseToSemester = (
       compareFirestoreSemesters
     );
   });
+  if (requirementID) {
+    addCourseToSelectableRequirements(newCourse.uniqueID, requirementID);
+  }
 };
 
 export const deleteCourseFromSemester = (
@@ -146,6 +150,33 @@ export const deleteCourseFromSemesters = (courseUniqueID: number, gtag?: GTag): 
   deleteCourseFromSelectableRequirements(courseUniqueID);
 };
 
+export const chooseToggleableRequirementOption = (
+  toggleableRequirementChoices: AppToggleableRequirementChoices
+): void => {
+  toggleableRequirementChoicesCollection
+    .doc(store.state.currentFirebaseUser.email)
+    .set(toggleableRequirementChoices);
+};
+
+const chooseSelectableRequirementOption = (
+  selectableRequirementChoices: AppSelectableRequirementChoices
+): void => {
+  selectableRequirementChoicesCollection
+    .doc(store.state.currentFirebaseUser.email)
+    .set(selectableRequirementChoices);
+};
+
+export const addCourseToSelectableRequirements = (
+  courseUniqueID: number,
+  requirementID: string
+): void => {
+  if (!requirementID) return;
+  chooseSelectableRequirementOption({
+    ...store.state.selectableRequirementChoices,
+    [courseUniqueID]: requirementID,
+  });
+};
+
 export const deleteCourseFromSelectableRequirements = (courseUniqueID: number): void => {
   chooseSelectableRequirementOption(
     Object.assign(
@@ -155,22 +186,6 @@ export const deleteCourseFromSelectableRequirements = (courseUniqueID: number): 
         .map(([k, v]) => ({ [k]: v }))
     )
   );
-};
-
-export const chooseToggleableRequirementOption = (
-  toggleableRequirementChoices: AppToggleableRequirementChoices
-): void => {
-  toggleableRequirementChoicesCollection
-    .doc(store.state.currentFirebaseUser.email)
-    .set(toggleableRequirementChoices);
-};
-
-export const chooseSelectableRequirementOption = (
-  selectableRequirementChoices: AppSelectableRequirementChoices
-): void => {
-  selectableRequirementChoicesCollection
-    .doc(store.state.currentFirebaseUser.email)
-    .set(selectableRequirementChoices);
 };
 
 /** @returns a tuple [color of the subject, whether new colors are added] */

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -37,7 +37,7 @@ export const compareFirestoreSemesters = (a: FirestoreSemester, b: FirestoreSeme
   return -1;
 };
 
-export const editSemesters = (
+const editSemesters = (
   updater: (oldSemesters: readonly FirestoreSemester[]) => readonly FirestoreSemester[]
 ): void => {
   const newSemesters = updater(store.state.semesters);
@@ -131,6 +131,18 @@ export const deleteCourseFromSemester = (
     if (semesterFound) return newSemestersWithoutCourse;
     return oldSemesters;
   });
+  deleteCourseFromSelectableRequirements(courseUniqueID);
+};
+
+export const deleteCourseFromSelectableRequirements = (courseUniqueID: number): void => {
+  chooseSelectableRequirementOption(
+    Object.assign(
+      {},
+      ...Object.entries(store.state.selectableRequirementChoices)
+        .filter(([k, _]) => parseInt(k, 10) !== courseUniqueID)
+        .map(([k, v]) => ({ [k]: v }))
+    )
+  );
 };
 
 export const chooseToggleableRequirementOption = (

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -81,8 +81,20 @@ export const addSemester = (
 
 export const deleteSemester = (type: FirestoreSemesterType, year: number, gtag?: GTag): void => {
   GTagEvent(gtag, 'delete-semester');
+  const semester = store.state.semesters.find(sem => sem.type === type && sem.year === year);
+  if (semester) {
+    const courseUniqueIds = new Set(semester.courses.map(course => course.uniqueID));
+    chooseSelectableRequirementOption(
+      Object.assign(
+        {},
+        ...Object.entries(store.state.selectableRequirementChoices)
+          .filter(([k]) => !courseUniqueIds.has(parseInt(k, 10)))
+          .map(([k, v]) => ({ [k]: v }))
+      )
+    );
+  }
   editSemesters(oldSemesters =>
-    oldSemesters.filter(semester => semester.type !== type || semester.year !== year)
+    oldSemesters.filter(sem => sem.type !== type || sem.year !== year)
   );
 };
 

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -183,7 +183,7 @@ export const deleteCourseFromSelectableRequirements = (courseUniqueID: number): 
     Object.assign(
       {},
       ...Object.entries(store.state.selectableRequirementChoices)
-        .filter(([k, _]) => parseInt(k, 10) !== courseUniqueID)
+        .filter(([k]) => parseInt(k, 10) !== courseUniqueID)
         .map(([k, v]) => ({ [k]: v }))
     )
   );

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -133,10 +133,7 @@ export const deleteCourseFromSemester = (
   });
   deleteCourseFromSelectableRequirements(courseUniqueID);
 };
-export const deleteCourseFromSemesters = (
-  courseUniqueID: number,
-  gtag?: GTag
-): void => {
+export const deleteCourseFromSemesters = (courseUniqueID: number, gtag?: GTag): void => {
   GTagEvent(gtag, 'delete-course');
   editSemesters(oldSemesters =>
     oldSemesters.map(semester => {

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -133,6 +133,21 @@ export const deleteCourseFromSemester = (
   });
   deleteCourseFromSelectableRequirements(courseUniqueID);
 };
+export const deleteCourseFromSemesters = (
+  courseUniqueID: number,
+  gtag?: GTag
+): void => {
+  GTagEvent(gtag, 'delete-course');
+  editSemesters(oldSemesters =>
+    oldSemesters.map(semester => {
+      const coursesWithoutDeleted = semester.courses.filter(
+        course => course.uniqueID !== courseUniqueID
+      );
+      return { ...semester, courses: coursesWithoutDeleted };
+    })
+  );
+  deleteCourseFromSelectableRequirements(courseUniqueID);
+};
 
 export const deleteCourseFromSelectableRequirements = (courseUniqueID: number): void => {
   chooseSelectableRequirementOption(

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -137,6 +137,7 @@ export const deleteCourseFromSemester = (
   });
   deleteCourseFromSelectableRequirements(courseUniqueID);
 };
+
 export const deleteCourseFromSemesters = (courseUniqueID: number, gtag?: GTag): void => {
   GTagEvent(gtag, 'delete-course');
   editSemesters(oldSemesters =>

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -93,9 +93,7 @@ export const deleteSemester = (type: FirestoreSemesterType, year: number, gtag?:
       )
     );
   }
-  editSemesters(oldSemesters =>
-    oldSemesters.filter(sem => sem.type !== type || sem.year !== year)
-  );
+  editSemesters(oldSemesters => oldSemesters.filter(sem => sem.type !== type || sem.year !== year));
 };
 
 export const addCourseToSemester = (

--- a/src/store.ts
+++ b/src/store.ts
@@ -180,7 +180,8 @@ const autoRecomputeDerivedData = (): (() => void) =>
         .forEach(([courseUniqueId, reqId]) => {
           const course: FirestoreSemesterCourse =
             state.derivedCoursesData.courseMap[parseInt(courseUniqueId, 10)];
-          if (course) requirementToCoursesMap[reqId] = [...(requirementToCoursesMap[reqId] || []), course];
+          if (course)
+            requirementToCoursesMap[reqId] = [...(requirementToCoursesMap[reqId] || []), course];
         });
       const derivedSelectableRequirementData: DerivedSelectableRequirementData = {
         requirementToCoursesMap,

--- a/src/store.ts
+++ b/src/store.ts
@@ -25,10 +25,11 @@ type DerivedCoursesData = {
 /**
  * Some course data that can be derived from selectable requirement choices, but added to the global store
  * for efficiency and ease of access.
+ * This should be used for self-check requirements and are not used in the requirement graph.
  */
 type DerivedSelectableRequirementData = {
   // Mapping from requirement ID to the user-selected courses that fulfill the requirement.
-  readonly requirementToCoursesMap: Readonly<Record<string, FirestoreSemesterCourse[]>>;
+  readonly requirementToCoursesMap: Readonly<Record<string, readonly FirestoreSemesterCourse[]>>;
 };
 
 export type VuexStoreState = {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request finishes the self-check implementation ([notion](https://www.notion.so/courseplan/Save-User-Choice-for-Self-Check-and-Add-Modal-f99924771ce643d0a6299a89675f56fd)) and cleans up some of the components / semester-related firestore code.

Functionality:
- [x] Save user choice in selectable requirements when adding existing course and when adding new course through the add modal
- [x] When deleting a course, also delete it from selectableRequirementChoices
- [x] Properly read from global data store to generate list of CompletedSubReqCourses (this is implemented with a derived function)
- [x] Remove already-selected courses from self-check dropdown

Behind-the-scenes:
- [x] Refactor deleteCourseFromSemesters to be a global-firestore-data function
- [x] Break down chooseSelectableRequirementOption into friendlier functions that modify selectableRequirementChoices
- [x] Interdepend add/delete course functions with add to / delete from selectableRequirements to reduce code repetition

Code quality and bug fixes:
- [x] Fix small issues:
  - CURLink is no longer broken
  - "CS1110" placeholder changed to "CS 1110"
- [x] Get rid of unnecessary emit chains:
  - deleteCourseFromSemesters
  - addCourse (in self-check)
- [x] Add missing gtags (that I missed in #342)

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
This PR touches almost all of the semester functions in global-firestore-data; along with testing that the self-check add/delete functionality persists, please make sure the semester/course add/delete functionality still works as intended.

### Notes <!-- Optional -->
- Instead of writing complicated code for `store.state.selectableRequirementChoices`, you can directly reference `store.state.derivedSelectableRequirementData.requirementToCoursesMap` to get the user's selected courses for a given requirement id.
- After this PR is merged with master, I will delete everyone's data in the `user-selectable-requirement-choices` firestore collection.