### PR TITLE
Remove all edges when user has no requirement choice on a course

### DIFF
--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -1,10 +1,9 @@
 <template>
   <course-base-tooltip v-if="hasCourseCautions" :isInformation="false">
     <div v-if="singleWarning">
-      <div v-if="courseCautions.doubleCountingRequirementWarning">
-        This class is counted for these requirements:
-        <b>{{ doubleCountingRequirementWarning.join(', ') }}</b
-        >.
+      <div v-if="courseCautions.noMatchedRequirement">
+        This class is not matched to any requirement. Re-add this course to choose a requirement to
+        bind to.
       </div>
       <div v-if="courseCautions.typicallyOfferedWarning">
         This class is typically offered in {{ courseCautions.typicallyOfferedWarning.join(', ') }}.
@@ -12,10 +11,9 @@
       <div v-if="courseCautions.isCourseDuplicate">Duplicate</div>
     </div>
     <ul v-if="!singleWarning" class="warning-list">
-      <li class="warning-item" v-if="courseCautions.doubleCountingRequirementWarning">
-        This class is counted for these requirements:
-        <b>{{ doubleCountingRequirementWarning.join(', ') }}</b
-        >.
+      <li class="warning-item" v-if="courseCautions.noMatchedRequirement">
+        This class is not matched to any requirement. Re-add this course to choose a requirement to
+        bind to.
       </li>
       <li class="warning-item" v-if="courseCautions.typicallyOfferedWarning">
         This class is typically offered in {{ courseCautions.typicallyOfferedWarning.join(', ') }}.
