### PR TITLE
Do not show ineligible courses in self-check add course modal

### DIFF
--- a/src/components/Modals/NewCourse/CourseSelector.vue
+++ b/src/components/Modals/NewCourse/CourseSelector.vue
@@ -24,17 +24,21 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
 import { fullCoursesArray } from '@/assets/courses/typed-full-courses';
 
-const getMatchingCourses = (searchText: string): readonly CornellCourseRosterCourse[] => {
+const getMatchingCourses = (
+  searchText: string,
+  filter?: (course: CornellCourseRosterCourse) => boolean
+): readonly CornellCourseRosterCourse[] => {
   // search after value length of 2 to reduce search times of courses
   if (!searchText || searchText.length < 2) return [];
   /* code array for results that contain course code and title array for results that contain title */
   const code: CornellCourseRosterCourse[] = [];
   const title: CornellCourseRosterCourse[] = [];
 
-  for (const course of fullCoursesArray) {
+  const filteredCourses = filter != null ? fullCoursesArray.filter(filter) : fullCoursesArray;
+  for (const course of filteredCourses) {
     const courseCode = `${course.subject} ${course.catalogNbr}`;
     if (courseCode.toUpperCase().includes(searchText)) {
       code.push(course);
@@ -56,6 +60,10 @@ export default Vue.extend({
   props: {
     searchBoxClassName: { type: String, required: true },
     placeholder: { type: String, required: true },
+    courseFilter: {
+      type: Function as PropType<((course: CornellCourseRosterCourse) => boolean) | undefined>,
+      default: undefined,
+    },
     autoFocus: { type: Boolean, required: true },
   },
   data() {
@@ -66,7 +74,7 @@ export default Vue.extend({
   },
   computed: {
     matches(): readonly CornellCourseRosterCourse[] {
-      return getMatchingCourses(this.searchText.toUpperCase());
+      return getMatchingCourses(this.searchText.toUpperCase(), this.courseFilter);
     },
   },
   mounted() {

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -3,6 +3,7 @@
     <new-self-check-course-modal
       class="incompleteselfcheck-modal"
       :class="{ 'incompleteselfcheck-modal--block': isCourseModalOpen }"
+      :requirementId="subReqId"
       @close-course-modal="closeCourseModal"
       @add-course="addNewCourse"
       ref="modal"


### PR DESCRIPTION
### Summary <!-- Required -->

Resolve task 3 in [this notion item](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=a203824189894848bd7ce9275674aa96).

It adds an optional filter to `course-selector`, and make `new-self-check-course-modal` pass in the filter.

### Test Plan <!-- Required -->

correctly filtered
<img width="1080" alt="Screen Shot 2021-03-24 at 12 30 46" src="https://user-images.githubusercontent.com/4290500/112347689-7542d380-8c9d-11eb-8e36-0724b4da4905.png">
true self-check not affected
<img width="1101" alt="Screen Shot 2021-03-24 at 12 33 11" src="https://user-images.githubusercontent.com/4290500/112347692-75db6a00-8c9d-11eb-8227-f64e74476fff.png">
