### PR TITLE
Do not show ineligible requirement in add modal

### DIFF
--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -252,13 +252,10 @@ export function getRelatedUnfulfilledRequirements(
         toggleableRequirementChoices
       );
       // potential self-check requirements
-      if (
-        (requirementSpec == null || subRequirement.checkerWarning != null) &&
-        !subRequirement.allowCourseDoubleCounting
-      ) {
+      if (requirementSpec == null && !subRequirement.allowCourseDoubleCounting) {
         selfCheckRequirements.push(subRequirement);
       }
-      if (requirementSpec != null && subRequirement.checkerWarning == null) {
+      if (requirementSpec != null) {
         const allEligibleCourses = requirementSpec.eligibleCourses.flat();
         if (allEligibleCourses.includes(courseId)) {
           const fulfillmentStatisticsWithNewCourse = computeFulfillmentCoursesAndStatistics(


### PR DESCRIPTION
### Summary <!-- Required -->

Remove the special case for requirement with checker warnings. In this way, we can natually filter away requirements that cannot be fulfilled by the course.

### Test Plan <!-- Required -->

Technical elective no longer shows up since it's not 3000+ level class.
<img width="460" alt="Screen Shot 2021-03-25 at 20 22 22" src="https://user-images.githubusercontent.com/4290500/112559750-07370300-8da8-11eb-8bfe-eacd5ba4aa3d.png">