### PR TITLE
Save implicit user choice when dragging course from SubRequirement to Semester

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,10 @@ module.exports = {
     'max-classes-per-file': ['off'],
     // TypeScript will handle it. It also doesn't work with typescript global types.
     'no-undef': ['off'],
-    'no-unused-vars': ['off'],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { vars: 'all', args: 'after-used', ignoreRestSiblings: true },
+    ],
     'no-use-before-define': ['off'],
     'vue/no-mutating-props': ['warn'],
     // allow debugger during development

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
       return 'See all >';
     },
     coursesWithoutRequirementID() {
-      return this.courses.map(({ requirementID, ...rest }) => rest);
+      return this.courses.map(({ requirementID: _, ...rest }) => rest);
     },
   },
   methods: {
@@ -105,7 +105,6 @@ export default Vue.extend({
     cloneCourse(
       courseWithDummyUniqueID: AppFirestoreSemesterCourseWithRequirementID
     ): AppFirestoreSemesterCourseWithRequirementID {
-      console.log(this.coursesWithoutRequirementID);
       return { ...courseWithDummyUniqueID, uniqueID: incrementUniqueID() };
     },
     onShowAllCourses() {

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -21,7 +21,11 @@
         @start="onDrag"
         @end="onDrop"
       >
-        <div v-for="(course, index) in courses" :key="index" class="requirements-courseWrapper">
+        <div
+          v-for="(course, index) in coursesWithoutRequirementID"
+          :key="index"
+          class="requirements-courseWrapper"
+        >
           <course
             :courseObj="course"
             :isReqCourse="true"
@@ -57,7 +61,10 @@ export default Vue.extend({
   props: {
     subReq: { type: Object as PropType<RequirementFulfillment>, required: true },
     subReqCourseId: { type: Number, required: true },
-    courses: { type: Array as PropType<readonly FirestoreSemesterCourse[]>, required: true },
+    courses: {
+      type: Array as PropType<readonly AppFirestoreSemesterCourseWithRequirementID[]>,
+      required: true,
+    },
     showSeeAllLabel: { type: Boolean, required: true },
     displayDescription: { type: Boolean, required: true },
   },
@@ -81,6 +88,9 @@ export default Vue.extend({
     seeAll() {
       return 'See all >';
     },
+    coursesWithoutRequirementID() {
+      return this.courses.map(({ requirementID, ...rest }) => rest);
+    },
   },
   methods: {
     onDrag() {
@@ -92,7 +102,10 @@ export default Vue.extend({
     dragListener(event: { preventDefault: () => void }) {
       if (!this.scrollable) event.preventDefault();
     },
-    cloneCourse(courseWithDummyUniqueID: FirestoreSemesterCourse): FirestoreSemesterCourse {
+    cloneCourse(
+      courseWithDummyUniqueID: AppFirestoreSemesterCourseWithRequirementID
+    ): AppFirestoreSemesterCourseWithRequirementID {
+      console.log(this.coursesWithoutRequirementID);
       return { ...courseWithDummyUniqueID, uniqueID: incrementUniqueID() };
     },
     onShowAllCourses() {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -174,7 +174,7 @@ type Data = {
 const generateSubReqIncompleteCourses = (
   allTakenCourseIds: ReadonlySet<number>,
   eligibleCourseIds: readonly number[],
-  requirementID: number
+  requirementID: string
 ): readonly AppFirestoreSemesterCourseWithRequirementID[] => {
   const rosterCourses = eligibleCourseIds
     .filter(courseID => !allTakenCourseIds.has(courseID))

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -255,7 +255,13 @@ export default Vue.extend({
         if (!this.isCompleted) {
           slots.push({
             isCompleted: false,
-            courses: generateSubReqIncompleteCourses(allTakenCourseIds, subReqEligibleCourses[0]),
+            courses: generateSubReqIncompleteCourses(
+              allTakenCourseIds,
+              subReqEligibleCourses[0]
+            ).map(course => ({
+              ...course,
+              requirementID: this.subReq.requirement.id,
+            })),
           });
         }
       } else {
@@ -270,7 +276,10 @@ export default Vue.extend({
                 courses: generateSubReqIncompleteCourses(
                   allTakenCourseIds,
                   subReqEligibleCourses[i]
-                ),
+                ).map(course => ({
+                  ...course,
+                  requirementID: this.subReq.requirement.id,
+                })),
               });
             }
           }

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -161,7 +161,7 @@ type CompletedSubReqCourseSlot = {
 
 type IncompleteSubReqCourseSlot = {
   readonly isCompleted: false;
-  readonly courses: readonly FirestoreSemesterCourse[];
+  readonly courses: readonly AppFirestoreSemesterCourseWithRequirementID[];
 };
 
 export type SubReqCourseSlot = CompletedSubReqCourseSlot | IncompleteSubReqCourseSlot;

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -196,7 +196,7 @@ export default Vue.extend({
         return this.courses;
       },
       set(newCourses: readonly AppFirestoreSemesterCourseWithRequirementID[]) {
-        const courses = newCourses.map(({ requirementID, ...rest }) => rest);
+        const courses = newCourses.map(({ requirementID: _, ...rest }) => rest);
         editSemester(
           this.year,
           this.type,

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -118,6 +118,7 @@ import {
   editSemester,
   addCourseToSemester,
   deleteCourseFromSemester,
+  addCourseToSelectableRequirements,
 } from '@/global-firestore-data';
 import { cornellCourseRosterCourseToFirebaseSemesterCourse } from '@/user-data-converter';
 
@@ -194,14 +195,18 @@ export default Vue.extend({
       get(): readonly FirestoreSemesterCourse[] {
         return this.courses;
       },
-      set(newCourses: readonly FirestoreSemesterCourse[]) {
+      set(newCourses: readonly SubRequirementFirestoreSemesterCourseWithRequirementID[]) {
+        const courses = newCourses.map(({ requirementID, ...rest }) => rest);
         editSemester(
           this.year,
           this.type,
           (semester: FirestoreSemester): FirestoreSemester => ({
             ...semester,
-            courses: newCourses,
+            courses,
           })
+        );
+        newCourses.forEach(({ uniqueID, requirementID }) =>
+          addCourseToSelectableRequirements(uniqueID, requirementID)
         );
       },
     },

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -195,7 +195,7 @@ export default Vue.extend({
       get(): readonly FirestoreSemesterCourse[] {
         return this.courses;
       },
-      set(newCourses: readonly SubRequirementFirestoreSemesterCourseWithRequirementID[]) {
+      set(newCourses: readonly AppFirestoreSemesterCourseWithRequirementID[]) {
         const courses = newCourses.map(({ requirementID, ...rest }) => rest);
         editSemester(
           this.year,

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -179,7 +179,7 @@ const chooseSelectableRequirementOption = (
 
 export const addCourseToSelectableRequirements = (
   courseUniqueID: number,
-  requirementID: string
+  requirementID: string | undefined
 ): void => {
   if (!requirementID) return;
   chooseSelectableRequirementOption({

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -20,6 +20,12 @@ type FirestoreSemesterCourse = {
   readonly color: string;
 };
 
+// This should only be used in Semester.vue and SubRequirement.vue
+// for dragging from SubRequirement and dropping in Semester
+type SubRequirementFirestoreSemesterCourseWithRequirementID = FirestoreSemesterCourse & {
+  readonly requirementID?: string;
+};
+
 type FirestoreSemesterType = 'Fall' | 'Spring' | 'Summer' | 'Winter';
 type FirestoreSemester = {
   readonly year: number;

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -20,9 +20,8 @@ type FirestoreSemesterCourse = {
   readonly color: string;
 };
 
-// This should only be used in Semester.vue and SubRequirement.vue
-// for dragging from SubRequirement and dropping in Semester
-type SubRequirementFirestoreSemesterCourseWithRequirementID = FirestoreSemesterCourse & {
+// This is used for drag&drop between SubRequirement and Semester
+type AppFirestoreSemesterCourseWithRequirementID = FirestoreSemesterCourse & {
   readonly requirementID?: string;
 };
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request saves the implicit choice made when dragging a course from the sidebar. See [notion](https://www.notion.so/courseplan/Integrate-Implicit-User-Choice-from-Sidebar-Drag-Drop-into-Req-algo-d78852e3c37345e58a9a6bf49fca48c3) and Sam's notes in PR #324.

- [x] save implicit choice in selectable requirements

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->


<!--- Note dependencies on other PRs if any. -->


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Dragging a course from the sidebar should now automatically bind the course's unique id to the requirement id (see the [selectable requirements collection](console.firebase.google.com/u/0/project/cornelldti-courseplan-dev/firestore/data~2Fuser-selectable-requirement-choices)). In many cases, this removes a warning (eg. dragging CS 3410 as a CS Core).
![image](https://user-images.githubusercontent.com/34158284/111888518-a8dae080-89b3-11eb-902d-0b19510fef9f.png)

You can also test that the drag&drop functionality was not affected in other ways (eg. dragging between semesters).

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
- I created a new global type `SubRequirementFirestoreSemesterCourseWithRequirementID` that should only be used for drag&drops between Semester and SubRequirement (the sidebar).
- I updated the linter config as per Sam's comment below