### PR TITLE
Add semester year dropdown fixes

### DIFF
--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -74,6 +74,7 @@
             <div
               v-for="yearChoice in years"
               :key="yearChoice"
+              ref="yearRef"
               class="newSemester-dropdown-content-item"
               @click="selectYear(yearChoice)"
             >
@@ -116,6 +117,9 @@ type Data = {
   };
 };
 
+const yearScrollIndex = 4;
+const yearRange = 6;
+
 export default Vue.extend({
   props: {
     currentSemesters: {
@@ -137,8 +141,8 @@ export default Vue.extend({
       [winter, 'Winter'],
     ] as const;
     const years = [];
-    let startYear = currentYear - 10;
-    while (startYear <= currentYear + 10) {
+    let startYear = currentYear - yearRange;
+    while (startYear <= currentYear + yearRange) {
       years.push(startYear);
       startYear += 1;
     }
@@ -210,6 +214,14 @@ export default Vue.extend({
       } else {
         displayOptions.boxBorder = yuxuanBlue;
         displayOptions.arrowColor = yuxuanBlue;
+      }
+
+      // scroll to the middle of the year div after visible (on the next tick)
+      if (!contentShown && type === 'year') {
+        this.$nextTick(() => {
+          const el = (this.$refs.yearRef as Element[])[yearScrollIndex];
+          el.scrollIntoView({ behavior: 'auto' });
+        });
       }
     },
     showHideSeasonContent() {
@@ -422,7 +434,7 @@ export default Vue.extend({
   }
 
   &-dropdown-content {
-    max-height: 140px;
+    max-height: 8rem;
 
     background: #ffffff;
     box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
### Summary <!-- Required -->

Update the year dropdown in the add semester modal ([Notion](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=d946c24c7b2a42f8a52bb2a9db568982))

- [x] Autoscroll to the 5th year (so 2019 currently)
- [x] Limit years to +- 6 (so 2015 - 2027 currently)

![image](https://user-images.githubusercontent.com/25535093/112548301-638f2800-8d92-11eb-9fca-4b26af5301b9.png)

### Test Plan <!-- Required -->

1. Confirm the year range is from 2015-2027
2. Confirm that the scroll to 2019 occurs immediately after opening without delay

### Notes <!-- Optional -->

The scrolling code is a little hacky, so please let me know if there are any better ways to do this! This seemed like the best way to do it without using more excessive DOM manipulation.
