### PR TITLE
Remove all hardcoded width in Course.vue and Semester.vue

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -9,6 +9,7 @@ $white: #fff;
 $black: #000;
 
 $navMenuGray: #f7fafc;
+$borderGray: #d8d8d8;
 $offWhite: #f8f8f8;
 $searchBoxWhite: #f1f1f1;
 $medGray: #737373;

--- a/src/components/AddCourseButton.vue
+++ b/src/components/AddCourseButton.vue
@@ -53,7 +53,7 @@ export default Vue.extend({
     display: flex;
     justify-content: center;
     align-items: center;
-    border: 2px dashed #d8d8d8;
+    border: 2px dashed $borderGray;
     color: $medGray;
     margin-left: 1.125rem;
     margin-right: 1.125rem;

--- a/src/components/AddCourseButton.vue
+++ b/src/components/AddCourseButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="semester-courseWrapper semester-addWrapper"
+    class="semester-addWrapper"
     :class="{
       'semester-addWrapper--compact': compact,
       'my-2 mx-0': shouldClearPadding,
@@ -45,32 +45,21 @@ export default Vue.extend({
 }
 
 .semester {
-  width: fit-content;
-  position: relative;
-  border-radius: 11px;
-
-  &--compact {
-    padding: 0.875rem 1.125rem;
-  }
-
-  &-courseWrapper {
-    margin: 0.5rem 0 0.5rem 0;
-  }
-
   &-addWrapper {
     margin-top: -5rem;
-    width: 21.375rem;
+    margin-bottom: 0.5rem;
     height: 4.625rem;
     border-radius: 0.5rem;
     display: flex;
     justify-content: center;
     align-items: center;
+    border: 2px dashed #d8d8d8;
+    color: $medGray;
     margin-left: 1.125rem;
     margin-right: 1.125rem;
 
     &--compact {
       margin-top: -1.2rem;
-      width: 10rem;
       height: 2rem;
     }
 
@@ -90,18 +79,6 @@ export default Vue.extend({
     &--compact {
       font-size: 14px;
       line-height: 17px;
-    }
-  }
-}
-
-@media only screen and (max-width: $medium-breakpoint) {
-  .semester {
-    &-addWrapper {
-      width: 17rem;
-      &--compact {
-        width: 10rem;
-        height: 2rem;
-      }
     }
   }
 }

--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    :class="{ 'course--min': compact, active: active, 'course--reqs': isReqCourse && !compact }"
-    class="course"
-    @click="courseOnClick()"
-  >
+  <div :class="{ 'course--min': compact, active: active }" class="course" @click="courseOnClick()">
     <div class="course-color" :style="cssVars" :class="{ 'course-color--active': active }">
       <img src="@/assets/images/dots/sixDots.svg" alt="dots" />
     </div>
@@ -16,12 +12,10 @@
           </div>
         </div>
         <div v-if="!compact" class="course-name">{{ courseObj.name }}</div>
-        <div class="course-info">
-          <span v-if="!compact" class="course-credits">{{ creditString }}</span>
-          <span v-if="!compact && semesterString" class="course-semesters">{{
-            semesterString
-          }}</span>
-          <course-caution v-if="!compact" :course="courseObj" />
+        <div v-if="!compact" class="course-info">
+          <span class="course-credits">{{ creditString }}</span>
+          <span v-if="semesterString" class="course-semesters">{{ semesterString }}</span>
+          <course-caution v-if="!isReqCourse" :course="courseObj" />
         </div>
       </div>
     </div>
@@ -29,7 +23,6 @@
       v-if="menuOpen"
       :semesterIndex="semesterIndex"
       :isCompact="compact"
-      class="course-menu"
       @delete-course="deleteCourse"
       @color-course="colorCourse"
       @edit-course-credit="editCourseCredit"
@@ -133,8 +126,10 @@ export default Vue.extend({
 // TODO: font families
 @import '@/assets/scss/_variables.scss';
 
+$colored-grabber-width: 1.25rem;
+
 .course {
-  width: 21.375rem;
+  box-sizing: border-box;
   border-radius: 0.5rem;
   display: flex;
   flex-direction: row;
@@ -155,11 +150,10 @@ export default Vue.extend({
   }
 
   &--min {
-    width: 10rem;
     height: 2.125rem;
 
     & .course-content {
-      margin: 0 0.5em;
+      padding: 0 0.5em;
     }
   }
 
@@ -168,16 +162,12 @@ export default Vue.extend({
   }
 
   &-color {
-    width: 1.25rem;
+    width: $colored-grabber-width;
     border-radius: 0.42rem 0 0 0.42rem;
     background-color: var(--bg-color);
     display: flex;
     align-items: center;
     justify-content: center;
-
-    &--active {
-      width: 1.188rem;
-    }
   }
 
   &-dotRow {
@@ -192,8 +182,8 @@ export default Vue.extend({
   }
 
   &-content {
-    flex: 1 1 auto;
-    margin: 0 1rem;
+    width: calc(100% - #{$colored-grabber-width});
+    padding: 0 1rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -219,7 +209,6 @@ export default Vue.extend({
     color: $primaryGray;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
-    width: 18rem;
 
     white-space: nowrap;
     overflow: hidden;
@@ -227,7 +216,6 @@ export default Vue.extend({
   }
 
   &-info {
-    max-width: 18rem;
     font-size: 14px;
     line-height: 17px;
     color: $lightPlaceholderGray;
@@ -244,7 +232,6 @@ export default Vue.extend({
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    max-width: 14rem;
 
     &:before {
       margin-right: 0.2rem;
@@ -258,70 +245,9 @@ export default Vue.extend({
     justify-content: space-around;
     margin: 0.5rem;
   }
-
-  &-menu {
-    position: absolute;
-    right: -3rem;
-    top: 2rem;
-    z-index: 1;
-  }
 }
 
 .active {
   border: 1px solid $yuxuanBlue;
-}
-
-@media only screen and (max-width: $medium-breakpoint) {
-  .course {
-    width: 17rem;
-    &--min {
-      width: 10rem;
-      height: 2.125rem;
-    }
-    &-color {
-      &--active {
-        width: 1.188rem;
-      }
-    }
-
-    &-name {
-      width: 14rem;
-    }
-
-    &-info {
-      max-width: 14rem;
-    }
-
-    &-menu {
-      right: -1rem;
-    }
-  }
-}
-
-@media only screen and (max-width: $large-breakpoint) {
-  .course--reqs {
-    width: 17rem;
-    .course--min {
-      width: 10rem;
-      height: 2.125rem;
-    }
-    .course-color {
-      &--active {
-        width: 1.188rem;
-      }
-    }
-
-    .course-name {
-      width: 14rem;
-    }
-
-    .course-info {
-      max-width: 14rem;
-    }
-
-    .course-menu {
-      right: -1rem;
-    }
-  }
 }
 </style>

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -167,6 +167,11 @@ export default Vue.extend({
 @import '@/assets/scss/_variables.scss';
 
 .courseMenu {
+  position: absolute;
+  right: -3rem;
+  top: 2rem;
+  z-index: 1;
+
   &-content {
     background: $white;
     border: 1px solid #acacac;
@@ -255,6 +260,8 @@ export default Vue.extend({
 
 @media only screen and (max-width: $medium-breakpoint) {
   .courseMenu {
+    right: -1rem;
+
     &-arrow {
       display: none;
     }

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -148,6 +148,7 @@ export default Vue.extend({
 .loading {
   &-courseWrapper {
     padding: 0.2rem;
+    width: 50%;
     max-width: 50%;
   }
   &-course {

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -148,7 +148,7 @@ export default Vue.extend({
 .loading {
   &-courseWrapper {
     padding: 0.2rem;
-    width: 50%;
+    width: 10.25rem;
     max-width: 50%;
   }
   &-course {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -397,7 +397,7 @@ h1.title {
 }
 
 .requirements-course {
-  width: 17rem;
+  width: 21.375rem;
 }
 
 @media only screen and (max-width: $large-breakpoint) {
@@ -406,6 +406,10 @@ h1.title {
     width: 21rem;
   }
   .see-all-pages {
+    width: 17rem;
+  }
+
+  .requirements-course {
     width: 17rem;
   }
 }

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -396,6 +396,10 @@ h1.title {
   transform: rotate(90deg);
 }
 
+.requirements-course {
+  width: 17rem;
+}
+
 @media only screen and (max-width: $large-breakpoint) {
   .requirements,
   .fixed {

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -384,7 +384,8 @@ export default Vue.extend({
 @import '@/assets/scss/_variables.scss';
 
 .semester {
-  width: fit-content;
+  width: 24rem;
+  box-sizing: border-box;
   position: relative;
   border-radius: 11px;
 
@@ -406,6 +407,7 @@ export default Vue.extend({
   }
 
   &--compact {
+    width: 16rem;
     padding: 0.875rem 1.125rem;
   }
 
@@ -486,37 +488,6 @@ export default Vue.extend({
     cursor: grabbing;
   }
 
-  &-addWrapper {
-    margin-top: -5rem;
-    width: 21.375rem;
-    height: 4.625rem;
-    border-radius: 0.5rem;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border: 2px dashed #d8d8d8;
-    color: $medGray;
-    margin-left: 1.125rem;
-    margin-right: 1.125rem;
-
-    &--compact {
-      margin-top: -1.2rem;
-      width: 10rem;
-      height: 2rem;
-    }
-  }
-
-  &-buttonText {
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 20px;
-
-    &--compact {
-      font-size: 14px;
-      line-height: 17px;
-    }
-  }
-
   .season-emoji {
     height: 18px;
     margin-top: -4px;
@@ -540,30 +511,6 @@ export default Vue.extend({
     padding-top: 5px;
     padding-left: 1.125rem;
     padding-right: 1.125rem;
-  }
-
-  //Styling for drag and drop components and movement
-  .gu-mirror {
-    position: fixed !important;
-    margin: 0 !important;
-    z-index: 9999 !important;
-    opacity: 0.8;
-    -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)';
-    filter: alpha(opacity=80);
-  }
-  .gu-hide {
-    display: none !important;
-  }
-  .gu-unselectable {
-    -webkit-user-select: none !important;
-    -moz-user-select: none !important;
-    -ms-user-select: none !important;
-    user-select: none !important;
-  }
-  .gu-transit {
-    opacity: 0.2;
-    -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=20)';
-    filter: alpha(opacity=20);
   }
 
   .semester-modal {
@@ -600,15 +547,10 @@ export default Vue.extend({
 
 @media only screen and (max-width: $medium-breakpoint) {
   .semester {
+    width: 16rem;
+
     &-menu {
       right: 0rem;
-    }
-    &-addWrapper {
-      width: 17rem;
-      &--compact {
-        width: 10rem;
-        height: 2rem;
-      }
     }
   }
 }

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -402,7 +402,7 @@ export default Vue.extend({
 
   &-content {
     padding: 0.875rem 0;
-    border: 2px solid #d8d8d8;
+    border: 2px solid $borderGray;
     border-radius: 11px;
   }
 


### PR DESCRIPTION
### Summary <!-- Required -->

Prepare for semester view mobile design. This PR removes the hardcoded width in the current css.

The hardcoded ones are mostly used to place various elements at the correct place. However, this is the incorrect way of writing css since it makes it much harder to make it responsive on mobile: you need to change all the width values instead of only a few from the top-level. I replaced the absolute child width mostly with default width, but instead try to constraint the width on the parents. i.e. pick a correct width for containers of course component instead of the course component itself. 

### Test Plan <!-- Required -->

<img width="1375" alt="Screen Shot 2021-03-18 at 19 27 58" src="https://user-images.githubusercontent.com/4290500/111710440-1524db00-8820-11eb-9969-fcfbd394065c.png">
<img width="1375" alt="Screen Shot 2021-03-18 at 19 28 01" src="https://user-images.githubusercontent.com/4290500/111710441-15bd7180-8820-11eb-919e-7561b7472886.png">
