### PR TITLE
Change bottombar to fit the new mobile responsive design

### DIFF
--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -1,16 +1,18 @@
 <template>
   <div class="bottombar" v-if="hasBottomBarCourses">
-    <div class="bottombar-tabviewTitleWrapper">
-      <div class="bottombar-tabview" :class="{ expandedTabView: isExpanded }">
-        <bottom-bar-tab-view :maxBottomBarTabs="maxBottomBarTabs" />
-      </div>
-      <div class="bottombar-title" @click="toggleBottomBar()">
-        <bottom-bar-title
-          :color="focusedBottomBarCourse.color"
-          :name="focusedBottomBarCourse.name"
-          :isExpanded="isExpanded"
-        />
-      </div>
+    <div class="bottombar-tabview" :class="{ expandedTabView: isExpanded }">
+      <bottom-bar-tab-view :maxBottomBarTabs="maxBottomBarTabs" />
+    </div>
+    <div
+      class="bottombar-title"
+      :class="{ expandedBottomBarTitle: isExpanded }"
+      @click="toggleBottomBar()"
+    >
+      <bottom-bar-title
+        :color="focusedBottomBarCourse.color"
+        :name="focusedBottomBarCourse.name"
+        :isExpanded="isExpanded"
+      />
     </div>
     <div v-if="isExpanded" class="bottombar-course">
       <bottom-bar-course :courseObj="focusedBottomBarCourse" />
@@ -65,32 +67,68 @@ export default Vue.extend({
     left: 29.5rem;
     width: calc(100vw - 29.5rem);
   }
+
+  &-title {
+    position: fixed;
+    bottom: 0;
+    left: 29.5rem;
+    height: 2.5rem;
+    width: calc(100vw - 29.5rem);
+  }
+
+  &-course {
+    position: fixed;
+    bottom: 0;
+    left: 29.5rem;
+    width: 100%;
+    background-color: $white;
+    width: calc(100vw - 29.5rem);
+    height: 16.5rem;
+  }
 }
