### PR TITLE
Fix subject color allocation

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -307,18 +307,15 @@ export const initializeFirestoreListeners = (onLoad: () => void): (() => void) =
       selectableRequirementChoiceInitialLoadFinished = true;
       emitOnLoadWhenLoaded();
     });
-  const subjectColorUnsubscriber = fb.subjectColorsCollection
+  fb.subjectColorsCollection
     .doc(simplifiedUser.email)
-    .onSnapshot(snapshot => {
-      const subjectColors = snapshot.data();
-      if (subjectColors != null) {
-        store.commit('setSubjectColors', subjectColors);
-      } else {
-        // Pre-allocate all subject colors during this initialization step.
-        const newSubjectColors = allocateAllSubjectColor(store.state.subjectColors);
-        store.commit('setSubjectColors', newSubjectColors);
-        fb.subjectColorsCollection.doc(simplifiedUser.email).set(newSubjectColors);
-      }
+    .get()
+    .then(snapshot => {
+      const subjectColors = snapshot.data() || {};
+      // Pre-allocate all subject colors during this initialization step.
+      const newSubjectColors = allocateAllSubjectColor(subjectColors);
+      store.commit('setSubjectColors', newSubjectColors);
+      fb.subjectColorsCollection.doc(simplifiedUser.email).set(newSubjectColors);
       subjectColorInitialLoadFinished = true;
       emitOnLoadWhenLoaded();
     });
@@ -337,7 +334,6 @@ export const initializeFirestoreListeners = (onLoad: () => void): (() => void) =
     onboardingDataUnsubscriber();
     toggleableRequirementChoiceUnsubscriber();
     selectableRequirementChoiceUnsubscriber();
-    subjectColorUnsubscriber();
     uniqueIncrementerUnsubscriber();
     derivedDataComputationUnsubscriber();
   };


### PR DESCRIPTION
### Summary <!-- Required -->

Currently subject color is broken, because we only allocate all of them if the user doesn't already have subject color. This breaks the existing user's data.

I changed it so that subject color is only fetched once, and passed it to allocator, and then set to store and firestore. This is safe since nowhere in the app we will change the subject color again.

### Test Plan <!-- Required -->

- Delete all your subject color, reload. Colors are fine.
- Delete all your subject color but keep a few, reload. Colors are fine.