### PR TITLE
Accessibility 6/n - Added alt attribute to all imgs

### DIFF
--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -12,7 +12,7 @@
       class="bottombartab-delete"
       src="@/assets/images/x-white.svg"
       @click.stop="$emit('on-delete')"
-      alt="x"
+      alt="x to delete bottom bar tab"
     />
   </div>
 </template>

--- a/src/components/BottomBar/BottomBarTabView.vue
+++ b/src/components/BottomBar/BottomBarTabView.vue
@@ -24,13 +24,13 @@
           v-if="!seeMoreOpen"
           class="bottombarSeeMoreTab-arrow"
           src="@/assets/images/uparrow-white.svg"
-          alt="expand see more"
+          alt="expand see more bottom bar tabs"
         />
         <img
           v-if="seeMoreOpen"
           class="bottombarSeeMoreTab-arrow"
           src="@/assets/images/downarrow-white.svg"
-          alt="collapse see more"
+          alt="collapse see more bottom bar tabs"
         />
       </div>
       <div v-if="seeMoreOpen" class="bottombarSeeMoreOptions">
@@ -49,7 +49,7 @@
               class="seeMoreCourse-option-delete"
               src="@/assets/images/x-blue.svg"
               @click="deleteBottomBarCourse(index + maxBottomBarTabs, $gtag)"
-              alt="x"
+              alt="x to delete bottom bar tab"
             />
           </div>
         </div>

--- a/src/components/BottomBar/BottomBarTitle.vue
+++ b/src/components/BottomBar/BottomBarTitle.vue
@@ -5,13 +5,13 @@
       v-if="!isExpanded"
       class="bottombartitle-arrow"
       src="@/assets/images/uparrow-white.svg"
-      alt="collapse bottom bar class"
+      alt="collapse bottom bar"
     />
     <img
       v-if="isExpanded"
       class="bottombartitle-arrow"
       src="@/assets/images/downarrow-white.svg"
-      alt="expand bottom bar class"
+      alt="expand bottom bar"
     />
   </div>
 </template>

--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -1,14 +1,14 @@
 <template>
   <div :class="{ 'course--min': compact, active: active }" class="course" @click="courseOnClick()">
     <div class="course-color" :style="cssVars" :class="{ 'course-color--active': active }">
-      <img src="@/assets/images/dots/sixDots.svg" alt="dots" />
+      <img src="@/assets/images/dots/sixDots.svg" alt="" />
     </div>
     <div class="course-content">
       <div class="course-main">
         <div class="course-top">
           <div class="course-code">{{ courseObj.code }}</div>
           <div v-if="!isReqCourse" class="course-dotRow" @click="openMenu">
-            <img src="@/assets/images/dots/threeDots.svg" alt="dots" />
+            <img src="@/assets/images/dots/threeDots.svg" alt="open menu for course card" />
           </div>
         </div>
         <div v-if="!compact" class="course-name">{{ courseObj.name }}</div>

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -6,12 +6,26 @@
         @mouseover="setDisplayColors(true)"
         @mouseleave="setDisplayColors(false)"
       >
-        <img v-if="isLeft" class="courseMenu-arrow" src="@/assets/images/sidearrowleft.svg" />
+        <img
+          v-if="isLeft"
+          class="courseMenu-arrow"
+          src="@/assets/images/sidearrowleft.svg"
+          alt="arrow to expand edit course color"
+        />
         <div class="courseMenu-left">
-          <img class="courseMenu-icon" src="@/assets/images/paint.svg" />
+          <img
+            class="courseMenu-icon"
+            src="@/assets/images/paint.svg"
+            alt="edit course color paint icon"
+          />
           <span class="courseMenu-text">Edit Color</span>
         </div>
-        <img v-if="!isLeft" class="courseMenu-arrow" src="@/assets/images/sidearrow.svg" />
+        <img
+          v-if="!isLeft"
+          class="courseMenu-arrow"
+          src="@/assets/images/sidearrow.svg"
+          alt="arrow to expand edit course color"
+        />
 
         <div
           v-if="displayColors"
@@ -40,16 +54,27 @@
         @mouseleave="setDisplayEditCourseCredits(false)"
         v-if="getCreditRange[0] != getCreditRange[1]"
       >
-        <img v-if="isLeft" class="courseMenu-arrow" src="@/assets/images/sidearrowleft.svg" />
+        <img
+          v-if="isLeft"
+          class="courseMenu-arrow"
+          src="@/assets/images/sidearrowleft.svg"
+          alt="arrow to expand edit course credits"
+        />
         <div class="courseMenu-left">
           <img
             class="courseMenu-icon"
             :class="{ 'courseMenu-icon--left': isLeft }"
             src="@/assets/images/edit-credits.svg"
