### PR TITLE
Semesters Backwards Compatibility Script

### DIFF
--- a/functions/update-user-data-semesters.js
+++ b/functions/update-user-data-semesters.js
@@ -81,7 +81,8 @@ const transformData = data => ({
 if (process.argv[2] === '--dry-run') {
   userDataCollection.get().then(userData => {
     const oldUserData = userData.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-    const newUserData = oldUserData.map(transformData);
+    // Using JSON parse and stringify trick so we get a deep copy of the nested oldUserData
+    const newUserData = JSON.parse(JSON.stringify(oldUserData)).map(transformData);
     fs.writeFileSync('old-userData-semesters.json', JSON.stringify(oldUserData, undefined, 2));
     fs.writeFileSync('new-userData-semesters.json', JSON.stringify(newUserData, undefined, 2));
   });

--- a/functions/update-user-data-semesters.js
+++ b/functions/update-user-data-semesters.js
@@ -1,0 +1,97 @@
+// Updates the order of the semesters in the userData collection to be in order
+// from most recent to least recent
+
+const admin = require('firebase-admin');
+const fs = require('fs');
+const serviceAccount = require('./service-account.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
+});
+
+const db = admin.firestore();
+const userDataCollection = db.collection('userData');
+
+/**
+ * @param {*} type of the season. 'Spring' | 'Summer' | 'Fall' | 'Winter'
+ * @returns the ordered number that represents the type of season. 1 is returned
+ * for 'Spring', 6 is returned for 'Summer', 8 is returned for 'Fall', and 12 is
+ * returned for 'Winter'
+ */
+function typeToOrderedNumber(type) {
+  switch (type) {
+    case 'Spring':
+      return 1;
+    case 'Summer':
+      return 6;
+    case 'Fall':
+      return 8;
+    case 'Winter':
+      return 12;
+    default:
+  }
+}
+
+/**
+ * Compares semesterObject1 and semesterObject2 based on type and year properties
+ * @param {*} semesterObject1 is an object that is in the userData.semesters array
+ * @param {*} semesterObject2 is an object that is in the userData.semesters array
+ * @returns 1 if semesterObject2 occurs more recently than semesterObject1,
+ * -1 if semesterObject1 occurs more recently than semesterObject2, 0 otherwise.
+ */
+function compareSemesterObjectsByTypeAndYear(semesterObject1, semesterObject2) {
+  const type1 = semesterObject1.type;
+  const type2 = semesterObject2.type;
+  const year1 = semesterObject1.year;
+  const year2 = semesterObject2.year;
+
+  if (year2 > year1) {
+    // semesterObject2 has more recent year than semesterObject1
+    return 1;
+  } else if (year1 > year2) {
+    // semesterObject1 has more recent year than semesterObject2
+    return -1;
+  } else if (typeToOrderedNumber(type2) > typeToOrderedNumber(type1)) {
+    // semesterObject2 has more recent semester type than semesterObject1
+    return 1;
+  } else if (typeToOrderedNumber(type1) > typeToOrderedNumber(type2)) {
+    // semesterObject1 has more recent semester type than semesterObject2
+    return -1;
+  } else {
+    return 0;
+  }
+}
+
+/**
+ *
+ * @param {*} semesters is the userData.semesters array on Firestore
+ * @returns semesters sorted from most recent to least recent type and year
+ */
+function semesterObjectsByMostRecentTypeAndYear(semesters) {
+  // Sorts from most recent type and year
+  return semesters.sort(compareSemesterObjectsByTypeAndYear);
+}
+
+const transformData = data => ({
+  ...data,
+  semesters: semesterObjectsByMostRecentTypeAndYear(data.semesters),
+});
+
+if (process.argv[2] === '--dry-run') {
+  userDataCollection.get().then(userData => {
+    const oldUserData = userData.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const newUserData = oldUserData.map(transformData);
+    fs.writeFileSync('old-userData-semesters.json', JSON.stringify(oldUserData, undefined, 2));
+    fs.writeFileSync('new-userData-semesters.json', JSON.stringify(newUserData, undefined, 2));
+  });
+  return;
+} else {
+  userDataCollection.get().then(userData => {
+    Promise.all(
+      userData.docs.map(userDataDocument =>
+        userDataDocument.ref.set(transformData(userDataDocument.data()))
+      )
+    );
+  });
+}


### PR DESCRIPTION
### Summary

This pull request resolves the semesters backwards compatibility issue.

Currently, on [courseplan.io](courseplan.io), users who added semesters before CP decided to order semesters from most recent to least recent semester may end up with a schedule where the semesters are out of order.

See the example of the bug below. The schedule has the old order (least recent to most recent semester) so that Spring 2015 appears above Winter 2028. The add new semester functionality is up-to-date with our decision to have semesters go in most recent to least recent. Therefore, when I add Spring 2021, it is added to the top.

https://user-images.githubusercontent.com/54298311/113212182-6d0e0980-9244-11eb-8ba6-dba1a8dee1cc.mov

**The solution for this issue is to create a script that we would run during the data migration at launch so that the semesters are ordered correctly from most recent to least recent.**

- [x] Implemented `update-user-data-semesters.js` with dry run option

### Test Plan

- Navigate to `functions\` folder
- Run `node update-user-data-semesters.js --dry-run`
- Compare output files: `'old-userData-semesters.json'` and `'new-userData-semesters.json'`

**NOTE: ** In order to do the test plan, you will need access to prod. If you do not have access, but would like to test, slack @tcho6319 so that she can screenshare and show you the files generated. The output files will not be committed as they contain the emails of our users.

### Notes
I'm confused as to why the semester ordering is correct (i.e. Winter 2028, Spring 2021, Spring 2015) in `'old-userData-semesters.json'` because on Firestore, the ordering is incorrect (Spring 2021, Spring 2015, Winter 2028). The good thing is that the semester ordering is correct in `'new-userData-semesters.json'`, but if anyone might have an idea of why, please lmk!

![Screen Shot 2021-03-31 at 5 20 22 PM](https://user-images.githubusercontent.com/54298311/113212894-646a0300-9245-11eb-8d89-40cd818c4d27.png)



