### PR TITLE
RFC: choose a requirement for a course to fulfill by default

### DIFF
--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -103,7 +103,11 @@ export default Vue.extend({
       this.requirementsThatAllowDoubleCounting = requirementsThatAllowDoubleCounting;
       this.relatedRequirements = relatedRequirements;
       this.selfCheckRequirements = selfCheckRequirements;
-      this.selectedRequirementID = '';
+      if (relatedRequirements.length > 0) {
+        this.selectedRequirementID = relatedRequirements[0].id;
+      } else {
+        this.selectedRequirementID = '';
+      }
     },
     closeCurrentModal() {
       this.reset();

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -309,7 +309,11 @@ export function getRelatedUnfulfilledRequirements(
             toggleableRequirementChoices
           );
           if (fulfillmentStatisticsWithNewCourse.minCountFulfilled > existingMinCountFulfilled) {
-            directlyRelatedRequirements.push(subRequirement);
+            if (subRequirement.checkerWarning == null) {
+              directlyRelatedRequirements.push(subRequirement);
+            } else {
+              selfCheckRequirements.push(subRequirement);
+            }
           }
         }
       }


### PR DESCRIPTION
### Summary <!-- Required -->

Based on feedback and user testing, it seems like the users are very confused when they add a class the requirement bar doesn't change at all. To clarify, there is no requirement bug or UI bug in this case, but more like a UX bug:

The requirement editor chooses nothing by default. Since the user doesn't read the text carefully, they will just click through with a course bind to no requirement.

The fix is easy. Choose one for them. I decided to first choose from related requirement, so that a known and solid requirement is prioritized.

### Test Plan <!-- Required -->

Example of a course with related requirement:
<img width="436" alt="Screen Shot 2021-03-28 at 14 49 14" src="https://user-images.githubusercontent.com/4290500/112764289-d50ae880-8fd5-11eb-9f77-0c4bbf3819ab.png">
Example of a course with only self-check requirement:
<img width="437" alt="Screen Shot 2021-03-28 at 17 53 08" src="https://user-images.githubusercontent.com/4290500/112769353-8cabf480-8fee-11eb-926f-6990be8a8136.png">

### Notes <!-- Optional -->

Maybe we also need to tweak the design a little. Right now it takes me a while to realized that the bolded requirement is the one you selected. Maybe we should just move the dropdown right in the page without click a button to find the dropdown?