### PR TITLE
Created a reset modal for subreq

### DIFF
--- a/src/components/Modals/NewSemesterModal.vue
+++ b/src/components/Modals/NewSemesterModal.vue
@@ -63,4 +63,13 @@ export default Vue.extend({
 .content-semester {
   width: 15.5rem;
 }
+
+.modal {
+  &--block {
+    display: block;
+  }
+  &--flex {
+    display: flex;
+  }
+}
 </style>

--- a/src/components/Modals/ResetConfirmationModal.vue
+++ b/src/components/Modals/ResetConfirmationModal.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="reset-modal" :class="{ 'modal--block': value }">
+    <flexible-modal
+      title="Reset Requirement"
+      :class="[{ 'modal--block': value }, 'modal-width']"
+      content-class="content-confirmation"
+      left-button-text="No"
+      right-button-text="Yes"
+      @left-button-clicked="closeClicked"
+      @right-button-clicked="resetClicked"
+      @modal-closed="closeCurrentModal"
+      :rightButtonIsDisabled="false"
+    >
+      <div v-if="isTestReq" class="text-width">
+        Are you sure you want to reset the "{{ reqName }}" requirement? This will delete the
+        selected course from your schedule, allowing you to add a different course to satisfy this
+        requirement.
+      </div>
+      <div v-else class="text-width">
+        Are you sure you want to reset "{{ reqName }}" for this requirement? This will delete the
+        selected transfer credit from your schedule, allowing you to add a different course to
+        satisfy this requirement.
+        <br />
+        Transfer credits can be re-added in your Profile.
+      </div>
+    </flexible-modal>
+  </div>
+</template>
+<script>
+import FlexibleModal from './FlexibleModal.vue';
+
+export default {
+  components: { FlexibleModal },
+  props: {
+    reqName: { type: String, required: true },
+    isTestReq: { type: Boolean, required: true },
+    value: { type: Boolean, required: true },
+  },
+  methods: {
+    closeCurrentModal() {
+      this.$emit('input', false);
+    },
+    resetClicked() {
+      this.closeCurrentModal();
+      this.$emit('close-reset-modal', true);
+    },
+    closeClicked() {
+      this.closeCurrentModal();
+      this.$emit('close-reset-modal', false);
+    },
+  },
+};
+</script>
+<style scoped lang="scss">
+.content-confirmation {
+  width: 15.5rem;
+}
+.reset-modal {
+  display: none; /* Hidden by default */
+  position: fixed; /* Stay in place */
+  z-index: 1; /* Sit on top */
+  left: 0;
+  top: 0;
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+  overflow: auto; /* Enable scroll if needed */
+  background-color: rgb(0, 0, 0); /* Fallback color */
+  background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
+}
+
+.modal-width {
+  transform: translateX(calc(50vw - 50%));
+  width: 30em;
+}
+
+.text-width {
+  width: 25em;
+}
+
+.modal {
+  &--block {
+    display: block;
+  }
+  &--flex {
+    display: flex;
+  }
+}
+</style>

--- a/src/components/Modals/ResetConfirmationModal.vue
+++ b/src/components/Modals/ResetConfirmationModal.vue
@@ -27,8 +27,8 @@
   </div>
 </template>
 <script lang="ts">
-import FlexibleModal from './FlexibleModal.vue';
 import Vue from 'vue';
+import FlexibleModal from './FlexibleModal.vue';
 
 export default Vue.extend({
   components: { FlexibleModal },

--- a/src/components/Modals/ResetConfirmationModal.vue
+++ b/src/components/Modals/ResetConfirmationModal.vue
@@ -26,10 +26,11 @@
     </flexible-modal>
   </div>
 </template>
-<script>
+<script lang="ts">
 import FlexibleModal from './FlexibleModal.vue';
+import Vue from 'vue';
 
-export default {
+export default Vue.extend({
   components: { FlexibleModal },
   props: {
     reqName: { type: String, required: true },
@@ -37,19 +38,19 @@ export default {
     value: { type: Boolean, required: true },
   },
   methods: {
-    closeCurrentModal() {
+    closeCurrentModal(): void {
       this.$emit('input', false);
     },
-    resetClicked() {
+    resetClicked(): void {
       this.closeCurrentModal();
       this.$emit('close-reset-modal', true);
     },
-    closeClicked() {
+    closeClicked(): void {
       this.closeCurrentModal();
       this.$emit('close-reset-modal', false);
     },
   },
-};
+});
 </script>
 <style scoped lang="scss">
 .content-confirmation {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="completedsubreqcourse">
+    <reset-confirmation-modal
+      :isTestReq="isTransferCredit"
+      :reqName="courseTaken.code"
+      v-model="resetConfirmVisible"
+      @close-reset-modal="onResetConfirmClosed"
+    />
     <div class="completed-reqCourses-course-wrapper">
       <div class="separator"></div>
       <div class="completed-reqCourses-course-heading-wrapper">
@@ -33,17 +39,21 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import ReqCourse from '@/components/Requirements/ReqCourse.vue';
+import ResetConfirmationModal from '@/components/Modals/ResetConfirmationModal.vue';
 import store from '@/store';
 import getCurrentSeason, { getCurrentYear } from '@/utilities';
 
 const transferCreditColor = 'DA4A4A'; // Arbitrary color for transfer credit
 
 export default Vue.extend({
-  components: { ReqCourse },
+  components: { ReqCourse, ResetConfirmationModal },
   props: {
     subReqCourseId: { type: Number, required: true },
     courseTaken: { type: Object as PropType<CourseTaken>, required: true },
   },
+  data: () => ({
+    resetConfirmVisible: false,
+  }),
   computed: {
     semesters(): readonly FirestoreSemester[] {
       return store.state.semesters;
@@ -73,7 +83,10 @@ export default Vue.extend({
   },
   methods: {
     onReset() {
-      this.$emit('deleteCourseFromSemesters', this.courseTaken.uniqueId);
+      this.resetConfirmVisible = true;
+    },
+    onResetConfirmClosed(isReset: boolean) {
+      if (isReset) this.$emit('deleteCourseFromSemesters', this.courseTaken.uniqueId);
     },
   },
 });


### PR DESCRIPTION
### Summary

This pull request creates a confirmation modal when a user attempts to reset a sub-requirement.

- [x] Implemented modal for confirmation of main/transfer credits
- [x] Added modal to reset action

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] I could not for the life of me figure out how to avoid the "transform" in the style after traveling up and down component trees from the other modals
- [ ] Need the ability to have a unique id for transfer credit or else deleting them will require many changes across 5 functions that may have deeply nested event handlers (possible merge conflicts)
- [ ] Possible media query for mobile devices to change the size of the modal for mobile devices

Desktop:
![image](https://user-images.githubusercontent.com/6832564/110274303-805aeb80-7f9c-11eb-9c14-38643b5ead81.png)

Phone:
![image](https://user-images.githubusercontent.com/6832564/110274331-92d52500-7f9c-11eb-96ff-2ff565c6bc08.png)


### Test Plan 

Keep testing if the reset functionality works on everything (maybe except transfer credits for now)


### Notes

The v-model modal functionality might be useful in the future.