### PR TITLE
[easy] Do not show incorrect semester warning when semesters are empty

### DIFF
--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -44,7 +44,9 @@ const getCourseCautions = (course: FirestoreSemesterCourse): CourseCautions => {
       .length === 0;
   const semesterOfUserCourse = courseToSemesterMap[course.uniqueID];
   const typicallyOfferedWarning =
-    semesterOfUserCourse != null && !course.semesters.includes(semesterOfUserCourse.type)
+    semesterOfUserCourse != null &&
+    course.semesters.length > 0 &&
+    !course.semesters.includes(semesterOfUserCourse.type)
       ? course.semesters
       : undefined;
   const isCourseDuplicate = duplicatedCourseCodeSet.has(course.code);


### PR DESCRIPTION
### Summary <!-- Required -->

Fix https://www.notion.so/courseplan/Warnings-Missing-Semester-70496a5911ee4ee096a4abd348a77c0a

We should simply not show it, since missing `semesters` array means that we don't know when it will be offered.

### Test Plan <!-- Required -->

No longer show up.

<img width="374" alt="Screen Shot 2021-03-21 at 19 54 03" src="https://user-images.githubusercontent.com/4290500/111925517-8b734880-8a7f-11eb-927b-c1c001f59769.png">
