### PR TITLE
Gtags for Google Analytics (1/2)

### DIFF
--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -6,7 +6,7 @@
     <div
       class="bottombar-title"
       :class="{ expandedBottomBarTitle: isExpanded }"
-      @click="toggleBottomBar(this.$gtag)"
+      @click="toggleBottomBar($gtag)"
     >
       <bottom-bar-title
         :color="focusedBottomBarCourse.color"

--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -6,7 +6,7 @@
     <div
       class="bottombar-title"
       :class="{ expandedBottomBarTitle: isExpanded }"
-      @click="toggleBottomBar()"
+      @click="toggleBottomBar(this.$gtag)"
     >
       <bottom-bar-title
         :color="focusedBottomBarCourse.color"

--- a/src/components/BottomBar/BottomBarCourseInfo.vue
+++ b/src/components/BottomBar/BottomBarCourseInfo.vue
@@ -41,7 +41,12 @@
       </div>
     </div>
     <div class="info-link">
-      <a :href="rosterLink" class="info-link-blue" target="_blank" @click="clickViewCourseInformationOnRoster()">
+      <a
+        :href="rosterLink"
+        class="info-link-blue"
+        target="_blank"
+        @click="clickViewCourseInformationOnRoster()"
+      >
         View Course Information on Roster
         <span class="info-link-blue-img"
           ><img src="@/assets/images/link-blue.svg" alt="link arrow"
