### PR TITLE
Fix subrequirement slot with minCount > 1

### DIFF
--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -97,7 +97,7 @@
         "
         class="subreqcourse-wrapper"
       >
-        <div v-for="(subReqCourseSlot, id) in subReqCoursesSlots" :key="id">
+        <div v-for="(subReqCourseSlot, id) in requirementCoursesSlots" :key="id">
           <div v-if="subReqCourseSlot.isCompleted" class="completedsubreqcourse-wrapper">
             <completed-sub-req-course
               :subReqCourseId="id"
@@ -223,7 +223,14 @@ export default Vue.extend({
         Object.keys(this.subReq.requirement.fulfillmentOptions)[0]
       );
     },
-    subReqCoursesSlots(): SubReqCourseSlot[] {
+    /**
+     * A list of "slots" for a requirement's fulfillment courses, completed or incomplete.
+     * Note that it is different from the concept of slot in `perSlotMinCount`.
+     * In `perSlotMinCount`, each slot can hold multiple courses, but here, each slot can only hold
+     * one course at a time. If `perSlotMinCount`'s slot i has minCount x, then x corresponding slots
+     * will be generated here.
+     */
+    requirementCoursesSlots(): SubReqCourseSlot[] {
       const subReqSpec = getMatchedRequirementFulfillmentSpecification(this.subReq.requirement, {
         [this.subReq.requirement.id]: this.toggleableRequirementChoice,
       });
@@ -284,7 +291,7 @@ export default Vue.extend({
     onShowAllCourses(subReqIndex: number) {
       this.$emit('onShowAllCourses', {
         requirementName: this.subReq.requirement.name,
-        subReqCoursesArray: this.subReqCoursesSlots[subReqIndex].courses,
+        subReqCoursesArray: this.requirementCoursesSlots[subReqIndex].courses,
       });
     },
     toggleDescription() {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -233,28 +233,34 @@ export default Vue.extend({
       const allTakenCourseIds = new Set(this.subReq.courses.flat().map(course => course.courseId));
       const slots: SubReqCourseSlot[] = [];
 
-      const coursesTaken = this.subReq.courses;
-
-      coursesTaken.forEach((subReqCourseSlot, i) => {
-        if (subReqCourseSlot.length > 0) {
-          subReqCourseSlot.forEach(subReqCourse => {
-            slots.push({ isCompleted: true, courses: [subReqCourse] });
-          });
-          // Create new IncompletedSubReqCourse slot if all credits or courses not met
-          // but only one CompletedSubReqCourse slot exists
-          if (coursesTaken.length === 1 && !this.isCompleted) {
-            slots.push({
-              isCompleted: false,
-              courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[i]),
-            });
-          }
+      if (subReqSpec.fulfilledBy === 'credits') {
+        if (this.isCompleted) {
+          slots.push({ isCompleted: true, courses: this.subReq.courses[0] });
         } else {
           slots.push({
             isCompleted: false,
-            courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[i]),
+            courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[0]),
           });
         }
-      });
+      } else {
+        this.subReq.courses.forEach((subReqCourseSlot, i) => {
+          const slotMinCount = subReqSpec.perSlotMinCount[i];
+          for (let j = 0; j < slotMinCount; j += 1) {
+            if (j < subReqCourseSlot.length) {
+              slots.push({ isCompleted: true, courses: [subReqCourseSlot[j]] });
+            } else {
+              slots.push({
+                isCompleted: false,
+                courses: generateSubReqIncompleteCourses(
+                  allTakenCourseIds,
+                  subReqEligibleCourses[i]
+                ),
+              });
+            }
+          }
+        });
+      }
+
       return slots;
     },
     subReqProgress(): string {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -234,9 +234,10 @@ export default Vue.extend({
       const slots: SubReqCourseSlot[] = [];
 
       if (subReqSpec.fulfilledBy === 'credits') {
-        if (this.isCompleted) {
-          slots.push({ isCompleted: true, courses: this.subReq.courses[0] });
-        } else {
+        this.subReq.courses[0].forEach(completedCourse =>
+          slots.push({ isCompleted: true, courses: [completedCourse] })
+        );
+        if (!this.isCompleted) {
           slots.push({
             isCompleted: false,
             courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[0]),

--- a/src/requirements/data/requirement-data-consistency.test.ts
+++ b/src/requirements/data/requirement-data-consistency.test.ts
@@ -46,4 +46,22 @@ allRequirementsWithIDs.forEach(({ id, requirement }) => {
         throw new Error();
     }
   });
+
+  it(`If ${id} is fulfilled by credits, then there is only one checker.`, () => {
+    switch (requirement.fulfilledBy) {
+      case 'self-check':
+      case 'courses':
+        return;
+      case 'credits':
+        expect(requirement.checker.length).toBe(1);
+        return;
+      case 'toggleable':
+        Object.values(requirement.fulfillmentOptions).forEach(option => {
+          if (option.counting === 'credits') expect(option.checker.length).toBe(1);
+        });
+        return;
+      default:
+        throw new Error();
+    }
+  });
 });


### PR DESCRIPTION
### Summary <!-- Required -->

Resolve [this notion item](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=d8736f944ef44d49bf02febd430ccdfc) with option 2.

Background: PBS/MQR requirement with perSlotMinCount will have 3 slots, with minCount to be 2, 1, 1. Our frontend always assumes that one slot can only contain one course. The option 1 in that notion item isn't doable now, since we would need data providing the name for each slot. Option 2 is very doable. In fact, this PR implements option 2 in a very principled way that removes a lot of existing hack.

We first deal with requirements fulfilled with credits. By observation and unit testing, we know that these requirements only has one checker and one slot. Therefore, we can easily special case that.
Requirement fulfilled by slots can be more complicated. However, now we have the perSlotMinCount, we can match the minCount with existing courses and generate variable number of completed and incomplete subrequirement.

E.g. there is a sub-requirement slot with `perSlotMinCount` 3. In the slot, we find there are two courses already taken. Then we can generate two CompletedSubReqCourse and one IncompleteSubReqCourse.

Note that this algorithm automatically deals with the case when we have one slot and multiple courses needed to fulfilled by that slot. In the past, it's handled by `subRequirementProgress: 'any-can-count'` and special case for single-slot requirements, but now it can be elegantly handled by the algorithm described above without any special case.

### Test Plan <!-- Required -->

Added test to ensure requirements fulfilled by credits only have one checker.

<img width="384" alt="Screen Shot 2021-03-14 at 20 45 32" src="https://user-images.githubusercontent.com/4290500/111090644-daacfc80-8506-11eb-9c39-6d398b48104f.png">
<img width="381" alt="Screen Shot 2021-03-14 at 20 45 50" src="https://user-images.githubusercontent.com/4290500/111090645-daacfc80-8506-11eb-950b-614559b2facf.png">
