### PR TITLE
move onClick to course content instead of wrapper

### DIFF
--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -1,9 +1,9 @@
 <template>
-  <div :class="{ 'course--min': compact, active: active }" class="course" @click="courseOnClick()">
+  <div :class="{ 'course--min': compact, active: active }" class="course">
     <div class="course-color" :style="cssVars" :class="{ 'course-color--active': active }">
       <img src="@/assets/images/dots/sixDots.svg" alt="" />
     </div>
-    <div class="course-content">
+    <div class="course-content" @click="courseOnClick()">
       <div class="course-main">
         <div class="course-top">
           <div class="course-code">{{ courseObj.code }}</div>


### PR DESCRIPTION
### Summary <!-- Required -->
Resolve bug where clicking delete or edit color opens bottom bar for course

https://www.notion.so/courseplan/Deleting-Course-Card-opens-Bottom-Bar-4fa29cb553af47668ee8cfca8b6fd369

### Test Plan <!-- Required -->
Playtest to make sure there are no breaking changes