### PR TITLE
[EZ Bug fix] Don't allow user to close onboarding if college isn't chosen

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -176,10 +176,12 @@ export default Vue.extend({
       };
     },
     cancel() {
-      this.$emit('cancelOnboarding');
+      if (this.onboarding.college !== '') {
+        this.$emit('cancelOnboarding');
+      }
     },
     checkClickOutside(e: MouseEvent) {
-      if (e.target === this.$refs.modalBackground && this.onboarding.college !== null) {
+      if (e.target === this.$refs.modalBackground && this.onboarding.college !== '') {
         this.cancel();
       }
     },

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -179,7 +179,9 @@ export default Vue.extend({
       this.$emit('cancelOnboarding');
     },
     checkClickOutside(e: MouseEvent) {
-      if (e.target === this.$refs.modalBackground) this.cancel();
+      if (e.target === this.$refs.modalBackground && this.onboarding.college !== null) {
+        this.cancel();
+      }
     },
   },
 });


### PR DESCRIPTION
### Summary
This PR prevents the user from leaving the onboarding modal if they don't have a college chosen.
[Bug description on notion](https://www.notion.so/courseplan/Closing-Onboarding-Modal-2381a40023ac4804a5fed6588d5daa7a)

### Test Plan
- Delete your firebase data and try to leave onboarding before completing everything. (You shouldn't be able to)

### Notes
I decided to use `this.onboarding.college !== ''` because `isEditingProfile` isn't what we need for this. and `isError` is only calculated once you press Finish so it isn't useful on step 1. TBH this is my first time really looking at onboarding and I think the whole thing can be refactored to use a hook and just be more concise and understandable overall. (i've fleshed out 2 onboarding flows in my lifetime (but both were in React, so it's possible Vue might just be bad.))

