### PR TITLE
Conditional Hover States for College/Major/Minor Tabs

### DIFF
--- a/src/assets/scss/_global.scss
+++ b/src/assets/scss/_global.scss
@@ -245,3 +245,20 @@ form {
 .fade-leave-to {
   opacity: 0;
 }
+
+// full opacity on hover.
+// Intended to undo reduced opacity for button:hover
+.full-opacity-on-hover {
+  &:hover {
+    opacity: 1;
+  }
+}
+
+// slightly lower opacity on hover.
+// Intended to have higher than the reduced opacity for button:hover but lower
+// than full opacity
+.slightly-lower-opacity-on-hover {
+  &:hover {
+    opacity: 0.8;
+  }
+}

--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -4,7 +4,7 @@
       <bottom-bar-tab-view :maxBottomBarTabs="maxBottomBarTabs" />
     </div>
     <button
-      class="bottombar-title"
+      class="bottombar-title full-opacity-on-hover"
       :class="{ expandedBottomBarTitle: isExpanded }"
       @click="toggleBottomBar($gtag)"
     >
@@ -76,9 +76,6 @@ export default Vue.extend({
     width: calc(100vw - 29.5rem);
     text-align: left;
     padding-left: 0;
-    &:hover {
-      opacity: 1;
-    }
   }
 
   &-course {

--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="bottombartab" :style="{ background: `#${color}` }" @click="$emit('on-change-focus')">
+  <div
+    class="bottombartab full-opacity-on-hover"
+    :style="{ background: `#${color}` }"
+    @click="$emit('on-change-focus')"
+  >
     <div class="bottombartab-wrapper">
       <div class="bottombartab-name">{{ courseObj.code }}</div>
     </div>
@@ -44,10 +48,6 @@ export default Vue.extend({
   justify-content: space-between;
   padding-left: 8px;
   padding-right: 8px;
-
-  &:hover {
-    opacity: 1;
-  }
 
   &-wrapper {
     display: flex;

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -35,7 +35,7 @@
           <button
             v-for="(color, index) in colors"
             :key="index"
-            class="courseMenu-section"
+            class="courseMenu-section full-opacity-on-hover"
             @click="colorCourse(color)"
           >
             <div class="courseMenu-left">
@@ -93,7 +93,7 @@
         </div>
       </div>
       <button
-        class="courseMenu-section"
+        class="courseMenu-section full-opacity-on-hover"
         :class="{ 'courseMenu-section--left': isLeft }"
         @click="deleteCourse"
       >
@@ -224,7 +224,6 @@ export default Vue.extend({
     &:active,
     &:focus {
       background-color: rgba(50, 160, 242, 0.15);
-      opacity: 1;
     }
 
     &:first-child {

--- a/src/components/Modals/SemesterMenu.vue
+++ b/src/components/Modals/SemesterMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="semesterMenu">
     <button
-      class="semesterMenu-section"
+      class="semesterMenu-section full-opacity-on-hover"
       :class="{ 'd-none': isOpenModal }"
       @click="openEditSemesterModal"
     >
@@ -19,7 +19,7 @@
       </div>
     </button>
     <button
-      class="semesterMenu-section"
+      class="semesterMenu-section full-opacity-on-hover"
       :class="{ 'd-none': isOpenModal }"
       @click="openDeleteSemesterModal"
     >
@@ -86,7 +86,6 @@ export default Vue.extend({
     &:active,
     &:focus {
       background-color: rgba(50, 160, 242, 0.15);
-      opacity: 1;
     }
     &:first-child {
       border-top-left-radius: 9px;

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,14 +1,23 @@
 <template>
   <nav class="navbar">
-    <div class="navbar-iconWrapper hamburger" @click="menuOpen = !menuOpen"></div>
+    <div
+      class="navbar-iconWrapper hamburger full-opacity-on-hover"
+      @click="menuOpen = !menuOpen"
+    ></div>
     <div class="navbar-top">
       <div class="navbar-iconWrapper course-plan-logo">
         <img class="navbar-icon" src="@/assets/images/branding/logo.svg" alt="Courseplan logo" />
       </div>
-      <button class="navbar-iconWrapper desktop profile-icon" @click="editProfile"></button>
+      <button
+        class="navbar-iconWrapper desktop profile-icon full-opacity-on-hover"
+        @click="editProfile"
+      ></button>
     </div>
     <div class="navbar-bottom">
-      <button class="navbar-iconWrapper desktop logout-icon" @click="logout" />
+      <button
+        class="navbar-iconWrapper desktop logout-icon full-opacity-on-hover"
+        @click="logout"
+      />
     </div>
     <div v-if="menuOpen" class="navbar-menu-background-shadow" @click="editProfile" />
     <div v-if="menuOpen" class="navbar-menu">
@@ -108,7 +117,6 @@ $mobile-navbar-height: 4.5rem;
     &:focus,
     &:active {
       background-image: url('~@/assets/images/navbar/profileIconBlue.svg');
-      opacity: 1;
     }
   }
 
@@ -125,7 +133,6 @@ $mobile-navbar-height: 4.5rem;
     &:focus,
     &:active {
       background-image: url('~@/assets/images/navbar/hamburger-blue.svg');
-      opacity: 1;
     }
   }
 
@@ -136,7 +143,6 @@ $mobile-navbar-height: 4.5rem;
     &:focus,
     &:active {
       background-image: url('~@/assets/images/navbar/logoutBlue.svg');
-      opacity: 1;
     }
   }
 

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -15,7 +15,10 @@
             id === displayedMajorIndex ? `2px solid #${reqGroupColorMap[req.groupName][0]}` : '',
         }"
         @click="activateMajor(id)"
-        class="major-title-button major-title"
+        :class="[
+          { 'full-opacity-on-hover': onboardingData.major.length === 1 },
+          'major-title-button major-title',
+        ]"
         v-for="(major, id) in onboardingData.major"
         :key="id"
         :disabled="id === displayedMajorIndex"
@@ -46,7 +49,10 @@
             id === displayedMinorIndex ? `2px solid #${reqGroupColorMap[req.groupName][0]}` : '',
         }"
         @click="activateMinor(id)"
-        class="major-title major-title-button"
+        :class="[
+          { 'full-opacity-on-hover': onboardingData.minor.length === 1 },
+          'major-title major-title-button',
+        ]"
         v-for="(minor, id) in onboardingData.minor"
         :key="id"
         :disabled="id === displayedMinorIndex"

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -13,7 +13,7 @@
         :style="{
           'border-bottom': `2px solid #${reqGroupColorMap[req.groupName][0]}`,
         }"
-        class="college-title-button college-title"
+        class="college-title-button college-title full-opacity-on-hover"
         :disabled="true"
       >
         <p

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -2,7 +2,7 @@
   <div class="subrequirement">
     <button
       @click="toggleDescription()"
-      class="dropdown row subreq-button"
+      class="dropdown row subreq-button slightly-lower-opacity-on-hover"
       aria-haspopup="true"
       data-toggle="dropdown"
     >
@@ -569,9 +569,6 @@ button.view {
 }
 
 .subreq {
-  &-button:hover {
-    opacity: 0.8;
-  }
   &-name {
     text-align: left;
     margin-left: 11px;

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -34,12 +34,12 @@
         >
           <span class="semesterView-switchText">View:</span>
           <button
-            class="semesterView-switchImage semesterView-twoColumn"
+            class="semesterView-switchImage semesterView-twoColumn full-opacity-on-hover"
             @click="setNotCompact"
             :class="{ 'semesterView-twoColumn--active': !compact }"
           />
           <button
-            class="semesterView-switchImage semesterView-fourColumn"
+            class="semesterView-switchImage semesterView-fourColumn full-opacity-on-hover"
             @click="setCompact"
             :class="{ 'semesterView-fourColumn--active': compact }"
           />
@@ -289,7 +289,6 @@ export default Vue.extend({
     &--active {
       cursor: pointer;
       background-image: url('~@/assets/images/views/twoColumnSelected.svg');
-      opacity: 1;
     }
   }
 
@@ -302,7 +301,6 @@ export default Vue.extend({
     &--active {
       cursor: pointer;
       background-image: url('~@/assets/images/views/fourColumnSelected.svg');
-      opacity: 1;
     }
   }
 


### PR DESCRIPTION
### Summary

This pull request implements conditional hover states for the College/Major/Minor tabs on the requirements sidebar.

- [x] College tab always has `opacity: 1` on hover since we only support one college
- [x] Major/Minor tabs will have `opacity: 1` on hover unless there are more than 1. If there are more than 1 major/minor tabs, then `opacity: 0.5` on hover, which is the default for all buttons.
- [x] Refactor special cases of `opacity: 1` on hover with `'full-opacity-on-hover'`class  and `opacity: 0.8` on hover with `'slightly-lower-opacity-on-hover'` class found in `src/assets/scss/_global.scss`.  See #391 for original hover states implementation of special cases.


### Test Plan <!-- Required -->
- College should not have lower opacity on hover
- Major/Minor should not have lower opacity on hover if there is only 1 Major and/or 1 Minor
- Add a second Major: Now the Major tabs should have lower opacity on hover
-  Add a second Minor: Now the Minor tabs should have lower opacity on hover

- Be sure to look through the site and ensure that nothing visually changed (besides the added hover states)
