### PR TITLE
Unbreak AP/IB requirement computation

### DIFF
--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -170,3 +170,22 @@ it('buildRequirementFulfillmentGraph phase 3 test 4', () => {
   expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
   expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3420, MATH4710]);
 });
+
+// Normally, we will remove all edges when there is no user choice associated with a unique ID.
+//  However, there is the case when all the AP/IB equivalent courses all have the same unique ID -1.
+// If we do the same for AP/IB courses, then all these courses will never be able to fulfill anything.
+// The following test ensures that we don't regress again.
+it('AP/IB course edge is not removed in step 3', () => {
+  const graph = buildRequirementFulfillmentGraph({
+    requirements,
+    userCourses: [{ courseId: CS3410.courseId, uniqueId: -1 }], // mock an AP/IB course
+    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+    userChoiceOnDoubleCountingElimination: {},
+    getAllCoursesThatCanPotentiallySatisfyRequirement,
+    allowDoubleCounting: r => r === 'Probability',
+  });
+
+  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([
+    { courseId: CS3410.courseId, uniqueId: -1 },
+  ]);
+});

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -102,6 +102,10 @@ const buildRequirementFulfillmentGraph = <
 
   // Phase 3: Respect user's choices on double-counted courses.
   userCourses.forEach(({ uniqueId }) => {
+    // uniqueId === -1 means it's AP/IB course.
+    // User never gets to make a choice about these courses, so it will never appear in the choices.
+    // Therefore, removing those edges will nullify all these credits.
+    if (uniqueId === -1) return;
     const chosenRequirement = userChoiceOnDoubleCountingElimination[uniqueId];
     graph.getConnectedRequirementsFromCourse({ uniqueId }).forEach(connectedRequirement => {
       if (allowDoubleCounting(connectedRequirement)) return;


### PR DESCRIPTION
### Summary <!-- Required -->

This bug is introduced during my live coding session. In that change, I will remove all edges when there is no user choice associated with a unique ID. However, I forget to consider the case when all the AP/IB equivalent courses all have the same unique ID -1. If we do the same for AP/IB courses, then all these courses will never be able to fulfill anything.

Therefore, we must bail out when `uniqueID == -1`.

### Test Plan <!-- Required -->

Added a regression test about this bug.

### Notes <!-- Optional -->

This change will fix #397.