### PR TITLE
Bottom Bar Fixes

### DIFF
--- a/src/components/BottomBar/BottomBarCourseReview.vue
+++ b/src/components/BottomBar/BottomBarCourseReview.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="details">
     <div class="details-ratings-link-wrapper">
-      <a :href="CURLink" class="details-ratings-link" target="_blank" @click="clickSeeAllReviews()"
-        >See All Reviews</a
+      <a :href="CURLink" class="details-ratings-link" target="_blank" @click="clickCUReviewsLink()"
+        >Learn more on CUReviews</a
       >
     </div>
     <div class="details-ratings-wrapper">
@@ -105,8 +105,8 @@ export default Vue.extend({
       return flip ? colors[colors.length - 1 - index] : colors[index];
     },
 
-    clickSeeAllReviews(): void {
-      GTagEvent(this.$gtag, 'bottom-bar-see-all-reviews');
+    clickCUReviewsLink(): void {
+      GTagEvent(this.$gtag, 'bottom-bar-CU-reviews-link');
     },
   },
 
@@ -194,6 +194,12 @@ export default Vue.extend({
 .rating {
   width: 100%;
   border-radius: 100px;
+}
+
+.info {
+  &-fact {
+    color: $primaryGray;
+  }
 }
 
 @media only screen and (max-width: $medium-breakpoint) {

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -59,7 +59,8 @@ const getReviews = (
 export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
   for (let i = 0; i < vueForBottomBar.bottomCourses.length; i += 1) {
     const existingCourse = vueForBottomBar.bottomCourses[i];
-    if (existingCourse.uniqueID === course.uniqueID) {
+    // Must check both uniqueID and code (e.g. CS 1110) to handle req courses that share uniqueID -1
+    if (existingCourse.uniqueID === course.uniqueID && existingCourse.code === course.code) {
       vueForBottomBar.bottomCourseFocus = i;
       return;
     }

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -55,7 +55,7 @@ const getReviews = (
   fetch('https://www.cureviews.org/v2/getCourseByInfo', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ subject: subject.toLowerCase(), number: number }),
+    body: JSON.stringify({ subject: subject.toLowerCase(), number }),
   }).then(res => res.json().then(reviews => reviews.result));
 
 export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -52,9 +52,11 @@ const getReviews = (
   classDifficulty: number;
   classWorkload: number;
 }> =>
-  fetch(`https://www.cureviews.org/classInfo/${subject}/${number}/CY0LG2ukc2EOBRcoRbQy`).then(res =>
-    res.json().then(reviews => reviews[0])
-  );
+  fetch('https://www.cureviews.org/v2/getCourseByInfo', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ subject: subject.toLowerCase(), number: number }),
+  }).then(res => res.json().then(reviews => reviews.result));
 
 export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
   for (let i = 0; i < vueForBottomBar.bottomCourses.length; i += 1) {

--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    class="bottombartab"
-    :style="{ background: `#${color}` }"
-    :class="{ inactive: !isBottomCourseFocus }"
-    @click="$emit('on-change-focus')"
-  >
+  <div class="bottombartab" :style="{ background: `#${color}` }" @click="$emit('on-change-focus')">
     <div class="bottombartab-wrapper">
       <div class="bottombartab-name">{{ courseObj.code }}</div>
     </div>
@@ -29,12 +24,6 @@ export default Vue.extend({
     bottomCourseFocus: { type: Number, required: true },
     isExpanded: { type: Boolean, required: true },
   },
-
-  computed: {
-    isBottomCourseFocus(): boolean {
-      return this.tabIndex === this.bottomCourseFocus;
-    },
-  },
 });
 </script>
 
@@ -45,7 +34,7 @@ export default Vue.extend({
   position: relative;
   width: 11.5rem;
   height: 1.75rem;
-  background-color: #25a2aa;
+  background-color: $yuxuanBlue;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
   display: flex;
@@ -74,7 +63,7 @@ export default Vue.extend({
   }
 
   &-name {
-    color: white;
+    color: $white;
     font-weight: 500;
     font-size: 16px;
     line-height: 20px;
@@ -85,11 +74,6 @@ export default Vue.extend({
     height: 50%;
     cursor: pointer;
   }
-}
-
-.inactive {
-  mix-blend-mode: multiply;
-  opacity: 0.8;
 }
 
 @media only screen and (max-width: $large-breakpoint) {

--- a/src/components/BottomBar/BottomBarTabView.vue
+++ b/src/components/BottomBar/BottomBarTabView.vue
@@ -119,8 +119,6 @@ export default Vue.extend({
   margin-bottom: -0.2%;
   align-items: flex-end;
 
-  justify-content: space-between;
-
   &-bottomCourseWrapper {
     display: flex;
     flex-direction: row;
@@ -133,10 +131,9 @@ export default Vue.extend({
   &-seeMoreWrapper {
     display: flex;
     flex-direction: column;
-    margin-left: auto;
     margin-right: 1%;
     .bottombarSeeMoreTab {
-      color: white;
+      color: $white;
       width: 9rem;
       height: 1.75rem;
       background-color: $sangBlue;
@@ -159,7 +156,7 @@ export default Vue.extend({
 
   .bottombarSeeMoreOptions {
     width: 9rem;
-    background-color: #ffffff;
+    background-color: $white;
     border: 1px solid rgba(218, 218, 218, 0.2);
     max-height: 6.81rem;
     overflow-y: scroll;
@@ -173,7 +170,7 @@ export default Vue.extend({
         width: 100%;
         height: 25px;
 
-        color: #757575;
+        color: $lightPlaceholderGray;
         display: flex;
         align-items: center;
 

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -25,7 +25,7 @@ type EventType =
   | 'skip-walkthrough' // User clicks to skip the walkthrough
   | 'onboarding-edit-basic-information' // User clicks to edit basic info on the review page of Onboarding
   | 'onboarding-edit-transfer-credits' // User clicks to edit transfer credits on the review page of Onboarding
-  | 'bottom-bar-see-all-reviews' // User clicks See All Reviews link on Bottom Bar
+  | 'bottom-bar-CU-reviews-link' // User clicks CU Reviews link on Bottom Bar
   | 'bottom-bar-view-course-information-on-roster' // User clicks View Course Information on Roster link on Bottom Bar
   | 'bottom-bar-see-more' // User clicks on the See More tab of the Bottom Bar
   | 'bottom-bar-delete-tab' // User deletes a tab on the Bottom Bar
@@ -128,10 +128,10 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: EventType): void =>
         value: 1,
       };
       break;
-    case 'bottom-bar-see-all-reviews':
+    case 'bottom-bar-CU-reviews-link':
       eventPayload = {
         event_category: 'bottom-bar',
-        event_label: 'see-all-reviews',
+        event_label: 'CU-reviews-link',
         value: 1,
       };
       break;


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request includes Bottom Bar Fixes as indicated by Notion item: [Bottom Bar Updates](https://www.notion.so/Bottom-Bar-Updates-4d4493644ee948b4a8f06eadab9a74ed)

- [x] Fixed bug where when trying to click on courses from the Requirements Bar, only the first one seems to open up the Bottom Bar.
- [x] Change "See All Reviews" link text to "Learn more on CUReviews"
- [x] Update call to CUReviews
- [x] Remove transparency for tabs
- [x] Move See More tab right next to the max number tab (instead of very right)
- [x] Change prereq and description font color to `#3d3d3d`
- [x] Smaller updates to change hex colors to pre-existing scss variables

### Test Plan 
- Try clicking on req courses. Bottom bar tabs should appear for all that are clicked. 
- Ensure clicking on courses in schedule adds bottom bar tabs as usual
- Make sure ratings from CUReviews show up
- Visually ensure that tabs are no longer transparent, See More tab is right next to max number tab (instead of very right), colors are right (`#3d3d3d`), link text has correctly changed to "Learn more on CUReviews"