+            alt="edit course credits icon"
           />
           <span class="courseMenu-text">Edit Credits</span>
         </div>
-        <img v-if="!isLeft" class="courseMenu-arrow" src="@/assets/images/sidearrow.svg" />
+        <img
+          v-if="!isLeft"
+          class="courseMenu-arrow"
+          src="@/assets/images/sidearrow.svg"
+          alt="arrow to expand edit course credits"
+        />
         <div
           v-if="displayEditCourseCredits"
           class="courseMenu-content courseMenu-editCredits courseMenu-centerCredits"
@@ -73,7 +98,11 @@
         @click="deleteCourse"
       >
         <div class="courseMenu-left">
-          <img class="courseMenu-icon" src="@/assets/images/trash.svg" />
+          <img
+            class="courseMenu-icon"
+            src="@/assets/images/trash.svg"
+            alt="delete course trashcan icon"
+          />
           <span class="courseMenu-text">Delete</span>
         </div>
       </div>

--- a/src/components/Modals/DeleteSemester.vue
+++ b/src/components/Modals/DeleteSemester.vue
@@ -7,6 +7,7 @@
           class="deleteSemesterModal-exit"
           src="@/assets/images/x.png"
           @click="closeCurrentModal"
+          alt="x to close delete semester modal"
         />
       </div>
       <div class="deleteSemesterModal-body">
@@ -24,6 +25,7 @@
             <img
               class="deleteSemesterModal-button-left-icon"
               src="@/assets/images/trash-white.svg"
+              alt="delete semester trashcan icon"
             />
             <span class="deleteSemesterModal-button-left-text">Delete</span>
           </div>

--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -7,6 +7,7 @@
           class="editSemesterModal-exit"
           src="@/assets/images/x.png"
           @click="closeCurrentModal"
+          alt="x to close edit semester modal"
         />
       </div>
       <div class="editSemesterModal-body">

--- a/src/components/Modals/FlexibleModal.vue
+++ b/src/components/Modals/FlexibleModal.vue
@@ -3,7 +3,12 @@
     <div :class="['modal-content', contentClass]">
       <div class="modal-top">
         <h1>{{ title }}</h1>
-        <img class="modal-exit" src="@/assets/images/x.png" @click="closeCurrentModal" />
+        <img
+          class="modal-exit"
+          src="@/assets/images/x.png"
+          @click="closeCurrentModal"
+          alt="x to close modal"
+        />
       </div>
       <slot class="modal-body"></slot>
       <div class="modal-buttonWrapper">

--- a/src/components/Modals/NewCourse/RequirementsDropdown.vue
+++ b/src/components/Modals/NewCourse/RequirementsDropdown.vue
@@ -10,7 +10,7 @@
       v-if="potentialRequirements.some(req => req.id === selectedID)"
     >
       <div class="warning-row">
-        <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning-icon" />
+        <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning icon" />
         {{ selected }}
       </div>
       <drop-down-arrow :isFlipped="showDropdown" :fillColor="emGreen" />
@@ -42,7 +42,7 @@
           @keyup.enter="toggleSelectRequirement(option.id)"
           tabindex="0"
         >
-          <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning-icon" />
+          <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning icon" />
           {{ option.name }}
         </a>
       </li>

--- a/src/components/Modals/NewCourse/SelectedRequirementEditor.vue
+++ b/src/components/Modals/NewCourse/SelectedRequirementEditor.vue
@@ -29,7 +29,7 @@
       </div>
       <div v-else>
         <div v-if="potentialRequirements.length > 0" class="warning">
-          <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning-icon" />
+          <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning icon" />
           We cannot accurately check the requirements marked with the warning icon, so double check
           before selecting.
         </div>

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -36,7 +36,11 @@
               class="newSemester-dropdown-content-item"
               @click="selectSeason(season[1])"
             >
-              <img :src="season[0]" class="newSemester-dropdown-content-season" />
+              <img
+                :src="season[0]"
+                class="newSemester-dropdown-content-season"
+                :alt="`${season[1]} icon`"
+              />
               {{ season[1] }}
             </div>
           </div>

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -2,7 +2,11 @@
   <div class="onboarding" @click="checkClickOutside" ref="modalBackground">
     <div class="onboarding-main">
       <div v-if="isEditingProfile" class="onboarding-cancel" @click="cancel">
-        <img class="onboarding-cancel-icon" src="@/assets/images/x.svg" alt="X" />
+        <img
+          class="onboarding-cancel-icon"
+          src="@/assets/images/x.svg"
+          alt="x to close onboarding modal"
+        />
       </div>
       <div class="onboarding-content" :class="{ editing: isEditingProfile }">
         <div class="onboarding-top">
