### PR TITLE
Make mobile semester view occupy the entire width minus margin

### DIFF
--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -560,4 +560,12 @@ export default Vue.extend({
     }
   }
 }
+
+@media only screen and (max-width: $small-breakpoint) {
+  .semester,
+  .semester--compact {
+    width: calc(100vw - 4rem);
+    padding: 0;
+  }
+}
 </style>

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -27,16 +27,14 @@
         data-step="4"
         data-tooltipClass="tooltipCenter"
       >
-        <span v-if="!isMobile" class="semesterView-switchText">View:</span>
+        <span class="semesterView-switchText">View:</span>
         <div
           class="semesterView-switchImage semesterView-twoColumn"
-          v-if="!isMobile"
           @click="setNotCompact"
           :class="{ 'semesterView-twoColumn--active': !compact }"
         ></div>
         <div
           class="semesterView-switchImage semesterView-fourColumn"
-          v-if="!isMobile"
           @click="setCompact"
           :class="{ 'semesterView-fourColumn--active': compact }"
         ></div>
@@ -358,6 +356,23 @@ export default Vue.extend({
     &-content {
       width: 100%;
       justify-content: center;
+    }
+  }
+}
+
+@media only screen and (max-width: $small-breakpoint) {
+  .semesterView {
+    margin-top: 5.5rem;
+    margin-left: 0;
+    margin-right: 0;
+
+    &-content {
+      margin: 0;
+    }
+
+    &-wrapper {
+      flex: 1 1 auto;
+      padding: 0 2rem;
     }
   }
 }

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -46,7 +46,7 @@
     />
     <tour-window
       title="Let's get CoursePlanning!"
-      text="There’s more to explore as you start planning! CoursePlan is continously improving, so please use it as a guide and 
+      text="There’s more to explore as you start planning! CoursePlan is continously improving, so please use it as a guide and
       also consult your advisors for more up to date information!"
       :isFinalStep="true"
       exit=""
@@ -172,16 +172,9 @@ export default Vue.extend({
       this.isMobile = window.innerWidth <= smallBreakpointPixels;
       this.isTablet = window.innerWidth <= mediumBreakpointPixels;
       this.maxBottomBarTabs = getMaxButtonBarTabs();
-      this.updateSemesterView();
     },
     toggleRequirementsBar() {
       this.isOpeningRequirements = !this.isOpeningRequirements;
-    },
-    updateSemesterView() {
-      if (this.isMobile) {
-        // Make sure semesterView is not compact by default on mobile
-        this.compactVal = false;
-      }
     },
 
     showTourEnd() {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR makes the mobile view looks slightly better by making the semester card occupying the entire width, minus 2rem margin on left and right.

### Test Plan <!-- Required -->

<img width="433" alt="Screen Shot 2021-03-21 at 20 59 43" src="https://user-images.githubusercontent.com/4290500/111927865-76e77e00-8a88-11eb-9532-fb2474d491f6.png">
<img width="457" alt="Screen Shot 2021-03-21 at 20 59 47" src="https://user-images.githubusercontent.com/4290500/111927866-77801480-8a88-11eb-9cbd-e86d310a0994.png">


### Notes <!-- Optional -->

I originally plan to implement the full mobile design as shown here:

<img width="365" alt="Screen Shot 2021-03-21 at 15 07 43" src="https://user-images.githubusercontent.com/4290500/111917601-3b808b80-8a57-11eb-9fff-6995b0d88d9b.png">

Then I realized that it doesn't work with the drag and drop library we are using, which expects a one-column linear flow. I wonder whether I should do one of the alternative design instead?

<img width="640" alt="Screen Shot 2021-03-21 at 15 08 52" src="https://user-images.githubusercontent.com/4290500/111917625-6965d000-8a57-11eb-9282-2f14902252bd.png">