@@ -109,8 +114,8 @@ export default Vue.extend({
   methods: {
     clickViewCourseInformationOnRoster(): void {
       GTagEvent(this.$gtag, 'bottom-bar-view-course-information-on-roster');
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/BottomBar/BottomBarCourseInfo.vue
+++ b/src/components/BottomBar/BottomBarCourseInfo.vue
@@ -41,7 +41,7 @@
       </div>
     </div>
     <div class="info-link">
-      <a :href="rosterLink" class="info-link-blue" target="_blank">
+      <a :href="rosterLink" class="info-link-blue" target="_blank" @click="clickViewCourseInformationOnRoster()">
         View Course Information on Roster
         <span class="info-link-blue-img"
           ><img src="@/assets/images/link-blue.svg" alt="link arrow"
@@ -53,6 +53,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
+import { GTagEvent } from '@/gtag';
 
 const joinOrNAString = (arr: readonly string[]): string =>
   arr.length !== 0 && arr[0] !== '' ? arr.join(', ') : 'N/A';
@@ -104,6 +105,12 @@ export default Vue.extend({
       return `https://classes.cornell.edu/browse/roster/${this.courseObj.lastRoster}/class/${subject}/${number}`;
     },
   },
+
+  methods: {
+    clickViewCourseInformationOnRoster(): void {
+      GTagEvent(this.$gtag, 'bottom-bar-view-course-information-on-roster');
+    }
+  }
 });
 </script>
 

--- a/src/components/BottomBar/BottomBarCourseReview.vue
+++ b/src/components/BottomBar/BottomBarCourseReview.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="details">
     <div class="details-ratings-link-wrapper">
-      <a :href="CURLink" class="details-ratings-link" target="_blank">See All Reviews</a>
+      <a :href="CURLink" class="details-ratings-link" target="_blank" @click="clickSeeAllReviews()"
+        >See All Reviews</a
+      >
     </div>
     <div class="details-ratings-wrapper">
       <div class="details-ratings">
@@ -75,6 +77,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { reviewColors } from '@/assets/constants/colors';
+import { GTagEvent } from '@/gtag';
 
 const noneIfEmpty = (str: string): string => (str && str.length !== 0 ? str : 'None');
 
@@ -100,6 +103,10 @@ export default Vue.extend({
       }
 
       return flip ? colors[colors.length - 1 - index] : colors[index];
+    },
+
+    clickSeeAllReviews(): void {
+      GTagEvent(this.$gtag, 'bottom-bar-see-all-reviews');
     },
   },
 

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -110,11 +110,11 @@ export const changeBottomBarCourseFocus = (index: number): void => {
 };
 
 export const deleteBottomBarCourse = (index: number, gtag?: GTag): void => {
+  GTagEvent(gtag, 'bottom-bar-delete-tab');
   vueForBottomBar.bottomCourses = vueForBottomBar.bottomCourses.filter((_, i) => i !== index);
   if (vueForBottomBar.bottomCourseFocus >= vueForBottomBar.bottomCourses.length) {
     vueForBottomBar.bottomCourseFocus = vueForBottomBar.bottomCourses.length - 1;
   }
-  GTagEvent(gtag, 'bottom-bar-delete-tab');
 };
 
 export const moveBottomBarCourseToFirst = (index: number): void => {

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -7,6 +7,8 @@ import {
   firestoreSemesterCourseToBottomBarCourse,
 } from '../../user-data-converter';
 
+import { GTag, GTagEvent } from '@/gtag';
+
 export type BottomBarState = {
   bottomCourses: readonly AppBottomBarCourse[];
   bottomCourseFocus: number;
@@ -91,23 +93,30 @@ export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
   vueForBottomBar.bottomCourseFocus = 0;
 };
 
-export const toggleBottomBar = (): void => {
+export const toggleBottomBar = (gtag?: GTag): void => {
   vueForBottomBar.isExpanded = !vueForBottomBar.isExpanded;
+  if (vueForBottomBar.isExpanded) {
+    GTagEvent(gtag, 'bottom-bar-open');
+  } else {
+    GTagEvent(gtag, 'bottom-bar-close');
+  }
 };
 
-export const closeBottomBar = (): void => {
+export const closeBottomBar = (gtag?: GTag): void => {
   vueForBottomBar.isExpanded = false;
+  GTagEvent(gtag, 'bottom-bar-close');
 };
 
 export const changeBottomBarCourseFocus = (index: number): void => {
   vueForBottomBar.bottomCourseFocus = index;
 };
 
-export const deleteBottomBarCourse = (index: number): void => {
+export const deleteBottomBarCourse = (index: number, gtag?: GTag): void => {
   vueForBottomBar.bottomCourses = vueForBottomBar.bottomCourses.filter((_, i) => i !== index);
   if (vueForBottomBar.bottomCourseFocus >= vueForBottomBar.bottomCourses.length) {
     vueForBottomBar.bottomCourseFocus = vueForBottomBar.bottomCourses.length - 1;
   }
+  GTagEvent(gtag, 'bottom-bar-delete-tab');
 };
 
 export const moveBottomBarCourseToFirst = (index: number): void => {

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -1,13 +1,11 @@
 import Vue from 'vue';
-
+import { GTag, GTagEvent } from '@/gtag';
 import { checkNotNull } from '../../utilities';
 
 import {
   cornellCourseRosterCourseDetailedInformationToPartialBottomCourseInformation,
   firestoreSemesterCourseToBottomBarCourse,
 } from '../../user-data-converter';
-
-import { GTag, GTagEvent } from '@/gtag';
 
 export type BottomBarState = {
   bottomCourses: readonly AppBottomBarCourse[];

--- a/src/components/BottomBar/BottomBarTabView.vue
+++ b/src/components/BottomBar/BottomBarTabView.vue
@@ -13,7 +13,7 @@
           :bottomCourseFocus="bottomCourseFocus"
           :isExpanded="isExpanded"
           @on-change-focus="() => changeBottomBarCourseFocus(index)"
-          @on-delete="() => deleteBottomBarCourse(index)"
+          @on-delete="() => deleteBottomBarCourse(index, this.$gtag)"
         />
       </div>
     </div>
@@ -48,7 +48,7 @@
             <img
               class="seeMoreCourse-option-delete"
               src="@/assets/images/x-blue.svg"
-              @click="deleteBottomBarCourse(index + maxBottomBarTabs)"
+              @click="deleteBottomBarCourse(index + maxBottomBarTabs, this.$gtag)"
               alt="x"
             />
           </div>
@@ -67,6 +67,7 @@ import {
   deleteBottomBarCourse,
   moveBottomBarCourseToFirst,
 } from '@/components/BottomBar/BottomBarState';
+import { GTagEvent } from '@/gtag';
 
 export default Vue.extend({
   components: { BottomBarTab },
@@ -102,6 +103,7 @@ export default Vue.extend({
     moveBottomBarCourseToFirst,
     bottomBarSeeMoreToggle() {
       this.seeMoreOpen = !this.seeMoreOpen;
+      GTagEvent(this.$gtag, 'bottom-bar-see-more');
     },
   },
 });

--- a/src/components/BottomBar/BottomBarTabView.vue
+++ b/src/components/BottomBar/BottomBarTabView.vue
@@ -13,7 +13,7 @@
           :bottomCourseFocus="bottomCourseFocus"
           :isExpanded="isExpanded"
           @on-change-focus="() => changeBottomBarCourseFocus(index)"
-          @on-delete="() => deleteBottomBarCourse(index, this.$gtag)"
+          @on-delete="() => deleteBottomBarCourse(index, $gtag)"
         />
       </div>
     </div>
@@ -48,7 +48,7 @@
             <img
               class="seeMoreCourse-option-delete"
               src="@/assets/images/x-blue.svg"
-              @click="deleteBottomBarCourse(index + maxBottomBarTabs, this.$gtag)"
+              @click="deleteBottomBarCourse(index + maxBottomBarTabs, $gtag)"
               alt="x"
             />
           </div>

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -84,6 +84,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { coursesColorSet } from '@/assets/constants/colors';
+import { GTagEvent } from '@/gtag';
 
 export default Vue.extend({
   props: {
@@ -132,6 +133,7 @@ export default Vue.extend({
     },
     colorCourse(color: { hex: string }) {
       this.$emit('color-course', color.hex.substring(1));
+      GTagEvent(this.$gtag, 'course-edit-color');
     },
     setDisplayColors(bool: boolean) {
       this.displayColors = bool;

--- a/src/components/Modals/NewCourse/SelectedRequirementEditor.vue
+++ b/src/components/Modals/NewCourse/SelectedRequirementEditor.vue
@@ -61,6 +61,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
+import { GTagEvent } from '@/gtag';
 import RequirementsDropdown from '@/components/Modals/NewCourse/RequirementsDropdown.vue';
 
 export type RequirementWithID = { readonly id: string; readonly name: string };
@@ -117,6 +118,7 @@ export default Vue.extend({
       this.$emit('on-selected-change', id);
     },
     toggleEditMode() {
+      GTagEvent(this.$gtag, 'add-modal-edit-requirements');
       this.$emit('edit-mode');
     },
   },

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -4,7 +4,7 @@
       <div class="onboarding-subHeader">
         <span class="onboarding-subHeader--font"> Basic Information</span>
         <span>
-          <button class="onboarding-button-previous" @click="setPage(1)">
+          <button class="onboarding-button-previous" @click="editBasicInformation()">
             <img src="@/assets/images/edit-review.svg" alt="edit" />
           </button>
         </span>
@@ -66,7 +66,7 @@
       <div class="onboarding-subHeader">
         <span class="onboarding-subHeader--font"> Transfer Credits</span>
         <span>
-          <button class="onboarding-button-previous" @click="setPage(2)">
+          <button class="onboarding-button-previous" @click="editTransferCredits()">
             <img src="@/assets/images/edit-review.svg" />
           </button>
         </span>
@@ -165,6 +165,7 @@
 import Vue, { PropType } from 'vue';
 import { getExamCredit } from '@/components/Modals/Onboarding/OnboardingTransfer.vue';
 import { getCollegeFullName, getMajorFullName, getMinorFullName } from '@/utilities';
+import { GTagEvent } from '@/gtag';
 
 const placeholderText = 'Select one';
 
@@ -191,6 +192,14 @@ export default Vue.extend({
     },
   },
   methods: {
+    editBasicInformation(): void {
+      this.setPage(1);
+      GTagEvent(this.$gtag, 'onboarding-edit-basic-information');
+    },
+    editTransferCredits(): void {
+      this.setPage(2);
+      GTagEvent(this.$gtag, 'onboarding-edit-transfer-credits');
+    },
     getExamCredit,
     getMajorFullName,
     getMinorFullName,

--- a/src/components/Modals/TourWindow.vue
+++ b/src/components/Modals/TourWindow.vue
@@ -40,10 +40,25 @@
               <a href="mailto:courseplan@cornelldti.org">courseplan@cornelldti.org</a>.
             </div>
           </div>
-          <button class="startButton" @click="startTour()">
+          <button
+            class="startButton"
+            @click="
+              $emit('hide');
+              $emit('startTour');
+              startTour();
+            "
+          >
             {{ buttonText }}
           </button>
-          <button class="skipButton" @click="skipTour()">{{ exit }}</button>
+          <button
+            class="skipButton"
+            @click="
+              $emit('skip');
+              skipTour();
+            "
+          >
+            {{ exit }}
+          </button>
         </div>
       </div>
     </div>
@@ -73,12 +88,9 @@ export default Vue.extend({
   },
   methods: {
     startTour(): void {
-      this.$emit('hide');
-      this.$emit('startTour');
       GTagEvent(this.$gtag, 'start-walkthrough');
     },
     skipTour(): void {
-      this.$emit('skip');
       GTagEvent(this.$gtag, 'skip-walkthrough');
     },
   },

--- a/src/components/Modals/TourWindow.vue
+++ b/src/components/Modals/TourWindow.vue
@@ -40,16 +40,10 @@
               <a href="mailto:courseplan@cornelldti.org">courseplan@cornelldti.org</a>.
             </div>
           </div>
-          <button
-            class="startButton"
-            @click="
-              $emit('hide');
-              $emit('startTour');
-            "
-          >
+          <button class="startButton" @click="startTour()">
             {{ buttonText }}
           </button>
-          <button class="skipButton" @click="$emit('skip')">{{ exit }}</button>
+          <button class="skipButton" @click="skipTour()">{{ exit }}</button>
         </div>
       </div>
     </div>
@@ -59,6 +53,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { clickOutside } from '@/utilities';
+import { GTagEvent } from '@/gtag';
 
 export default Vue.extend({
   props: {
@@ -75,6 +70,17 @@ export default Vue.extend({
   },
   directives: {
     'click-outside': clickOutside,
+  },
+  methods: {
+    startTour(): void {
+      this.$emit('hide');
+      this.$emit('startTour');
+      GTagEvent(this.$gtag, 'start-walkthrough');
+    },
+    skipTour(): void {
+      this.$emit('skip');
+      GTagEvent(this.$gtag, 'skip-walkthrough');
+    },
   },
 });
 </script>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -41,6 +41,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import firebase from 'firebase/app';
+import { GTagEvent } from '@/gtag';
 
 export default Vue.extend({
   props: {
@@ -51,6 +52,7 @@ export default Vue.extend({
   },
   methods: {
     logout() {
+      GTagEvent(this.$gtag, 'logout');
       firebase
         .auth()
         .signOut()

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -39,6 +39,7 @@ import Vue, { PropType } from 'vue';
 import draggable from 'vuedraggable';
 import Course from '@/components/Course/Course.vue';
 import { incrementUniqueID } from '@/global-firestore-data';
+import { GTagEvent } from '@/gtag';
 
 export default Vue.extend({
   components: { draggable, Course },
@@ -87,6 +88,7 @@ export default Vue.extend({
     },
     onDrop() {
       this.scrollable = true;
+      GTagEvent(this.$gtag, 'requirements-bar-course-drag-and-drop');
     },
     dragListener(event: { preventDefault: () => void }) {
       if (!this.scrollable) event.preventDefault();

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -71,6 +71,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
+import { GTagEvent } from '@/gtag';
 import RequirementHeader from '@/components/Requirements/RequirementHeader.vue';
 import SubRequirement from '@/components/Requirements/SubRequirement.vue';
 
@@ -149,6 +150,7 @@ export default Vue.extend({
       this.displayDetails = !this.displayDetails;
     },
     turnCompleted(bool: boolean) {
+      GTagEvent(this.$gtag, 'requirements-bar-filled-requirements-toggle');
       this.displayCompleted = bool;
     },
   },

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -194,7 +194,7 @@ export default Vue.extend({
     },
     closeBar() {
       if (!this.isCourseClicked) {
-        closeBottomBar();
+        closeBottomBar(this.$gtag);
       }
       this.isCourseClicked = false;
     },

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -15,6 +15,13 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: string): void => {
   if (!gtag) return;
   let eventPayload: EventPayload | undefined;
   switch (eventType) {
+    case 'logout':
+      eventPayload = {
+        event_category: 'engagement',
+        event_label: 'logout',
+        value: 1,
+      };
+      break;
     case 'to-compact':
       eventPayload = {
         event_category: 'views',
@@ -131,6 +138,27 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: string): void => {
       eventPayload = {
         event_category: 'bottom-bar',
         event_label: 'close',
+        value: 1,
+      };
+      break;
+    case 'add-modal-edit-requirements':
+      eventPayload = {
+        event_category: 'add-modal',
+        event_label: 'edit-requirements',
+        value: 1,
+      };
+      break;
+    case 'requirements-bar-filled-requirements-toggle':
+      eventPayload = {
+        event_category: 'requirements-bar',
+        event_label: 'filled-requirements-toggle',
+        value: 1,
+      };
+      break;
+    case 'requirements-bar-course-drag-and-drop':
+      eventPayload = {
+        event_category: 'requirements-bar',
+        event_label: 'course-drag-and-drop',
         value: 1,
       };
       break;

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -12,53 +12,35 @@ export const GTagLoginEvent = (gtag: GTag | undefined, method: string): void => 
   gtag.event('login', { method });
 };
 
+type EventType =
+  | 'logout' // User logs out
+  | 'to-compact' // User sets the semester view to compact
+  | 'to-not-compact' // User sets the semester view to default
+  | 'add-semester' // User adds a semester
+  | 'delete-semester' // User deletes a semester
+  | 'add-course' // User adds a course
+  | 'delete-course' // User deletes a course
+  | 'course-edit-color' // User edits the course color
+  | 'start-walkthrough' // User clicks to start the walkthrough
+  | 'skip-walkthrough' // User clicks to skip the walkthrough
+  | 'onboarding-edit-basic-information' // User clicks to edit basic info on the review page of Onboarding
+  | 'onboarding-edit-transfer-credits' // User clicks to edit transfer credits on the review page of Onboarding
+  | 'bottom-bar-see-all-reviews' // User clicks See All Reviews link on Bottom Bar
+  | 'bottom-bar-view-course-information-on-roster' // User clicks View Course Information on Roster link on Bottom Bar
+  | 'bottom-bar-see-more' // User clicks on the See More tab of the Bottom Bar
+  | 'bottom-bar-delete-tab' // User deletes a tab on the Bottom Bar
+  | 'bottom-bar-open' // User opens or expands the Bottom Bar
+  | 'bottom-bar-close' // User collapses or closes the Bottom Bar
+  | 'add-modal-edit-requirements' // User clicks Edit Requirements on Add Modal
+  | 'requirements-bar-filled-requirements-toggle' // User toggles the SHOW/HIDE of Filled Requirements section on Requirements Bar
+  | 'requirements-bar-course-drag-and-drop'; // User drags and drops a course from the Requirements Bar
+
 /**
  * GTagEvent represents a gtag event.
  * @param gtag is the global site tag that sends events to Google Analytics
  * @param eventType specifies the type of event that the gtag sends
- * eventType === 'logout': User logs out
- *
- * eventType === 'to-compact': User sets the semester view to compact
- *
- * eventType === 'to-not-compact': User sets the semester view to default
- *
- * eventType === 'add-semester': User adds a semester
- *
- * eventType === 'delete-semester': User deletes a semester
- *
- * eventType === 'add-course': User adds a course
- *
- * eventType === 'delete-course': User deletes a course
- *
- * eventType === 'course-edit-color': User edits the course color
- *
- * eventType === 'start-walkthrough': User clicks to start the walkthrough
- *
- * eventType === 'skip-walkthrough': User clicks to skip the walkthrough
- *
- * eventType === 'onboarding-edit-basic-information': User clicks to edit basic info on the review page of Onboarding
- *
- * eventType === 'onboarding-edit-transfer-credits': User clicks to edit transfer credits on the review page of Onboarding
- *
- * eventType === 'bottom-bar-see-all-reviews': User clicks See All Reviews link on Bottom Bar
- *
- * eventType === 'bottom-bar-view-course-information-on-roster': User clicks View Course Information on Roster link on Bottom Bar
- *
- * eventType === 'bottom-bar-see-more': User clicks on the See More tab of the Bottom Bar
- *
- * eventType === 'bottom-bar-delete-tab': User deletes a tab on the Bottom Bar
- *
- * eventType === 'bottom-bar-open': User opens or expands the Bottom Bar
- *
- * eventType === 'bottom-bar-close': User collapses or closes the Bottom Bar
- *
- * eventType === 'add-modal-edit-requirements': User clicks Edit Requirements on Add Modal
- *
- * eventType === 'requirements-bar-filled-requirements-toggle': User toggles the SHOW/HIDE of Filled Requirements section on Requirements Bar
- *
- * eventType === 'requirements-bar-course-drag-and-drop': User drags and drops a course from the Requirements Bar
  */
-export const GTagEvent = (gtag: GTag | undefined, eventType: string): void => {
+export const GTagEvent = (gtag: GTag | undefined, eventType: EventType): void => {
   if (!gtag) return;
   let eventPayload: EventPayload | undefined;
   switch (eventType) {

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -6,11 +6,58 @@ export type GTag = {
   event(eventType: string, eventPayload: LoginEventPayload | EventPayload): void;
 };
 
+/** GTagLoginEvent represents the gtag that tracks when users login. */
 export const GTagLoginEvent = (gtag: GTag | undefined, method: string): void => {
   if (!gtag) return;
   gtag.event('login', { method });
 };
 
+/**
+ * GTagEvent represents a gtag event.
+ * @param gtag is the global site tag that sends events to Google Analytics
+ * @param eventType specifies the type of event that the gtag sends
+ * eventType === 'logout': User logs out
+ *
+ * eventType === 'to-compact': User sets the semester view to compact
+ *
+ * eventType === 'to-not-compact': User sets the semester view to default
+ *
+ * eventType === 'add-semester': User adds a semester
+ *
+ * eventType === 'delete-semester': User deletes a semester
+ *
+ * eventType === 'add-course': User adds a course
+ *
+ * eventType === 'delete-course': User deletes a course
+ *
+ * eventType === 'course-edit-color': User edits the course color
+ *
+ * eventType === 'start-walkthrough': User clicks to start the walkthrough
+ *
+ * eventType === 'skip-walkthrough': User clicks to skip the walkthrough
+ *
+ * eventType === 'onboarding-edit-basic-information': User clicks to edit basic info on the review page of Onboarding
+ *
+ * eventType === 'onboarding-edit-transfer-credits': User clicks to edit transfer credits on the review page of Onboarding
+ *
+ * eventType === 'bottom-bar-see-all-reviews': User clicks See All Reviews link on Bottom Bar
+ *
+ * eventType === 'bottom-bar-view-course-information-on-roster': User clicks View Course Information on Roster link on Bottom Bar
+ *
+ * eventType === 'bottom-bar-see-more': User clicks on the See More tab of the Bottom Bar
+ *
+ * eventType === 'bottom-bar-delete-tab': User deletes a tab on the Bottom Bar
+ *
+ * eventType === 'bottom-bar-open': User opens or expands the Bottom Bar
+ *
+ * eventType === 'bottom-bar-close': User collapses or closes the Bottom Bar
+ *
+ * eventType === 'add-modal-edit-requirements': User clicks Edit Requirements on Add Modal
+ *
+ * eventType === 'requirements-bar-filled-requirements-toggle': User toggles the SHOW/HIDE of Filled Requirements section on Requirements Bar
+ *
+ * eventType === 'requirements-bar-course-drag-and-drop': User drags and drops a course from the Requirements Bar
+ */
 export const GTagEvent = (gtag: GTag | undefined, eventType: string): void => {
   if (!gtag) return;
   let eventPayload: EventPayload | undefined;

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -57,6 +57,83 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: string): void => {
         value: 1,
       };
       break;
+    case 'course-edit-color':
+      eventPayload = {
+        event_category: 'course',
+        event_label: 'edit-color',
+        value: 1,
+      };
+      break;
+    case 'start-walkthrough':
+      eventPayload = {
+        event_category: 'walkthrough',
+        event_label: 'start',
+        value: 1,
+      };
+      break;
+    case 'skip-walkthrough':
+      eventPayload = {
+        event_category: 'walkthrough',
+        event_label: 'skip',
+        value: 1,
+      };
+      break;
+    case 'onboarding-edit-basic-information':
+      eventPayload = {
+        event_category: 'onboarding',
+        event_label: 'edit-basic-information',
+        value: 1,
+      };
+      break;
+    case 'onboarding-edit-transfer-credits':
+      eventPayload = {
+        event_category: 'onboarding',
+        event_label: 'edit-transfer-credits',
+        value: 1,
+      };
+      break;
+    case 'bottom-bar-see-all-reviews':
+      eventPayload = {
+        event_category: 'bottom-bar',
+        event_label: 'see-all-reviews',
+        value: 1,
+      };
+      break;
+    case 'bottom-bar-view-course-information-on-roster':
+      eventPayload = {
+        event_category: 'bottom-bar',
+        event_label: 'view-course-information-on-roster',
+        value: 1,
+      };
+      break;
+    case 'bottom-bar-see-more':
+      eventPayload = {
+        event_category: 'bottom-bar',
+        event_label: 'see-more',
+        value: 1,
+      };
+      break;
+    case 'bottom-bar-delete-tab':
+      eventPayload = {
+        event_category: 'bottom-bar',
+        event_label: 'delete-tab',
+        value: 1,
+      };
+      break;
+    case 'bottom-bar-open':
+      eventPayload = {
+        event_category: 'bottom-bar',
+        event_label: 'open',
+        value: 1,
+      };
+      break;
+    case 'bottom-bar-close':
+      eventPayload = {
+        event_category: 'bottom-bar',
+        event_label: 'close',
+        value: 1,
+      };
+      break;
     default:
       return;
   }


### PR DESCRIPTION
### Summary

This pull request is the first step towards implementing more gtags for launch. 

- [x] Added gtags for the following metrics we want to track based on [this Google Doc](https://docs.google.com/document/d/1l2Gwz8drw0_zFff3prsESFgTJTdZmd5b2YDCjmx8sEQ/edit). Note the text in the parentheses are the eventTypes:
   - Onboarding:
      - [x] # of clicks for “Edit” (onboarding-edit-basic-information, onboarding-edit-transfer-credits)
   - Walkthrough:
      - [x] # of clicks for skipping tutorial (skip-walkthrough)
      - [x] # of clicks for “Finish tutorial”(start-walkthrough)
   - Requirements Bar:
      - [x] # of clicks for “show/hide” Filled Requirements (requirements-bar-filled-requirements-toggle)
      - [x] # of courses dragged and dropped from Req Bar (requirements-bar-course-drag-and-drop)
   - Bottom Bar:
      - [x] # of times “See All Reviews” (bottom-bar-see-all-reviews)
      - [x] # of times for “View Course Information on Roster” (bottom-bar-view-course-information-on-roster)
      - [x] # of times “See More” is pressed (bottom-bar-see-more)
      - [x] # of times press “x” to close tab (accident vs real vs mistake) (bottom-bar-delete-tab)
      - [x] # of times open (= to closed?)) (bottom-bar-open, bottom-bar-close)
   - Course Cards:
      - [x] # of times for “edit color”(course-edit-color)
      - [x] # of times for delete [courtesy of @benjamin-shen] (delete-course)
   - Add Modal:
      - [x] # of times “Edit Requirements” is clicked (add-modal-edit-requirements)
   - Miscellaneous:
      - [x] # of logouts?(logout)
   
- [x] Documentation for the gtag eventTypes


Remaining TODOs:
 - Onboarding:
    - [ ] # of clicks for the “Learn more” link  
 - Requirements Bar:
    - [ ] # of times “See All” is clicked per specific Requirement?? **This may require modifying `GTagEvent`**
    - [ ] # of times Reset is clicked per Requirement **This may require modifying `GTagEvent`**
    - [ ] # of times “Learn more” is clicked (per req?) **This may require modifying `GTagEvent`**
    - [ ] # of times self check dropdown is clicked
    - [ ] # of times “Add course” from self check dropdown is clicked

### Test Plan <!-- Required -->
There should be no changes to the functionality of CP.
- Make sure that Onboarding works as usual (especially clicking "Edit" in the Onboarding Review page)
- Go through Walkthrough
- Ensure toggling of Filled Requirements and drag&drop of req courses are unchanged
- Bottom bar: adding new tabs, deleting tabs, collapsing/expanding bottom bar, clicking the links, See More tab
- Course cards: editing course color
- Add Modal: Editing requirements should be unchanged
- Logout should be unchanged

### Notes

It seems that gtags pushed to prod are the ones that show up on our Google Analytics dashboard so I don't know if there is a way we can test that these gtags work locally. I will explore this, but everything seems to type check.