@@ -57,7 +61,7 @@
           <img
             class="timeline"
             :src="require(`@/assets/images/timeline${currentPage}text.svg`)"
-            alt="X"
+            alt="onboarding progress timeline"
           />
         </div>
         <div v-if="currentPage === 3" class="onboarding-bottom--section">

--- a/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
@@ -38,7 +38,7 @@
         'onboarding--hidden': cannotBeRemoved,
       }"
     >
-      <img src="@/assets/images/x-green.svg" alt="x" />
+      <img src="@/assets/images/x-green.svg" alt="x to delete dropdown" />
     </div>
   </div>
 </template>

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -5,7 +5,7 @@
         <span class="onboarding-subHeader--font"> Basic Information</span>
         <span>
           <button class="onboarding-button-previous" @click="editBasicInformation()">
-            <img src="@/assets/images/edit-review.svg" alt="edit" />
+            <img src="@/assets/images/edit-review.svg" alt="edit icon" />
           </button>
         </span>
       </div>
@@ -75,7 +75,7 @@
         <span class="onboarding-subHeader--font"> Transfer Credits</span>
         <span>
           <button class="onboarding-button-previous" @click="editTransferCredits()">
-            <img src="@/assets/images/edit-review.svg" />
+            <img src="@/assets/images/edit-review.svg" alt="edit icon" />
           </button>
         </span>
       </div>
@@ -86,7 +86,11 @@
         <div class="onboarding-selectWrapper">
           <div class="onboarding-selectWrapper-review">
             <label class="onboarding-label">
-              <img class="checkmark" src="@/assets/images/checkmark-onboarding.svg" />
+              <img
+                class="checkmark"
+                src="@/assets/images/checkmark-onboarding.svg"
+                alt="checkmark"
+              />
               {{ onboardingData.tookSwim === 'yes' ? 'Yes' : 'No' }}
             </label>
           </div>

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -43,7 +43,10 @@
                         examsAP.length === 1 && exam.subject === placeholderText,
                     }"
                   >
-                    <img src="@/assets/images/x-green.svg" alt="x" />
+                    <img
+                      src="@/assets/images/x-green.svg"
+                      :alt="`x to remove AP exam ${exam.type} ${exam.subject}`"
+                    />
                   </div>
                 </div>
               </div>
@@ -85,7 +88,10 @@
                         examsIB.length === 1 && exam.subject === placeholderText,
                     }"
                   >
-                    <img src="@/assets/images/x-green.svg" alt="x" />
+                    <img
+                      src="@/assets/images/x-green.svg"
+                      :alt="`x to remove IB exam ${exam.type} ${exam.subject}`"
+                    />
                   </div>
                 </div>
               </div>
@@ -124,7 +130,7 @@
                       (options.class == placeholderText || options.class == null),
                   }"
                 >
-                  <img src="@/assets/images/x-green.svg" alt="x" />
+                  <img src="@/assets/images/x-green.svg" alt="x to remove transfer class" />
                 </div>
               </div>
             </div>

--- a/src/components/Modals/SemesterMenu.vue
+++ b/src/components/Modals/SemesterMenu.vue
@@ -4,7 +4,11 @@
       <div class="semesterMenu-content">
         <div class="semesterMenu-content" @click="openEditSemesterModal">
           <div class="semesterMenu-left">
-            <img class="semesterMenu-icon" src="@/assets/images/edit.svg" />
+            <img
+              class="semesterMenu-icon"
+              src="@/assets/images/edit.svg"
+              alt="edit semester pencil icon"
+            />
             <span class="semesterMenu-edit">Edit Semester</span>
           </div>
         </div>
@@ -14,7 +18,11 @@
       <div class="semesterMenu-content">
         <div class="semesterMenu-content" @click="openDeleteSemesterModal">
           <div class="semesterMenu-left">
-            <img class="semesterMenu-icon" src="@/assets/images/trash.svg" />
+            <img
+              class="semesterMenu-icon"
+              src="@/assets/images/trash.svg"
+              alt="delete semester trashcan icon"
+            />
             <span class="semesterMenu-delete">Delete Semester</span>
           </div>
         </div>

--- a/src/components/Requirements/ReqCourse.vue
+++ b/src/components/Requirements/ReqCourse.vue
@@ -10,7 +10,7 @@
       :style="courseColorCSSvar"
       :class="{ 'reqcourse-color--min': compact }"
     >
