### PR TITLE
[EZ] Update progress bar to fill for each course/credit

### DIFF
--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -142,11 +142,21 @@ export default Vue.extend({
     requirementTotalRequired(): number {
       return this.req.reqs.length;
     },
+    // the sum of the progress of each requirement, maxed out at 1
+    totalRequirementProgress(): number {
+      let fulfilled = 0;
+      this.req.reqs.forEach(req => {
+        if (req.minCountFulfilled >= req.minCountRequired) fulfilled += 1;
+        else fulfilled += req.minCountFulfilled / req.minCountRequired;
+      });
+      return fulfilled;
+    },
+    // the sum of the progress of each requirement, divided by number of requirements
     progressWidth(): string {
-      return `${(this.requirementFulfilled / this.requirementTotalRequired) * 100}%`;
+      return `${(this.totalRequirementProgress / this.requirementTotalRequired) * 100}%`;
     },
     progressWidthValue(): string {
-      return ((this.requirementFulfilled / this.requirementTotalRequired) * 100).toFixed(1);
+      return ((this.totalRequirementProgress / this.requirementTotalRequired) * 100).toFixed(1);
     },
   },
   methods: {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request updates the progress bar each time a user partially fills a requirement to avoid confusion. Progress is divided into equal sections per requirement (so if there are 4 requirements, each represents 1/4 of the bar), and then each section is incremented based on # of credits and courses fulfilled (so if 1 course of 2 is added, 1/2 of that part of the bar should be colored). ([Notion](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=b46ddc637c1342e0b03a326d9fee6109))

![image](https://user-images.githubusercontent.com/25535093/112868346-f4fbe400-9089-11eb-9e79-93b329fa9acb.png)

Remaining TODOs:

- [ ] Handle pure self-check reqs as they can never show up fulfilled in the requirement's bar (@einc may be doing this, see [Notion](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=7c333cae77ec485a979f46a68a37a413))

### Test Plan <!-- Required -->

- Fully complete a major or college (with warning self-checks) and closely watch the progress bar to make sure it behaves as detailed above.

### Notes <!-- Optional -->

Per discussion with @einc, decided not to update the text below the progress bar, as alternatives are all too wordy or more confusing. Let me know if you have any suggestions though!
