### PR TITLE
Give every user's AP/IB equivalent course a negative unique ID

### DIFF
--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -67,7 +67,7 @@ export default Vue.extend({
       return 'Reset';
     },
     isTransferCredit(): boolean {
-      return this.courseTaken.uniqueId === -1;
+      return this.courseTaken.uniqueId < 0;
     },
     semesterLabel(): string {
       if (this.isTransferCredit) return 'Transfer Credits';

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -56,7 +56,7 @@ type DecoratedCollegeOrMajorRequirement = RequirementCommon &
 type CourseTaken = {
   /** The course ID from course roster, or our dummy id to denote special courses like FWS equiv. */
   readonly courseId: number;
-  /** Using the unique ID of firestore course for real course, and less than 0 for AP/IB/Swim */
+  /** Using the unique ID of firestore course for real course, -1 for swim test and < -1 for AP/IB. */
   readonly uniqueId: number;
   /**
    * Course code like 'CS 2112', 'AP CS'.

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -56,7 +56,7 @@ type DecoratedCollegeOrMajorRequirement = RequirementCommon &
 type CourseTaken = {
   /** The course ID from course roster, or our dummy id to denote special courses like FWS equiv. */
   readonly courseId: number;
-  /** Using the unique ID of firestore course for real course, and -1 for AP/IB/Swim */
+  /** Using the unique ID of firestore course for real course, and less than 0 for AP/IB/Swim */
   readonly uniqueId: number;
   /**
    * Course code like 'CS 2112', 'AP CS'.

--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -172,20 +172,23 @@ it('buildRequirementFulfillmentGraph phase 3 test 4', () => {
 });
 
 // Normally, we will remove all edges when there is no user choice associated with a unique ID.
-//  However, there is the case when all the AP/IB equivalent courses all have the same unique ID -1.
-// If we do the same for AP/IB courses, then all these courses will never be able to fulfill anything.
+// If we do the same for AP/IB/swim courses, then all these courses will never be able to fulfill
+// anything.
 // The following test ensures that we don't regress again.
-it('AP/IB course edge is not removed in step 3', () => {
-  const graph = buildRequirementFulfillmentGraph({
-    requirements,
-    userCourses: [{ courseId: CS3410.courseId, uniqueId: -1 }], // mock an AP/IB course
-    userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
-    userChoiceOnDoubleCountingElimination: {},
-    getAllCoursesThatCanPotentiallySatisfyRequirement,
-    allowDoubleCounting: r => r === 'Probability',
-  });
+it('AP/IB/swim test course edge is not removed in step 3', () => {
+  // Test this for a lot of different unique ID less than
+  for (let uniqueId = -1; uniqueId >= -10; uniqueId -= 1) {
+    const graph = buildRequirementFulfillmentGraph({
+      requirements,
+      userCourses: [{ courseId: CS3410.courseId, uniqueId }], // mock an AP/IB course
+      userChoiceOnFulfillmentStrategy: { 'CS3410/CS3420': [CS3410.courseId] },
+      userChoiceOnDoubleCountingElimination: {},
+      getAllCoursesThatCanPotentiallySatisfyRequirement,
+      allowDoubleCounting: r => r === 'Probability',
+    });
 
-  expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([
-    { courseId: CS3410.courseId, uniqueId: -1 },
-  ]);
+    expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([
+      { courseId: CS3410.courseId, uniqueId },
+    ]);
+  }
 });

--- a/src/requirements/data/exams/ExamCredit.ts
+++ b/src/requirements/data/exams/ExamCredit.ts
@@ -400,7 +400,7 @@ function userDataToCourses(
   const userExams = userData[examType];
   const exams = examData[examType];
   const courses: CourseTaken[] = [];
-  userExams.forEach(userExam => {
+  userExams.forEach((userExam, examIndex) => {
     // match exam to user-taken exam
     const exam = exams.reduce((prev: ExamRequirements | undefined, curr: ExamRequirements) => {
       // check if exam name matches and score is high enough
@@ -426,7 +426,7 @@ function userDataToCourses(
           const courseId = courseEquivalents[0];
           courses.push({
             courseId,
-            uniqueId: -1,
+            uniqueId: -examIndex - 2,
             code: `${examType} ${exam.name}`,
             credits: exam.fulfillment.credits,
           });
@@ -435,14 +435,14 @@ function userDataToCourses(
           courseEquivalents.forEach(courseId => {
             courses.push({
               courseId,
-              uniqueId: -1,
+              uniqueId: -examIndex - 2,
               code: `${examType} ${exam.name}`,
               credits: 0,
             });
           });
           courses.push({
             courseId: CREDITS_COURSE_ID,
-            uniqueId: -1,
+            uniqueId: -examIndex - 2,
             code: `${examType} ${exam.name}`,
             credits: exam.fulfillment.credits,
           });

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -102,10 +102,10 @@ const buildRequirementFulfillmentGraph = <
 
   // Phase 3: Respect user's choices on double-counted courses.
   userCourses.forEach(({ uniqueId }) => {
-    // uniqueId === -1 means it's AP/IB course.
+    // uniqueId < 0 means it's AP/IB course.
     // User never gets to make a choice about these courses, so it will never appear in the choices.
     // Therefore, removing those edges will nullify all these credits.
-    if (uniqueId === -1) return;
+    if (uniqueId < 0) return;
     const chosenRequirement = userChoiceOnDoubleCountingElimination[uniqueId];
     graph.getConnectedRequirementsFromCourse({ uniqueId }).forEach(connectedRequirement => {
       if (allowDoubleCounting(connectedRequirement)) return;

--- a/src/requirements/requirement-graph-builder.ts
+++ b/src/requirements/requirement-graph-builder.ts
@@ -102,7 +102,8 @@ const buildRequirementFulfillmentGraph = <
 
   // Phase 3: Respect user's choices on double-counted courses.
   userCourses.forEach(({ uniqueId }) => {
-    // uniqueId < 0 means it's AP/IB course.
+    // uniqueId < 0 means it's AP/IB course or swim test.
+    // (-1 == swim test, < -1 == AP/IB)
     // User never gets to make a choice about these courses, so it will never appear in the choices.
     // Therefore, removing those edges will nullify all these credits.
     if (uniqueId < 0) return;


### PR DESCRIPTION
### Summary <!-- Required -->

The requirement graph is implemented as a hashtable with requirement name and unique ID used as key for both sides. It really doesn't like two courses to have the same unique ID.

Unfortunately, that's the case for AP/IB credits' equivalent courses. They are all hardcoded to have `uniqueID === -1`. This causes issues like #397 to occur when a requirement is connected to two AP credits, only one is recorded in the graph due to unique ID duplication.

This PR tries to fix the problem by giving all AP/IB equivalent course a NEGATIVE unique id, starting from -2. (-1 is reserved for swim test). The unique IDs are provisioned according to the order they appear in the user exam object. The stability of the IDs are not that important, since those IDs are never stored in the database, and will always be recomputed on the fly when the requirement is recomputed.

### Test Plan <!-- Required -->

It should fix @abcdefguan's problem when only one physics AP credit is counted.
<img width="375" alt="Screen Shot 2021-03-31 at 12 26 07" src="https://user-images.githubusercontent.com/4290500/113178243-62d81500-921c-11eb-98c0-3196a6aa1baf.png">