-      <img src="@/assets/images/dots/sixDots.svg" alt="dots" />
+      <img src="@/assets/images/dots/sixDots.svg" alt="" />
     </div>
     <div :class="{ 'reqcourse-content--min': compact }" class="reqcourse-content">
       <div :class="{ 'reqcourse-main--min': compact }" class="reqcourse-main">

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -214,9 +214,9 @@ export default Vue.extend({
       this.displayedMinorIndex = id;
     },
     getRequirementsTooltipText() {
-      return `<div class="introjs-tooltipTop"><div class="introjs-customTitle">Meet your Requirements Bar <img src="${clipboard}" class = "introjs-emoji newSemester-emoji-text" alt="clipboard-icon"/>
+      return `<div class="introjs-tooltipTop"><div class="introjs-customTitle">Meet your Requirements Bar <img src="${clipboard}" class = "introjs-emoji newSemester-emoji-text" alt="clipboard icon"/>
           </div><div class="introjs-customProgress">1/4</div></div><div class = "introjs-bodytext">Based on your school and major/minor, we’ve compiled your requirements and
-          required courses.<br><img src="${warning}" class = "newSemester-emoji-text" alt="warning-icon"/> Some requirements
+          required courses.<br><img src="${warning}" class = "newSemester-emoji-text" alt="warning icon"/> Some requirements
           aren’t fully tracked by us yet, so pay attention to the warnings.</div>`;
     },
     getCoursesTooltipText() {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -51,7 +51,7 @@
         <img
           class="requirement-checker-warning-icon"
           src="@/assets/images/warning.svg"
-          alt="warning-icon"
+          alt="warning icon"
         />
         {{ subReq.requirement.checkerWarning }}
       </div>

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -50,7 +50,7 @@
         </div>
         <div class="semester-right" :class="{ 'semester-right--compact': compact }">
           <div class="semester-dotRow" @click="openSemesterMenu">
-            <img src="@/assets/images/dots/threeDots.svg" alt="dots" />
+            <img src="@/assets/images/dots/threeDots.svg" alt="open menu for semester" />
           </div>
         </div>
       </div>

--- a/src/components/Semester/SemesterCaution.vue
+++ b/src/components/Semester/SemesterCaution.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="caution">
     <div class="caution-left">
-      <img class="caution-icon" src="@/assets/images/caution-white.svg" />
+      <img class="caution-icon" src="@/assets/images/caution-white.svg" alt="caution icon" />
     </div>
     <div class="caution-text">{{ text }}</div>
     <div class="caution-right">

--- a/src/containers/Login.vue
+++ b/src/containers/Login.vue
@@ -52,7 +52,7 @@
           <div class="col-12 col-md-6 tasks-wrapper">
             <div class="row tasks">
               <div class="col-1 tasks">
-                <img src="@/assets/images/Task1.svg" alt="checklist" />
+                <img src="@/assets/images/Task1.svg" alt="checklist icon" />
               </div>
               <div class="col-11">
                 <p class="sub sub--task">Fully personalized to track your requirements</p>
@@ -60,7 +60,7 @@
             </div>
             <div class="row tasks">
               <div class="col-1 tasks">
-                <img src="@/assets/images/Task2.svg" alt="browser" />
+                <img src="@/assets/images/Task2.svg" alt="browser icon" />
               </div>
               <div class="col-11">
                 <p class="sub sub--task">Customizable interface to view your courses</p>
@@ -68,7 +68,7 @@
             </div>
             <div class="row tasks">
               <div class="col-1 tasks">
-                <img src="@/assets/images/Task3.svg" alt="Network" />
+                <img src="@/assets/images/Task3.svg" alt="Network icon" />
               </div>
               <div class="col-11">
                 <p class="sub sub--task">Built-in system to check your progress</p>
@@ -76,7 +76,7 @@
             </div>
             <div class="row tasks">
               <div class="col-1 tasks">
-                <img src="@/assets/images/Task4.svg" alt="Starred comment" />
+                <img src="@/assets/images/Task4.svg" alt="Starred comment icon" />
               </div>
               <div class="col-11">
                 <p class="sub sub--task">Recommends courses based on your needs</p>


### PR DESCRIPTION
### Summary

This pull request adds the `alt` attribute to all `img` tags. In cases where the `img` does not have any meaning, `alt=""`. 

- [x] added `alt` attribute to all `img` tags
- [x] if `img` does not have any meaning, `alt=""`
- [x] changed some values of `alt` to be more meaningful (e.g. `alt` values of the X image to close out of modals, delete bottom bar tabs, etc.) 

### Test Plan
Nothing should change visually. Go through the site, click on bottom bar, etc. to make sure that `img`s all appear as normal.

### Notes

**Please add `alt` attribute for `img`s moving forward. **