### PR TITLE
Add dry-run option for data migration script

### DIFF
--- a/functions/split-user-data.js
+++ b/functions/split-user-data.js
@@ -17,24 +17,70 @@ const subjectColorsCollection = db.collection('user-subject-colors');
 const uniqueIncrementerCollection = db.collection('user-unique-incrementer');
 const onboardingDataCollection = db.collection('user-onboarding-data');
 
-userDataCollection.get().then(userData => {
-  Promise.all(
-    userData.docs.map(userDataDocument => {
-      const batch = db.batch();
+if (process.argv[2] === '--dry-run') {
+  userDataCollection.get().then(userData => {
+    const oldData = [];
+    const newUsernameCollection = {};
+    const newSemestersCollection = {};
+    const newToggleableRequirementChoicesCollection = {};
+    const newSubjectColorsCollection = {};
+    const newUniqueIncrementerCollection = {};
+    const newOnboardingDataCollection = {};
+    userData.docs.forEach(userDataDocument => {
       const data = userDataDocument.data();
-      batch.set(usernameCollection.doc(userDataDocument.id), data.name);
-      batch.set(semestersCollection.doc(userDataDocument.id), { semesters: data.semesters });
-      batch.set(
-        toggleableRequirementChoicesCollection.doc(userDataDocument.id),
-        data.toggleableRequirementChoices || {}
-      );
-      batch.set(subjectColorsCollection.doc(userDataDocument.id), data.subjectColors || {});
-      batch.set(uniqueIncrementerCollection.doc(userDataDocument.id), {
+      oldData.push(data);
+
+      newUsernameCollection[userDataDocument.id] = data.name;
+      newSemestersCollection[userDataDocument.id] = { semesters: data.semesters };
+      newToggleableRequirementChoicesCollection[userDataDocument.id] =
+        data.toggleableRequirementChoices || {};
+      newSubjectColorsCollection[userDataDocument.id] = data.subjectColors || {};
+      newUniqueIncrementerCollection[userDataDocument.id] = {
         uniqueIncrementer: data.uniqueIncrementer || 0,
-      });
-      batch.set(onboardingDataCollection.doc(userDataDocument.id), data.userData);
-      batch.delete(userDataDocument.ref);
-      return batch.commit();
-    })
-  );
-});
+      };
+      newOnboardingDataCollection[userDataDocument.id] = data.userData;
+    });
+
+    fs.writeFileSync('old.json', JSON.stringify(oldData, undefined, 2));
+    fs.writeFileSync('new-usernames.json', JSON.stringify(newUsernameCollection, undefined, 2));
+    fs.writeFileSync('new-semesters.json', JSON.stringify(newSemestersCollection, undefined, 2));
+    fs.writeFileSync(
+      'new-toggleable.json',
+      JSON.stringify(newToggleableRequirementChoicesCollection, undefined, 2)
+    );
+    fs.writeFileSync(
+      'new-subject-color.json',
+      JSON.stringify(newSubjectColorsCollection, undefined, 2)
+    );
+    fs.writeFileSync(
+      'new-unique-incrementer.json',
+      JSON.stringify(newUniqueIncrementerCollection, undefined, 2)
+    );
+    fs.writeFileSync(
+      'new-onboarding.json',
+      JSON.stringify(newOnboardingDataCollection, undefined, 2)
+    );
+  });
+} else {
+  userDataCollection.get().then(userData => {
+    Promise.all(
+      userData.docs.map(userDataDocument => {
+        const batch = db.batch();
+        const data = userDataDocument.data();
+        batch.set(usernameCollection.doc(userDataDocument.id), data.name);
+        batch.set(semestersCollection.doc(userDataDocument.id), { semesters: data.semesters });
+        batch.set(
+          toggleableRequirementChoicesCollection.doc(userDataDocument.id),
+          data.toggleableRequirementChoices || {}
+        );
+        batch.set(subjectColorsCollection.doc(userDataDocument.id), data.subjectColors || {});
+        batch.set(uniqueIncrementerCollection.doc(userDataDocument.id), {
+          uniqueIncrementer: data.uniqueIncrementer || 0,
+        });
+        batch.set(onboardingDataCollection.doc(userDataDocument.id), data.userData);
+        batch.delete(userDataDocument.ref);
+        return batch.commit();
+      })
+    );
+  });
+}

--- a/functions/update-user-data-courses.js
+++ b/functions/update-user-data-courses.js
@@ -7,34 +7,44 @@ admin.initializeApp({
   databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
 });
 
-const filteredCoursesPaths = fs.readdirSync('./filtered_courses/');
-
-const filteredAllCourses = filteredCoursesPaths
-  .map(path => require('./filtered_courses/' + path))
-  .reduce((accum, currentValue) => Object.assign(accum, currentValue));
+const filteredAllCourses = Object.values(
+  JSON.parse(fs.readFileSync('../src/assets/courses/full-courses.json').toString())
+).flat();
 
 const db = admin.firestore();
 const userDataCollection = db.collection('userData');
 
-userDataCollection.get().then(userData => {
-  Promise.all(
-    userData.docs.map(userDataDocument => {
-      const data = userDataDocument.data();
-      return userDataDocument.ref.set({
-        ...data,
-        semesters: data.semesters.map(semester => ({
-          ...semester,
-          courses: semester.courses.map(course => {
-            const { code, lastRoster } = course;
-            const [subject, number] = code.split(' ');
-            const crseId = filteredAllCourses[lastRoster].find(
-              it => it.subject === subject && it.catalogNbr === number
-            ).crseId;
-            if (crseId == null) throw new Error(`${lastRoster}, ${subject}, ${number}, ${crseId}`);
-            return { ...course, crseId };
-          }),
-        })),
-      });
-    })
-  );
+const transformData = data => ({
+  ...data,
+  semesters: data.semesters.map(semester => ({
+    ...semester,
+    courses: semester.courses.map(course => {
+      const { code } = course;
+      const [subject, number] = code.split(' ');
+      const fullCourse = filteredAllCourses.find(
+        it => it.subject === subject && it.catalogNbr === number
+      );
+      const crseId = fullCourse && fullCourse.crseId;
+      if (crseId == null) throw new Error(`user=${data.id}, subject=${subject}, number=${number}`);
+      return { ...course, crseId };
+    }),
+  })),
 });
+
+if (process.argv[2] === '--dry-run') {
+  userDataCollection.get().then(userData => {
+    const oldUserData = userData.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const newUserData = oldUserData.map(transformData);
+    fs.writeFileSync('old.json', JSON.stringify(oldUserData, undefined, 2));
+    fs.writeFileSync('new.json', JSON.stringify(newUserData, undefined, 2));
+  });
+  return;
+} else {
+  userDataCollection.get().then(userData => {
+    Promise.all(
+      userData.docs.map(userDataDocument =>
+        userDataDocument.ref.set(transformData(userDataDocument.data()))
+      )
+    );
+  });
+}


### PR DESCRIPTION
### Summary <!-- Required -->

As discussed in the meeting, it helps to add dry run options to help increase the confidence of data migration.
Now these scripts are runnable via `node [script.js] --dry-run`.

The dry-run option will write the changes to a file instead of actually writing to the database.

### Test Plan <!-- Required -->

Cannot test now since I don't have prod credential. @tcho6319 can you help test this?

### Notes

It will be easier to review if you turn the option hide whitespace changes on
<img width="292" alt="Screen Shot 2021-03-27 at 11 06 20" src="https://user-images.githubusercontent.com/4290500/112725037-7ae22880-8eec-11eb-8147-bf9d48a58ef0.png">
