### PR TITLE
Match to figma and add ap/ib reset feature

### DIFF
--- a/src/components/Modals/ResetConfirmationModal.vue
+++ b/src/components/Modals/ResetConfirmationModal.vue
@@ -12,16 +12,16 @@
       :rightButtonIsDisabled="false"
     >
       <div v-if="isTestReq" class="text-width">
-        Are you sure you want to reset the "{{ reqName }}" requirement? This will delete the
-        selected course from your schedule, allowing you to add a different course to satisfy this
-        requirement.
-      </div>
-      <div v-else class="text-width">
         Are you sure you want to reset "{{ reqName }}" for this requirement? This will delete the
         selected transfer credit from your schedule, allowing you to add a different course to
         satisfy this requirement.
         <br />
         Transfer credits can be re-added in your Profile.
+      </div>
+      <div v-else class="text-width">
+        Are you sure you want to reset the "{{ reqName }}" requirement? This will delete the
+        selected course from your schedule, allowing you to add a different course to satisfy this
+        requirement.
       </div>
     </flexible-modal>
   </div>
@@ -52,10 +52,16 @@ export default Vue.extend({
   },
 });
 </script>
-<style scoped lang="scss">
+<style lang="scss">
+@import '@/assets/scss/_variables.scss';
+
 .content-confirmation {
-  width: 15.5rem;
+  width: 30.5em;
+  button {
+    width: 48px;
+  }
 }
+
 .reset-modal {
   display: none; /* Hidden by default */
   position: fixed; /* Stay in place */
@@ -71,11 +77,12 @@ export default Vue.extend({
 
 .modal-width {
   transform: translateX(calc(50vw - 50%));
-  width: 30em;
 }
 
 .text-width {
-  width: 25em;
+  width: 28em;
+  line-height: 17px;
+  color: $lightPlaceholderGray;
 }
 
 .modal {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -42,7 +42,7 @@ import ReqCourse from '@/components/Requirements/ReqCourse.vue';
 import ResetConfirmationModal from '@/components/Modals/ResetConfirmationModal.vue';
 import store from '@/store';
 import { deleteCourseFromSemesters } from '@/global-firestore-data';
-import { db, onboardingDataCollection } from '@/firebaseConfig';
+import { onboardingDataCollection } from '@/firebaseConfig';
 import getCurrentSeason, { getCurrentYear } from '@/utilities';
 
 const transferCreditColor = 'DA4A4A'; // Arbitrary color for transfer credit
@@ -95,16 +95,9 @@ export default Vue.extend({
 
           const onBoardingData = store.state.onboardingData;
 
-          db.batch()
-            .set(onboardingDataCollection.doc(store.state.currentFirebaseUser.email), {
-              tookSwim: onBoardingData.tookSwim,
-              colleges: [{ acronym: onBoardingData.college }],
-              class: onBoardingData.transferCourse,
-              majors: onBoardingData.major.map(m => ({ acronym: m })),
-              minors: onBoardingData.minor.map(m => ({ acronym: m })),
-              exam: onBoardingData.exam.filter(e => !(e.type === type && e.subject === name)),
-            } as FirestoreOnboardingUserData)
-            .commit();
+          onboardingDataCollection.doc(store.state.currentFirebaseUser.email).update({
+            exam: onBoardingData.exam.filter(e => !(e.type === type && e.subject === name)),
+          });
         } else deleteCourseFromSemesters(this.courseTaken.uniqueId, this.$gtag);
       }
     },

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -42,6 +42,7 @@ import ReqCourse from '@/components/Requirements/ReqCourse.vue';
 import ResetConfirmationModal from '@/components/Modals/ResetConfirmationModal.vue';
 import store from '@/store';
 import { deleteCourseFromSemesters } from '@/global-firestore-data';
+import { db, onboardingDataCollection } from '@/firebaseConfig';
 import getCurrentSeason, { getCurrentYear } from '@/utilities';
 
 const transferCreditColor = 'DA4A4A'; // Arbitrary color for transfer credit
@@ -87,7 +88,25 @@ export default Vue.extend({
       this.resetConfirmVisible = true;
     },
     onResetConfirmClosed(isReset: boolean): void {
-      if (isReset) deleteCourseFromSemesters(this.courseTaken.uniqueId, this.$gtag);
+      if (isReset) {
+        if (this.isTransferCredit) {
+          const type = this.courseTaken.code.substr(0, 2);
+          const name = this.courseTaken.code.substr(3);
+
+          const onBoardingData = store.state.onboardingData;
+
+          db.batch()
+            .set(onboardingDataCollection.doc(store.state.currentFirebaseUser.email), {
+              tookSwim: onBoardingData.tookSwim,
+              colleges: [{ acronym: onBoardingData.college }],
+              class: onBoardingData.transferCourse,
+              majors: onBoardingData.major.map(m => ({ acronym: m })),
+              minors: onBoardingData.minor.map(m => ({ acronym: m })),
+              exam: onBoardingData.exam.filter(e => !(e.type === type && e.subject === name)),
+            } as FirestoreOnboardingUserData)
+            .commit();
+        } else deleteCourseFromSemesters(this.courseTaken.uniqueId, this.$gtag);
+      }
     },
   },
 });


### PR DESCRIPTION
### Summary 

Fixed the reset confirmation modal design to match the figma design.

![image](https://user-images.githubusercontent.com/6832564/111935477-efa30600-8a99-11eb-8f76-cd0655c01118.png)
![image](https://user-images.githubusercontent.com/6832564/111935500-faf63180-8a99-11eb-982c-10f7a8fed5cb.png)

Added the ability to remove transfer credits as well.

- [x] Implemented firestore commit to the onboarding data in order to remove the transfer course 
- [x] Changed css styling to match figma style.

Remaining TODOs:

- [ ] Make the firestore commit more flexible. Onboarding data has a really finicky way of committing to firestore because AppOnboardingData does not match FirestoreOnboardingData.


### Test Plan <!-- Required -->

Check that the style is correct and transfer credits are always removed.