@@ -31,32 +29,26 @@ import CourseBaseTooltip from '@/components/Course/CourseBaseTooltip.vue';
 import store from '@/store';
 
 type CourseCautions = {
-  readonly doubleCountingRequirementWarning: readonly string[] | undefined;
+  readonly noMatchedRequirement: boolean;
   readonly typicallyOfferedWarning: readonly string[] | undefined;
   readonly isCourseDuplicate: boolean;
 };
 
 const getCourseCautions = (course: FirestoreSemesterCourse): CourseCautions => {
   const {
-    derivedCoursesData: { duplicatedCourseCodeSet, courseToSemesterMap },
-    userRequirementsMap,
     requirementFulfillmentGraph,
-    illegallyDoubleCountedCourseUniqueIDs,
+    derivedCoursesData: { duplicatedCourseCodeSet, courseToSemesterMap },
   } = store.state;
-  let doubleCountingRequirementWarning: readonly string[] | undefined;
-  if (illegallyDoubleCountedCourseUniqueIDs.has(course.uniqueID)) {
-    doubleCountingRequirementWarning = requirementFulfillmentGraph
-      .getConnectedRequirementsFromCourse({ uniqueId: course.uniqueID })
-      .filter(id => !userRequirementsMap[id].allowCourseDoubleCounting)
-      .map(id => userRequirementsMap[id].name);
-  }
+  const noMatchedRequirement =
+    requirementFulfillmentGraph.getConnectedRequirementsFromCourse({ uniqueId: course.uniqueID })
+      .length === 0;
   const semesterOfUserCourse = courseToSemesterMap[course.uniqueID];
   const typicallyOfferedWarning =
     semesterOfUserCourse != null && !course.semesters.includes(semesterOfUserCourse.type)
       ? course.semesters
       : undefined;
   const isCourseDuplicate = duplicatedCourseCodeSet.has(course.code);
-  return { doubleCountingRequirementWarning, typicallyOfferedWarning, isCourseDuplicate };
+  return { noMatchedRequirement, typicallyOfferedWarning, isCourseDuplicate };
 };
 
 export default Vue.extend({
@@ -68,24 +60,17 @@ export default Vue.extend({
     courseCautions(): CourseCautions {
       return getCourseCautions(this.course);
     },
-    doubleCountingRequirementWarning(): readonly string[] {
-      return this.courseCautions.doubleCountingRequirementWarning || [];
-    },
     hasCourseCautions(): boolean {
       const {
-        doubleCountingRequirementWarning,
+        noMatchedRequirement,
         typicallyOfferedWarning,
         isCourseDuplicate,
       } = this.courseCautions;
-      return (
-        doubleCountingRequirementWarning != null ||
-        typicallyOfferedWarning != null ||
-        isCourseDuplicate
-      );
+      return noMatchedRequirement || typicallyOfferedWarning != null || isCourseDuplicate;
     },
     singleWarning(): boolean {
       let warningCounter = 0;
-      if (this.doubleCountingRequirementWarning.length > 0) warningCounter += 1;
+      if (this.courseCautions.noMatchedRequirement) warningCounter += 1;
       if (this.courseCautions.typicallyOfferedWarning != null) warningCounter += 1;
       if (this.courseCautions.isCourseDuplicate) warningCounter += 1;
       return warningCounter === 1;

--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -22,14 +22,17 @@ const getAllCoursesThatCanPotentiallySatisfyRequirement = (
 };
 
 it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
-    requirements,
-    userCourses: [CS3410, CS3420, MATH4710],
-    userChoiceOnFulfillmentStrategy: {},
-    userChoiceOnDoubleCountingElimination: [],
-    getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: () => false,
-  });
+  const graph = buildRequirementFulfillmentGraph(
+    {
+      requirements,
+      userCourses: [CS3410, CS3420, MATH4710],
+      userChoiceOnFulfillmentStrategy: {},
+      userChoiceOnDoubleCountingElimination: [],
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      allowDoubleCounting: () => false,
+    },
+    /* keepCoursesWithoutDoubleCountingEliminationChoice */ true
+  );
 
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410, CS3420]);
   expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
@@ -39,14 +42,17 @@ it('buildRequirementFulfillmentGraph phase 1 test 1', () => {
 // This test ensures that we are actually using userCourses and drop any courses from pre-computed
 // course list that are not in userCourses.
 it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
-    requirements,
-    userCourses: [CS3410, MATH4710],
-    userChoiceOnFulfillmentStrategy: {},
-    userChoiceOnDoubleCountingElimination: [],
-    getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: () => false,
-  });
+  const graph = buildRequirementFulfillmentGraph(
+    {
+      requirements,
+      userCourses: [CS3410, MATH4710],
+      userChoiceOnFulfillmentStrategy: {},
+      userChoiceOnDoubleCountingElimination: [],
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      allowDoubleCounting: () => false,
+    },
+    /* keepCoursesWithoutDoubleCountingEliminationChoice */ true
+  );
 
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
   expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
@@ -55,14 +61,17 @@ it('buildRequirementFulfillmentGraph phase 1 test 2', () => {
 
 // Following two tests test how we are removing edges depending on user choices on fulfillment strategy.
 it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
-    requirements,
-    userCourses: [CS3410, CS3420, MATH4710],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
-    userChoiceOnDoubleCountingElimination: [],
-    getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: () => false,
-  });
+  const graph = buildRequirementFulfillmentGraph(
+    {
+      requirements,
+      userCourses: [CS3410, CS3420, MATH4710],
+      userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+      userChoiceOnDoubleCountingElimination: [],
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      allowDoubleCounting: () => false,
+    },
+    /* keepCoursesWithoutDoubleCountingEliminationChoice */ true
+  );
 
   // In this case, 3420 is removed since user chooses strategy 1.
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
@@ -71,14 +80,17 @@ it('buildRequirementFulfillmentGraph phase 2-1 test', () => {
 });
 
 it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
-    requirements,
-    userCourses: [CS3410, CS3420, MATH4710],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3420.courseId] },
-    userChoiceOnDoubleCountingElimination: [],
-    getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: () => false,
-  });
+  const graph = buildRequirementFulfillmentGraph(
+    {
+      requirements,
+      userCourses: [CS3410, CS3420, MATH4710],
+      userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3420.courseId] },
+      userChoiceOnDoubleCountingElimination: [],
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      allowDoubleCounting: () => false,
+    },
+    /* keepCoursesWithoutDoubleCountingEliminationChoice */ true
+  );
 
   // In this case, 3410 is removed since user chooses strategy 2.
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3420]);
@@ -88,7 +100,44 @@ it('buildRequirementFulfillmentGraph phase 2-2 test', () => {
 
 // The following two tests test that we will remove edges incompatible with user supplied choices.
 it('buildRequirementFulfillmentGraph phase 3 test 1', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
+  const graph = buildRequirementFulfillmentGraph(
+    {
+      requirements,
+      userCourses: [CS3410, CS3420, MATH4710],
+      userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+      userChoiceOnDoubleCountingElimination: { [MATH4710.uniqueId]: 'Probability' },
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      allowDoubleCounting: () => false,
+    },
+    /* keepCoursesWithoutDoubleCountingEliminationChoice */ true
+  );
+
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420]);
+});
+
+it('buildRequirementFulfillmentGraph phase 3 test 2', () => {
+  const graph = buildRequirementFulfillmentGraph(
+    {
+      requirements,
+      userCourses: [CS3410, CS3420, MATH4710],
+      userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+      userChoiceOnDoubleCountingElimination: { [MATH4710.uniqueId]: 'Elective' },
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      allowDoubleCounting: () => false,
+    },
+    /* keepCoursesWithoutDoubleCountingEliminationChoice */ true
+  );
+
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420, MATH4710]);
+});
+
+// The following test ensures that we will remove edges when user makes no choice on courses.
+it('buildRequirementFulfillmentGraph phase 3 test 3', () => {
+  const graph = buildRequirementFulfillmentGraph({
     requirements,
     userCourses: [CS3410, CS3420, MATH4710],
     userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
@@ -97,72 +146,27 @@ it('buildRequirementFulfillmentGraph phase 3 test 1', () => {
     allowDoubleCounting: () => false,
   });
 
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([]);
   expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
-  // We need a functional phase 3-2 to eliminate CS3410 here.
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([]);
 });
 
-it('buildRequirementFulfillmentGraph phase 3 test 2', () => {
-  const { requirementFulfillmentGraph: graph } = buildRequirementFulfillmentGraph({
-    requirements,
-    userCourses: [CS3410, CS3420, MATH4710],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
-    userChoiceOnDoubleCountingElimination: { [MATH4710.uniqueId]: 'Elective' },
-    getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: () => false,
-  });
-
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
-  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([]);
-  // We need a functional phase 3-2 to eliminate CS3410 here.
-  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3410, CS3420, MATH4710]);
-});
-
-// The following 3 tests test that we will detect all double counted courses.
-it('buildRequirementFulfillmentGraph phase 4 test 1', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph({
+// The following test runs on a fully specified graph algorithm on complete user choices
+it('buildRequirementFulfillmentGraph phase 3 test 4', () => {
+  const graph = buildRequirementFulfillmentGraph({
     requirements,
     userCourses: [CS3410, CS3420, MATH4710],
     userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
     userChoiceOnDoubleCountingElimination: {
       [CS3410.uniqueId]: 'CS3410/CS3420',
-      [MATH4710.uniqueId]: 'Probability',
+      [CS3420.uniqueId]: 'Elective',
+      [MATH4710.uniqueId]: 'Elective',
     },
     getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: () => false,
+    allowDoubleCounting: r => r === 'Probability',
   });
 
-  // User specified how to break tie for every double-counted courses, so we are happy here.
-  expect(illegallyDoubleCountedCourses).toEqual([]);
-});
-
-it('buildRequirementFulfillmentGraph phase 4 test 2', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph({
-    requirements,
-    userCourses: [CS3410, CS3420, MATH4710],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
-    userChoiceOnDoubleCountingElimination: { [CS3410.uniqueId]: 'CS3410/CS3420' },
-    getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: () => false,
-  });
-
-  // User doesn't specify whether to use MATH4710 to fulfill elective or probability, so MATH4710
-  // appears in the double counted list.
-  expect(illegallyDoubleCountedCourses).toEqual([MATH4710]);
-});
-
-it('buildRequirementFulfillmentGraph phase 4 test 3', () => {
-  const { illegallyDoubleCountedCourses } = buildRequirementFulfillmentGraph({
-    requirements,
-    userCourses: [CS3410, CS3420, MATH4710],
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
-    userChoiceOnDoubleCountingElimination: { [CS3410.uniqueId]: 'CS3410/CS3420' },
-    getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: requirement => requirement === 'Probability',
-  });
-
-  // Similar to the test case above, but we allowed Probability to be double-counted, so the list is
-  // empty.
-  expect(illegallyDoubleCountedCourses).toEqual([]);
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
+  expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
+  expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3420, MATH4710]);
 });

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -197,7 +197,6 @@ export default function computeGroupedRequirementFulfillmentReports(
 ): {
   readonly userRequirementsMap: Readonly<Record<string, RequirementWithIDSourceType>>;
   readonly requirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
-  readonly illegallyDoubleCountedCourseUniqueIDs: ReadonlySet<number>;
   readonly groupedRequirementFulfillmentReport: readonly GroupedRequirementFulfillmentReport[];
 } {
   const coursesTaken = getCourseCodesArray(semesters, onboardingData);
@@ -206,7 +205,6 @@ export default function computeGroupedRequirementFulfillmentReports(
   const {
     userRequirements,
     requirementFulfillmentGraph,
-    illegallyDoubleCountedCourseUniqueIDs,
   } = buildRequirementFulfillmentGraphFromUserData(
     coursesTaken,
     onboardingData,
@@ -281,7 +279,6 @@ export default function computeGroupedRequirementFulfillmentReports(
   return {
     userRequirementsMap: Object.fromEntries(userRequirements.map(it => [it.id, it])),
     requirementFulfillmentGraph,
-    illegallyDoubleCountedCourseUniqueIDs,
     groupedRequirementFulfillmentReport,
   };
 }

--- a/src/requirements/requirement-graph-builder-from-user-data.ts
+++ b/src/requirements/requirement-graph-builder-from-user-data.ts
@@ -30,15 +30,11 @@ export default function buildRequirementFulfillmentGraphFromUserData(
   readonly userRequirements: readonly RequirementWithIDSourceType[];
   readonly userRequirementsMap: Readonly<Record<string, RequirementWithIDSourceType>>;
   readonly requirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
-  readonly illegallyDoubleCountedCourseUniqueIDs: ReadonlySet<number>;
 } {
   const userRequirements = getUserRequirements(onboardingData);
   const userRequirementsMap = Object.fromEntries(userRequirements.map(it => [it.id, it]));
 
-  const {
-    requirementFulfillmentGraph,
-    illegallyDoubleCountedCourses,
-  } = buildRequirementFulfillmentGraph<string, CourseTaken>({
+  const requirementFulfillmentGraph = buildRequirementFulfillmentGraph<string, CourseTaken>({
     requirements: userRequirements.map(it => it.id),
     userCourses: forfeitTransferCredit(coursesTaken),
     userChoiceOnFulfillmentStrategy: Object.fromEntries(
@@ -83,12 +79,5 @@ export default function buildRequirementFulfillmentGraphFromUserData(
       userRequirementsMap[requirementID].allowCourseDoubleCounting || false,
   });
 
-  return {
-    userRequirements,
-    userRequirementsMap,
-    requirementFulfillmentGraph,
-    illegallyDoubleCountedCourseUniqueIDs: new Set(
-      illegallyDoubleCountedCourses.map(it => it.uniqueId)
-    ),
-  };
+  return { userRequirements, userRequirementsMap, requirementFulfillmentGraph };
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -44,7 +44,6 @@ export type VuexStoreState = {
   userRequirementsMap: Readonly<Record<string, RequirementWithIDSourceType>>;
   requirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
   groupedRequirementFulfillmentReport: readonly GroupedRequirementFulfillmentReport[];
-  illegallyDoubleCountedCourseUniqueIDs: ReadonlySet<number>;
   subjectColors: Readonly<Record<string, string>>;
   uniqueIncrementer: number;
 };
@@ -83,7 +82,6 @@ const store: TypedVuexStore = new TypedVuexStore({
     // It won't be null once the app loads.
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     requirementFulfillmentGraph: null!,
-    illegallyDoubleCountedCourseUniqueIDs: new Set(),
     groupedRequirementFulfillmentReport: [],
     subjectColors: {},
     uniqueIncrementer: 0,
@@ -129,13 +127,11 @@ const store: TypedVuexStore = new TypedVuexStore({
         VuexStoreState,
         | 'userRequirementsMap'
         | 'requirementFulfillmentGraph'
-        | 'illegallyDoubleCountedCourseUniqueIDs'
         | 'groupedRequirementFulfillmentReport'
       >
     ) {
       state.userRequirementsMap = data.userRequirementsMap;
       state.requirementFulfillmentGraph = data.requirementFulfillmentGraph;
-      state.illegallyDoubleCountedCourseUniqueIDs = data.illegallyDoubleCountedCourseUniqueIDs;
       state.groupedRequirementFulfillmentReport = data.groupedRequirementFulfillmentReport;
     },
     setSubjectColors(state: VuexStoreState, colors: Readonly<Record<string, string>>) {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR fixes the problem when user doesn't select any requirement for a course to fulfill, but it causes the course to fulfill all matching requirements and results in double counting warning.

The issue is in step 3 of the requirement graph building:

> Remove all the edges from courses to requirements that are not the picked requirement in the choice.

This step doesn't remove edges at all when the user doesn't make any choice, which causes the problem described above.

The fix itself is very straightforward: take a look at **every course**. If the course has no choice, when the chosen requirement is `null`. Since `null` is not equal to any connected requirement that doesn't allow double counting, all those edges will be correctly removed.

This changes cause some test that abuse the wrong old behavior to break, so I also fixed those tests.

**While fixing the requirement, I realized that this change also makes double counting impossible**, so I removed all the code to support double counting warnings as well. It's because for each course, it can only connect to one courses that doesn't allow double counting. Previously it's possible because if you don't select any requirement, it's matched to all courses. This PR removes the ability to do that.

### Test Plan <!-- Required -->

Add CS4300 without assigning any requirement to it. Now it doesn't auto fulfill CS electives any more.

### Breaking Changes  <!-- Optional -->

This is actually a big breaking change for users on prod. They don't have any requirement choice data, so they won't fulfill any requirement that doesn't allow double counting. We should probably add another type of warning when a course is not used to fulfill any requirement.

I implemented the new warning in this PR, so they existing users on prod can know why the requirement bar stops to show the added courses fulfill the requirements.

<img width="411" alt="Screen Shot 2021-03-21 at 21 04 23" src="https://user-images.githubusercontent.com/4290500/111928126-26245500-8a89-11eb-8dec-ac5434c58e18.png">
