### PR TITLE
Onboarding and requirements sidebar frontend bugs

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -52,7 +52,7 @@ input {
   }
 
   &-main {
-    background: #ffffff;
+    background: $white;
     border-radius: 9px;
     margin-left: auto;
     margin-right: auto;
@@ -135,7 +135,7 @@ input {
   }
   &-subsection {
     width: 100%;
-    border: 1px solid #c4c4c4;
+    border: 1px solid $inactiveGray;
     box-sizing: border-box;
     border-radius: 9px;
     padding: 3rem;
@@ -160,13 +160,13 @@ input {
     &--font {
       color: $darkGray2;
       flex-direction: row;
-      background-color: white;
+      background-color: $white;
     }
     &--review {
       font-weight: normal;
       padding: 5px;
       margin-left: 10px;
-      background-color: white;
+      background-color: $white;
       color: $lightPlaceholderGray;
       font-size: 16px;
     }
@@ -180,9 +180,9 @@ input {
     margin-bottom: 0.75rem;
 
     &-fillRow {
-      border: 1px solid #ffffff;
+      border: 1px solid $white;
       width: 100%;
-      border-bottom-color: #c4c4c4;
+      border-bottom-color: $inactiveGray;
       margin-bottom: 1.5rem;
       margin-top: 20px;
     }
@@ -209,7 +209,7 @@ input {
       justify-self: end;
       flex-direction: row;
       &---bold {
-        color: black;
+        color: $black;
         font-weight: bold;
         margin-right: 5px;
       }
@@ -217,7 +217,7 @@ input {
 
     &--review {
       font-weight: normal;
-      background-color: white;
+      background-color: $white;
       color: $lightPlaceholderGray;
       font-size: 16px;
     }
@@ -240,8 +240,8 @@ input {
     height: auto;
     min-height: 1.75rem;
     padding: 5px 8px;
-    background-color: white;
-    border: 0.5px solid #c4c4c4;
+    background-color: $white;
+    border: 0.5px solid $inactiveGray;
     box-sizing: border-box;
     border-radius: 2px;
   }
@@ -328,7 +328,7 @@ input {
       display: flex;
       align-items: center;
       text-align: center;
-      color: #b6b6b6;
+      color: $darkPlaceholderGray;
 
       &:hover {
         color: $darkGray2;
@@ -343,13 +343,13 @@ input {
     border-radius: 1px;
     font-size: 14px;
     line-height: 14px;
-    color: #ffffff;
+    color: $white;
     margin: 5px;
     width: 80px;
     min-height: 1.75rem;
 
     &-previous {
-      background: #ffffff;
+      background: $white;
       color: $emGreen;
       border-radius: 0px;
       border-width: 0px;
@@ -364,8 +364,8 @@ input {
     color: #d8000c;
   }
   &-select {
-    background: #ffffff;
-    border: 1px solid #c4c4c4;
+    background: $white;
+    border: 1px solid $inactiveGray;
 
     box-sizing: border-box;
     border-radius: 1px;
@@ -374,7 +374,7 @@ input {
     line-height: 17px;
     padding-left: 0;
 
-    color: #b6b6b6;
+    color: $darkPlaceholderGray;
     position: relative;
 
     &--disabled {
@@ -423,7 +423,7 @@ input {
       display: flex;
       align-items: center;
 
-      color: #b6b6b6;
+      color: $darkPlaceholderGray;
 
       background: transparent;
 
@@ -440,7 +440,7 @@ input {
         border-left: 6.24px solid transparent;
         border-right: 6.24px solid transparent;
 
-        border-top: 6.24px solid #c4c4c4;
+        border-top: 6.24px solid $inactiveGray;
         background: transparent;
 
         //when clicked border-top-color: #32A0F2;
@@ -454,7 +454,7 @@ input {
         border-left: 6.24px solid transparent;
         border-right: 6.24px solid transparent;
 
-        border-top: 6.24px solid #c4c4c4;
+        border-top: 6.24px solid $inactiveGray;
         background: transparent;
 
         //when clicked border-top-color: #32A0F2;
@@ -469,13 +469,13 @@ input {
     z-index: 2;
     position: absolute;
     width: inherit;
-    background: #ffffff;
+    background: $white;
     box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.25);
     border-radius: 7px;
     max-height: 150px;
     overflow: auto;
 
-    margin-top: 3px;
+    margin-top: 6px;
 
     &-item {
       height: 2.25rem;
@@ -527,7 +527,7 @@ input {
 }
 
 select option {
-  color: black;
+  color: $black;
 }
 select option:first-child {
   color: grey;

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -237,8 +237,9 @@ input {
     line-height: 17px;
     color: $lightPlaceholderGray;
     width: 100%;
-    height: 1.75rem;
-    padding-left: 8px;
+    height: auto;
+    min-height: 1.75rem;
+    padding: 5px 8px;
     background-color: white;
     border: 0.5px solid #c4c4c4;
     box-sizing: border-box;
@@ -431,8 +432,6 @@ input {
       }
 
       &.college-major-minor-placeholder {
-        margin-top: 5px;
-        margin-bottom: 5px;
         width: 100%;
       }
 
@@ -445,9 +444,7 @@ input {
 
         //when clicked border-top-color: #32A0F2;
 
-        margin-top: 30px;
-        margin-bottom: 10.17px;
-
+        height: auto;
         margin-right: 8.7px;
         margin-left: 5px;
       }
@@ -460,10 +457,7 @@ input {
         background: transparent;
 
         //when clicked border-top-color: #32A0F2;
-
-        margin-top: 30px;
-        margin-bottom: 10.17px;
-
+        height: auto;
         margin-right: 6px;
         margin-left: 15px;
       }

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -372,6 +372,7 @@ input {
     width: 100%;
     font-size: 14px;
     line-height: 17px;
+    padding-left: 0;
 
     color: #b6b6b6;
     position: relative;

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -133,8 +133,8 @@ type Data = {
   classes: TransferClassWithOptionalCourse[];
 };
 
-const scoresAP = [1, 2, 3, 4, 5];
-const scoresIB = [1, 2, 3, 4, 5, 6, 7];
+const scoresAP = [5, 4, 3, 2, 1];
+const scoresIB = [7, 6, 5, 4, 3, 2, 1];
 const existingAP: Record<string, boolean> = {};
 const unmodifiedReqsData = { ...reqsData };
 // filter duplicate exam names and ones already selected

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -8,7 +8,27 @@
       {{ req.groupName }} Requirements
     </h1>
     <!-- TODO change for multiple colleges -->
-    <div v-if="reqIndex == numOfColleges" class="major">
+    <div v-if="reqIndex === 0" class="college">
+      <button
+        :style="{
+          'border-bottom': `2px solid #${reqGroupColorMap[req.groupName][0]}`,
+        }"
+        class="college-title-button college-title"
+        :disabled="true"
+      >
+        <p
+          :style="{
+            'font-weight': '500',
+            color: `#${reqGroupColorMap[req.groupName][0]}`,
+          }"
+          class="college-title-top"
+        >
+          {{ getCollegeFullName(onboardingData.college) }}
+        </p>
+      </button>
+    </div>
+    <!-- TODO change for multiple colleges -->
+    <div v-if="reqIndex === numOfColleges" class="major">
       <button
         :style="{
           'border-bottom':
@@ -181,6 +201,7 @@ export default Vue.extend({
 <style scoped lang="scss">
 @import '@/assets/scss/_variables.scss';
 
+.college,
 .major,
 .minor {
   display: flex;


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes a small number of front-end issues with the Onboarding modal and Requirements sidebar ([Notion](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=9a7345937b304fdcbedba87b6daeb8e0))

- [x] Added a label for college in the reqs sidebar like for majors and minors
- [x] Flipped AP/IB credit dropdown numbers
- [x] Implement text-wrapping for long AP/IB test names
- [x] Line up onboarding dropdowns with their parent input 

![image](https://user-images.githubusercontent.com/25535093/113088794-56b86d00-91b4-11eb-84e0-659df0dbd31a.png)

![image](https://user-images.githubusercontent.com/25535093/113087783-58813100-91b2-11eb-9063-4297330ffe34.png)

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] I've already mentioned this to @tcho6319, but the major/minor labels now have hover states even when not clickable. This now applies to the college label as well.
- [x] The requirement header code is kind of messy (styling in the html) and replicated heavily between college/major/minor. Could be a low priority task post-launch to clean it up (@tcho6319 lmk if I should make a notion item)

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

1. Confirm there is now a label for all colleges on the requirements bar
2. Confirm text wraps for long AP/IB test names (like BC non-engineering) on small break points
3. Confirm dropdown children now line up with their input boxes
4. Outside of the above changes, confirm all onboarding dropdowns look the same on the webapp/figma
5. Confirm AP/IB score dropdowns are now from top to bottom (and save that way)
