### PR TITLE
[EZ] Exclude self check from progress bar, add warning

### DIFF
--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -132,6 +132,7 @@ export default Vue.extend({
     numOfColleges: { type: Number, required: true },
   },
   computed: {
+    // number of fully fulfilled requirements, note pure self-checks are never fulfilled
     requirementFulfilled(): number {
       let fulfilled = 0;
       this.req.reqs.forEach(req => {
@@ -139,10 +140,11 @@ export default Vue.extend({
       });
       return fulfilled;
     },
+    // number of requirements that can be fulfilled (so no pure self-checks)
     requirementTotalRequired(): number {
-      return this.req.reqs.length;
+      return this.req.reqs.filter(req => req.fulfilledBy !== 'self-check').length;
     },
-    // the sum of the progress of each requirement, maxed out at 1
+    // the sum of the progress of each requirement (outside of pure self-check), maxed out at 1
     totalRequirementProgress(): number {
       let fulfilled = 0;
       this.req.reqs.forEach(req => {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -55,6 +55,17 @@
         />
         {{ subReq.requirement.checkerWarning }}
       </div>
+      <div
+        v-if="subReq.requirement.fulfilledBy === 'self-check'"
+        class="requirement-checker-warning"
+      >
+        <img
+          class="requirement-checker-warning-icon"
+          src="@/assets/images/warning.svg"
+          alt="warning icon"
+        />
+        {{ selfCheckWarning }}
+      </div>
       <div v-if="subReq.requirement.fulfilledBy === 'toggleable'">
         <div class="toggleable-requirements-select-wrapper">
           <div
@@ -297,6 +308,9 @@ export default Vue.extend({
     fulfilledSelfCheckCourses(): readonly FirestoreSemesterCourse[] {
       const reqId = this.subReq.requirement.id;
       return store.state.derivedSelectableRequirementData.requirementToCoursesMap[reqId];
+    },
+    selfCheckWarning(): string {
+      return 'This requirement is not included in the progress bar because we do not check if it’s completed.';
     },
   },
   directives: {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request improves the logic of the progress bar for pure self-checks that can never be fulfilled. ([Notion](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=7c333cae77ec485a979f46a68a37a413))

- [x] Exclude pure self-checks from the progress bar (so that the bars and count can be fully completed)
- [x] Add a warning to pure self-checks to tell the users this info
- [x] Add some more comments on progress bar functions 

![image](https://user-images.githubusercontent.com/25535093/113042706-7f674500-9169-11eb-9675-901436275855.png)

### Test Plan <!-- Required -->

1. Completely fulfill a college or major that has at least one pure self-check (like Engineering) and confirm the progress bar is full, and the number of requirements reflects the total number of non-pure self checks (like the above image).
2. Confirm the new warning shows up under pure self-checks, and not under credit/course self-checks or other reqs.  
