### PR TITLE
Fixed long a&s names and hover bugs.

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -5,7 +5,7 @@
       @click="menuOpen = !menuOpen"
     ></div>
     <div class="navbar-top">
-      <div class="navbar-iconWrapper course-plan-logo">
+      <div class="navbar-iconWrapper course-plan-logo no-hover">
         <img class="navbar-icon" src="@/assets/images/branding/logo.svg" alt="Courseplan logo" />
       </div>
       <button
@@ -190,6 +190,10 @@ $mobile-navbar-height: 4.5rem;
 
 .mobile {
   display: none;
+}
+
+.no-hover {
+  cursor: default;
 }
 
 @media only screen and (max-width: $medium-breakpoint) {

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -572,7 +572,7 @@ button.view {
   &-name {
     text-align: left;
     margin-left: 11px;
-    max-width: 14rem;
+    max-width: 12rem;
   }
 }
 </style>

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -572,6 +572,7 @@ button.view {
   &-name {
     text-align: left;
     margin-left: 11px;
+    max-width: 14rem;
   }
 }
 </style>

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -572,7 +572,7 @@ button.view {
   &-name {
     text-align: left;
     margin-left: 11px;
-    max-width: 12rem;
+    max-width: 11rem;
   }
 }
 </style>


### PR DESCRIPTION
### Summary 

- [x] Added 12rem max width for rec names
- [x] Added cursor: default for logo

### Test 

Check that wrapping works correctly and the logo doesn't hover anymore.

Before:
![image](https://user-images.githubusercontent.com/6832564/113495047-8b7e3a00-94bc-11eb-8f69-434f6370f160.png)
After:
![image](https://user-images.githubusercontent.com/6832564/113495055-9933bf80-94bc-11eb-8c28-c57fbfd837df.png)

