### PR TITLE
Sub req styling changes

### DIFF
--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -17,7 +17,7 @@
     <div v-if="showMajorOrMinorRequirements">
       <!--Show more of completed requirements -->
       <div v-if="displayDetails || tourStep === 1">
-        <h2>In-Depth College Requirements</h2>
+        <h2>Ongoing Requirements</h2>
         <div class="separator"></div>
         <div v-for="(subReq, id) in partitionedRequirementsProgress.ongoing" :key="id">
           <sub-requirement
@@ -33,7 +33,7 @@
         </div>
 
         <div v-if="partitionedRequirementsProgress.completed.length > 0" class="row completed">
-          <h2 class="col specific">Filled Requirements</h2>
+          <h2 class="col specific">Completed Requirements</h2>
           <div class="col-1 text-right">
             <button
               class="btn float-right"
@@ -183,6 +183,7 @@ export default Vue.extend({
 }
 .specific {
   color: $lightPlaceholderGray;
+  padding: 0;
 }
 button.active {
   color: $sangBlue;

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -15,24 +15,17 @@
           />
         </div>
         <div class="subreq-name">
-          <p
-            :class="[
-              { 'sub-req': !isCompleted },
-              isCompleted ? 'completed-ptext' : 'incomplete-ptext',
-            ]"
-          >
-            <span>{{ subReq.requirement.name }}</span>
+          <p class="sub-req" :class="{ 'completed-ptext': isCompleted }">
+            {{ subReq.requirement.name }}
           </p>
         </div>
       </div>
-      <div v-if="!isCompleted" class="col sub-req-progress text-right incomplete-ptext">
-        {{ subReqProgress }}
+      <div v-if="isCompleted" class="col text-right completed-ptext-fraction">
+        {{ subReq.minCountFulfilled }}/{{ subReq.minCountRequired }}
+        {{ subReq.fulfilledBy }}
       </div>
-      <div v-if="isCompleted" class="col text-right completed-ptext">
-        <span
-          >{{ subReq.minCountFulfilled }}/{{ subReq.minCountRequired }}
-          {{ subReq.fulfilledBy }}</span
-        >
+      <div v-else class="col sub-req-progress text-right incomplete-ptext">
+        {{ subReqProgress }}
       </div>
     </button>
     <div v-if="displayDescription" :class="[{ 'completed-ptext': isCompleted }, 'description']">
@@ -414,12 +407,21 @@ button.view {
   color: $white;
   text-transform: uppercase;
 }
-.completed-ptext span {
+.completed-ptext {
   color: $lightPlaceholderGray;
-  font-size: 12px;
   opacity: 0.8;
-  font-weight: normal;
+  line-height: 14px;
+  font-size: 12px;
+  &-fraction {
+    color: $lightPlaceholderGray;
+    opacity: 0.8;
+    line-height: 14px;
+    font-size: 12px;
+    margin-top: auto;
+    margin-bottom: auto;
+  }
 }
+
 .incomplete {
   &-ptext {
     font-size: 14px;


### PR DESCRIPTION
### Summary
Before:
![image](https://user-images.githubusercontent.com/55263191/113363431-d5311e00-931e-11eb-9972-0a218d73e87d.png)
After:
![image](https://user-images.githubusercontent.com/55263191/113363303-85525700-931e-11eb-834f-4512aef0fcfd.png)

- [x] change "Filled Requirements" to "Completed Requirements"
- [x] change "In-Depth College Requirements" to "Ongoing Requirements"
- [x] "Completed Requirements" styling was off after changing them to buttons. Altered them to look the way they should. 

### Test Plan
- Make sure all sub requirements are looking spiffy!