+
 .expandedTabView {
   position: fixed;
-  bottom: 18.75rem;
+  bottom: 19rem;
+}
+.expandedBottomBarTitle {
+  position: fixed;
+  bottom: 16.5rem;
 }
 
 @media only screen and (max-width: $large-breakpoint) {
   .bottombar {
-    &-tabview {
+    &-tabview,
+    &-title,
+    &-course {
       left: 25.5rem;
       width: calc(100vw - 25.5rem);
     }
   }
 }
+
 @media only screen and (max-width: $medium-breakpoint) {
   .bottombar {
-    &-tabview {
-      left: 0rem;
-      width: 100%;
+    &-tabview,
+    &-title,
+    &-course {
+      left: 0;
+      width: 100vw;
+    }
+
+    &-course {
+      height: calc(100vh - 14rem);
     }
   }
-}
 
-@media only screen and (max-width: $small-breakpoint) {
   .expandedTabView {
-    bottom: 11.75rem;
+    position: fixed;
+    bottom: calc(100vh - 11.5rem);
+  }
+
+  .expandedBottomBarTitle {
+    position: fixed;
+    bottom: calc(100vh - 14rem);
   }
 }
 </style>

--- a/src/components/BottomBar/BottomBarCourse.vue
+++ b/src/components/BottomBar/BottomBarCourse.vue
@@ -1,18 +1,10 @@
 <template>
-  <div class="bottombarcourse">
-    <div class="bottombarcourse-wrapper">
-      <div class="bottombarcourse-bar-info-overflow" v-if="!isSmallerWidth">
-        <bottom-bar-course-info :courseObj="courseObj" />
-      </div>
-      <div class="bottombarcourse-bar-details-overflow" v-if="!isSmallerWidth">
-        <bottom-bar-course-review :courseObj="courseObj" />
-      </div>
-      <div class="bottombarcourse-bar-details-noOverflow" v-if="isSmallerWidth">
-        <bottom-bar-course-review :courseObj="courseObj" />
-      </div>
-      <div class="bottombarcourse-bar-info-noOverflow" v-if="isSmallerWidth">
-        <bottom-bar-course-info :courseObj="courseObj" />
-      </div>
+  <div class="bottombarcourse-wrapper">
+    <div class="bottombarcourse-bar-info">
+      <bottom-bar-course-info :courseObj="courseObj" />
+    </div>
+    <div class="bottombarcourse-bar-details">
+      <bottom-bar-course-review :courseObj="courseObj" />
     </div>
   </div>
 </template>
@@ -24,25 +16,8 @@ import BottomBarCourseReview from '@/components/BottomBar/BottomBarCourseReview.
 
 export default Vue.extend({
   components: { BottomBarCourseInfo, BottomBarCourseReview },
-  data() {
-    return {
-      isSmallerWidth: window.innerWidth <= 976,
-    };
-  },
   props: {
     courseObj: { type: Object as PropType<AppBottomBarCourse>, required: true },
-  },
-  created() {
-    window.addEventListener('resize', this.isSmallerWidthEventHandler);
-  },
-  destroyed() {
-    window.removeEventListener('resize', this.isSmallerWidthEventHandler);
-  },
-
-  methods: {
-    isSmallerWidthEventHandler() {
-      this.isSmallerWidth = window.innerWidth <= 976;
-    },
   },
 });
 </script>
@@ -51,98 +26,47 @@ export default Vue.extend({
 @import '@/assets/scss/_variables.scss';
 
 .bottombarcourse {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  background-color: $white;
-
-  left: 29.5rem;
-  width: calc(100vw - 29.5rem);
-
-  &-tabs {
-    height: 0px;
+  &-wrapper {
+    height: 100%;
+    overflow: scroll;
   }
 
   &-bar {
-    width: 100%;
-
     &-info {
-      &-overflow {
-        float: left;
-        height: 16.25rem;
-        width: 40%;
-        background: $offWhite;
-        overflow: auto;
-      }
+      float: left;
+      width: 40%;
+      height: 100%;
+      background: $offWhite;
+      overflow: scroll;
     }
 
     &-details {
-      &-overflow {
-        float: right;
-        height: 16.25rem;
-        width: 60%;
-        background: $white;
-        overflow: auto;
-      }
+      float: right;
+      width: 60%;
+      height: 100%;
+      background: $white;
+      overflow: scroll;
     }
   }
 }
 
 @media only screen and (max-width: $large-breakpoint) {
   .bottombarcourse {
-    left: 25.5rem;
-    width: calc(100vw - 25.5rem);
-
     &-wrapper {
       display: flex;
       flex-direction: column;
-      height: 16.25rem;
-      overflow: auto;
-      padding: 0.5rem;
     }
 
     &-bar {
-      &-info {
-        &-noOverflow {
-          width: 100%;
-          height: auto;
-          float: none;
-          overflow: none;
-          display: flex;
-          background: $offWhite;
-          flex-shrink: 0;
-          .info {
-            width: 100%;
-          }
-        }
-      }
+      &-info,
       &-details {
-        &-noOverflow {
-          width: 100%;
-          height: auto;
-          float: none;
-          display: flex;
-          background: $white;
-          overflow: none;
-          flex-shrink: 0;
-        }
+        width: 100%;
+        height: auto;
+        float: none;
+        display: flex;
+        overflow: none;
+        flex-shrink: 0;
       }
-    }
-  }
-}
-
-@media only screen and (max-width: $medium-breakpoint) {
-  .bottombarcourse {
-    left: 0rem;
-    width: 100%;
-  }
-}
-
-@media only screen and (max-width: $small-breakpoint) {
-  .bottombarcourse {
-    &-wrapper {
-      height: 9.25rem;
     }
   }
 }

--- a/src/components/BottomBar/BottomBarCourseInfo.vue
+++ b/src/components/BottomBar/BottomBarCourseInfo.vue
@@ -111,10 +111,10 @@ export default Vue.extend({
 @import '@/assets/scss/_variables.scss';
 
 .info {
-  margin: 20px;
+  width: 100%;
+  padding: 20px;
   display: flex;
   flex-direction: column;
-  height: 90%;
   justify-content: space-between;
   margin-bottom: 0rem;
 

--- a/src/components/BottomBar/BottomBarCourseReview.vue
+++ b/src/components/BottomBar/BottomBarCourseReview.vue
@@ -134,7 +134,7 @@ export default Vue.extend({
 @import '@/assets/scss/_variables.scss';
 
 .details {
-  margin: 20px;
+  padding: 20px;
 
   &-head {
     margin-top: 10px;

--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -101,8 +101,7 @@ export default Vue.extend({
 
 @media only screen and (max-width: $small-breakpoint) {
   .bottombartab {
-    width: 100%;
-    height: 100%;
+    width: 9rem;
 
     &-arrow {
       margin-top: auto;

--- a/src/components/BottomBar/BottomBarTitle.vue
+++ b/src/components/BottomBar/BottomBarTitle.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    class="bottombartitle"
-    :style="{ background: `#${color}` }"
-    :class="{ expandedBottomBarTitle: isExpanded }"
-  >
+  <div class="bottombartitle" :style="{ background: `#${color}` }">
     <div class="bottombar-square-title">{{ name }}</div>
     <img
       v-if="!isExpanded"
@@ -36,20 +32,12 @@ export default Vue.extend({
 @import '@/assets/scss/_variables.scss';
 .bottombartitle {
   padding-left: 0.5rem;
-  height: 2.5rem;
   line-height: 40px;
   background-color: #25a2aa;
   color: #fff;
   font-size: 16px;
   cursor: pointer;
   filter: brightness(100%);
-
-  position: fixed;
-  bottom: 0rem;
-  width: 100%;
-
-  left: 29.5rem;
-  width: calc(100vw - 29.5rem);
 
   &:hover {
     filter: brightness(95%);
@@ -67,30 +55,5 @@ export default Vue.extend({
   position: absolute;
   right: 2%;
   top: 40%;
-}
-
-.expandedBottomBarTitle {
-  position: fixed;
-  bottom: 16.25rem;
-}
-
-@media only screen and (max-width: $large-breakpoint) {
-  .bottombartitle {
-    left: 25.5rem;
-    width: calc(100vw - 25.5rem);
-  }
-}
-
-@media only screen and (max-width: $medium-breakpoint) {
-  .bottombartitle {
-    left: 0rem;
-    width: 100%;
-  }
-}
-
-@media only screen and (max-width: $small-breakpoint) {
-  .expandedBottomBarTitle {
-    bottom: 9.25rem;
-  }
 }
 </style>

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -53,13 +53,11 @@
       @hide="showTourEndWindow = false"
       v-if="showTourEndWindow"
     />
-    <div>
-      <bottom-bar
-        v-if="(!isOpeningRequirements && isTablet) || !isTablet"
-        :isExpanded="bottomBarIsExpanded"
-        :maxBottomBarTabs="maxBottomBarTabs"
-      />
-    </div>
+    <bottom-bar
+      v-if="(!isOpeningRequirements && isTablet) || !isTablet"
+      :isExpanded="bottomBarIsExpanded"
+      :maxBottomBarTabs="maxBottomBarTabs"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
### Summary <!-- Required -->

This PR implements the new design for the bottombar with the new responsive design. There are two main UI change in the new mobile design:

1. bottom bar now can span almost full screen on mobile when expanded
2. Course information now appears before course review and detail.

To make the css more management, I also made some refactoring that moves all the responsive height and width into `BottomBar.vue`, so it becomes much easier to see different width and heights config in one place.

### Test Plan <!-- Required -->

<img width="1530" alt="Screen Shot 2021-03-08 at 17 18 51" src="https://user-images.githubusercontent.com/4290500/110389403-77b4f480-8032-11eb-8545-99681e97dd08.png">
<img width="1378" alt="Screen Shot 2021-03-08 at 17 18 54" src="https://user-images.githubusercontent.com/4290500/110389404-784d8b00-8032-11eb-89a1-5f00d2fec4dc.png">
<img width="1318" alt="Screen Shot 2021-03-08 at 17 19 27" src="https://user-images.githubusercontent.com/4290500/110389408-78e62180-8032-11eb-8a40-eb7187052e89.png">
<img width="1879" alt="Screen Shot 2021-03-08 at 17 19 31" src="https://user-images.githubusercontent.com/4290500/110389410-78e62180-8032-11eb-8d7c-38947ba7f2af.png">

When the screen is small, should we only have one tab that's not in see more:

<img width="376" alt="Screen Shot 2021-03-08 at 17 19 13" src="https://user-images.githubusercontent.com/4290500/110389405-784d8b00-8032-11eb-950a-af7f3150468e.png">
<img width="377" alt="Screen Shot 2021-03-08 at 17 19 19" src="https://user-images.githubusercontent.com/4290500/110389407-784d8b00-8032-11eb-8183-5cdfeec008d2.png">

Reference design:
<img width="201" alt="Screen Shot 2021-03-08 at 17 21 16" src="https://user-images.githubusercontent.com/4290500/110389575-b8147280-8032-11eb-94e3-23bd9c5dd3f0.png">

In the design the font size of the tab is 14px while the rest is 16px, that's how the design can fit in two tabs. However, I'm not sure whether we should reduce the font size of the tab just to fit in more tabs. Loop in @yuxuanchenn.