### PR TITLE
Dynamic z index

### DIFF
--- a/src/components/Modals/ResetConfirmationModal.vue
+++ b/src/components/Modals/ResetConfirmationModal.vue
@@ -40,6 +40,7 @@ export default Vue.extend({
   methods: {
     closeCurrentModal(): void {
       this.$emit('input', false);
+      this.$emit('modal-open', false);
     },
     resetClicked(): void {
       this.closeCurrentModal();

--- a/src/components/Modals/ResetConfirmationModal.vue
+++ b/src/components/Modals/ResetConfirmationModal.vue
@@ -93,4 +93,13 @@ export default Vue.extend({
     display: flex;
   }
 }
+
+@media only screen and (max-width: $small-medium-breakpoint) {
+  .content-confirmation {
+    width: 100%;
+  }
+  .text-width {
+    width: 100%;
+  }
+}
 </style>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="navbar">
+  <nav class="navbar" :style="{ zIndex: modalIsOpen ? 1 : 2 }">
     <div
       class="navbar-iconWrapper hamburger full-opacity-on-hover"
       @click="menuOpen = !menuOpen"
@@ -55,9 +55,12 @@ import { GTagEvent } from '@/gtag';
 export default Vue.extend({
   props: {
     isOpeningRequirements: { type: Boolean, required: true },
+    modalIsOpen: { type: Boolean, required: true },
   },
   data() {
-    return { menuOpen: false };
+    return {
+      menuOpen: false,
+    };
   },
   methods: {
     logout() {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -5,6 +5,7 @@
       :reqName="courseTaken.code"
       v-model="resetConfirmVisible"
       @close-reset-modal="onResetConfirmClosed"
+      @modal-open="modalToggled"
     />
     <div class="completed-reqCourses-course-wrapper">
       <div class="separator"></div>
@@ -102,6 +103,9 @@ export default Vue.extend({
           });
         } else deleteCourseFromSemesters(this.courseTaken.uniqueId, this.$gtag);
       }
+    },
+    modalToggled(isOpen: boolean) {
+      this.$emit('modal-open', isOpen);
     },
   },
 });

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -86,8 +86,10 @@ export default Vue.extend({
   methods: {
     onReset(): void {
       this.resetConfirmVisible = true;
+      this.$emit('modal-open', true);
     },
     onResetConfirmClosed(isReset: boolean): void {
+      this.$emit('modal-open', false);
       if (isReset) {
         if (this.isTransferCredit) {
           const type = this.courseTaken.code.substr(0, 2);

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -158,9 +158,11 @@ export default Vue.extend({
     },
     openCourseModal() {
       this.isCourseModalOpen = true;
+      this.$emit('modal-open', true);
     },
     closeCourseModal() {
       this.isCourseModalOpen = false;
+      this.$emit('modal-open', false);
     },
   },
 });

--- a/src/components/Requirements/RequirementView.vue
+++ b/src/components/Requirements/RequirementView.vue
@@ -28,6 +28,7 @@
             :tourStep="tourStep"
             @changeToggleableRequirementChoice="changeToggleableRequirementChoice"
             @onShowAllCourses="onShowAllCourses"
+            @modal-open="modalToggled"
           />
           <div class="separator"></div>
         </div>
@@ -152,6 +153,9 @@ export default Vue.extend({
     turnCompleted(bool: boolean) {
       GTagEvent(this.$gtag, 'requirements-bar-filled-requirements-toggle');
       this.displayCompleted = bool;
+    },
+    modalToggled(isOpen: boolean) {
+      this.$emit('modal-open', isOpen);
     },
   },
 });

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -12,7 +12,7 @@
       <div
         :class="{
           'd-none': shouldShowAllCourses,
-          fixed: !modalIsOpen,
+          fixed: !(isSafari && modalIsOpen),
         }"
         data-intro-group="req-tooltip"
         :data-intro="getCoursesTooltipText()"
@@ -194,6 +194,14 @@ export default Vue.extend({
     pageText(): string {
       return `Page ${this.showAllPage + 1}/${this.numPages}`;
     },
+    isSafari(): boolean {
+      return (
+        /constructor/i.test(window.HTMLElement) ||
+        (function (p) {
+          return p.toString() === '[object SafariRemoteNotification]';
+        })(!window.safari || (typeof safari !== 'undefined' && window.safari.pushNotification))
+      );
+    },
   },
   methods: {
     showMajorOrMinorRequirements(id: number, group: string): boolean {
@@ -279,6 +287,7 @@ export default Vue.extend({
     modalToggled(isOpen: boolean) {
       this.$emit('modal-open', isOpen);
       this.modalIsOpen = isOpen;
+      console.log(this.isSafari);
     },
   },
 });

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -10,9 +10,10 @@
     >
       <!-- loop through reqs array of req objects -->
       <div
+        class="fixed"
         :class="{
           'd-none': shouldShowAllCourses,
-          fixed: !(isSafari && modalIsOpen),
+          'position-fixed': !(isSafari && modalIsOpen),
         }"
         data-intro-group="req-tooltip"
         :data-intro="getCoursesTooltipText()"
@@ -322,11 +323,13 @@ export default Vue.extend({
   background-color: $white;
 }
 .fixed {
-  position: fixed;
   left: 4.5rem;
   top: 0;
   overflow-y: scroll;
   overflow-x: hidden;
+}
+.position-fixed {
+  position: fixed;
 }
 .fixed,
 .see-all-padding {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -13,7 +13,7 @@
         class="fixed"
         :class="{
           'd-none': shouldShowAllCourses,
-          'position-fixed': isSafari && modalIsOpen,
+          'position-static': isSafari && modalIsOpen,
         }"
         data-intro-group="req-tooltip"
         :data-intro="getCoursesTooltipText()"

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -197,11 +197,9 @@ export default Vue.extend({
     isSafari(): boolean {
       const htmlElement = window.HTMLElement as unknown;
       type windowType = {
-        safari:
-          | {
-              pushNotification: boolean;
-            }
-          | unknown;
+        safari: {
+          pushNotification: boolean;
+        };
       };
       const initWindow = window as unknown;
       const typedWindow = initWindow as windowType;

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -195,11 +195,24 @@ export default Vue.extend({
       return `Page ${this.showAllPage + 1}/${this.numPages}`;
     },
     isSafari(): boolean {
+      const htmlElement = window.HTMLElement as unknown;
+      type windowType = {
+        safari:
+          | {
+              pushNotification: boolean;
+            }
+          | unknown;
+      };
+      const initWindow = window as unknown;
+      const typedWindow = initWindow as windowType;
       return (
-        /constructor/i.test(window.HTMLElement) ||
+        /constructor/i.test(htmlElement as string) ||
         (function (p) {
           return p.toString() === '[object SafariRemoteNotification]';
-        })(!window.safari || (typeof safari !== 'undefined' && window.safari.pushNotification))
+        })(
+          !typedWindow.safari ||
+            (typeof typedWindow.safari !== 'undefined' && typedWindow.safari.pushNotification)
+        )
       );
     },
   },
@@ -287,7 +300,6 @@ export default Vue.extend({
     modalToggled(isOpen: boolean) {
       this.$emit('modal-open', isOpen);
       this.modalIsOpen = isOpen;
-      console.log(this.isSafari);
     },
   },
 });

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -10,8 +10,10 @@
     >
       <!-- loop through reqs array of req objects -->
       <div
-        class="fixed"
-        :class="{ 'd-none': shouldShowAllCourses }"
+        :class="{
+          'd-none': shouldShowAllCourses,
+          fixed: !modalIsOpen,
+        }"
         data-intro-group="req-tooltip"
         :data-intro="getCoursesTooltipText()"
         data-disable-interaction="1"
@@ -120,6 +122,7 @@ type Data = {
   shouldShowAllCourses: boolean;
   showAllPage: number;
   tourStep: number;
+  modalIsOpen: boolean;
 };
 
 // This section will be revisited when we try to make first-time tooltips
@@ -146,6 +149,7 @@ export default Vue.extend({
       shouldShowAllCourses: false,
       showAllPage: 0,
       tourStep: 0,
+      modalIsOpen: false,
     };
   },
   watch: {
@@ -274,6 +278,7 @@ export default Vue.extend({
     },
     modalToggled(isOpen: boolean) {
       this.$emit('modal-open', isOpen);
+      this.modalIsOpen = isOpen;
     },
   },
 });

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -13,7 +13,7 @@
         class="fixed"
         :class="{
           'd-none': shouldShowAllCourses,
-          'position-fixed': !(isSafari && modalIsOpen),
+          'position-fixed': isSafari && modalIsOpen,
         }"
         data-intro-group="req-tooltip"
         :data-intro="getCoursesTooltipText()"
@@ -322,14 +322,15 @@ export default Vue.extend({
   width: 25rem;
   background-color: $white;
 }
+.position-static {
+  position: static;
+}
 .fixed {
+  position: fixed;
   left: 4.5rem;
   top: 0;
   overflow-y: scroll;
   overflow-x: hidden;
-}
-.position-fixed {
-  position: fixed;
 }
 .fixed,
 .see-all-padding {

--- a/src/components/Requirements/Requirements.vue
+++ b/src/components/Requirements/Requirements.vue
@@ -32,6 +32,7 @@
             @activateMajor="activateMajor"
             @activateMinor="activateMinor"
             @onShowAllCourses="onShowAllCourses"
+            @modal-open="modalToggled"
           />
         </div>
       </div>
@@ -270,6 +271,9 @@ export default Vue.extend({
     },
     cloneCourse(courseWithDummyUniqueID: FirestoreSemesterCourse): FirestoreSemesterCourse {
       return { ...courseWithDummyUniqueID, uniqueID: incrementUniqueID() };
+    },
+    modalToggled(isOpen: boolean) {
+      this.$emit('modal-open', isOpen);
     },
   },
 });

--- a/src/components/Requirements/SubRequirement.vue
+++ b/src/components/Requirements/SubRequirement.vue
@@ -100,6 +100,7 @@
             <completed-sub-req-course
               :subReqCourseId="id"
               :courseTaken="subReqCourseSlot.courses[0]"
+              @modal-open="modalToggled"
             />
           </div>
           <div v-if="!subReqCourseSlot.isCompleted" class="incompletesubreqcourse-wrapper">
@@ -123,7 +124,11 @@
         class="subreqcourse-wrapper"
       >
         <div v-for="(selfCheckCourse, id) in fulfilledSelfCheckCourses" :key="id">
-          <completed-sub-req-course :subReqCourseId="id" :courseTaken="selfCheckCourse" />
+          <completed-sub-req-course
+            :subReqCourseId="id"
+            :courseTaken="selfCheckCourse"
+            @modal-open="modalToggled"
+          />
         </div>
         <div v-if="!isCompleted">
           <incomplete-self-check
@@ -131,6 +136,7 @@
             :subReqName="subReq.requirement.name"
             :subReqFulfillment="subReq.fulfilledBy"
             :subReqCourseId="subReq.minCountFulfilled"
+            @modal-open="modalToggled"
           />
         </div>
       </div>
@@ -366,6 +372,9 @@ export default Vue.extend({
     },
     convertCourse(course: FirestoreSemesterCourse): CourseTaken {
       return convertFirestoreSemesterCourseToCourseTaken(course);
+    },
+    modalToggled(isOpen: boolean) {
+      this.$emit('modal-open', isOpen);
     },
   },
 });

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -272,15 +272,19 @@ export default Vue.extend({
       // Delete confirmation for the use case of adding multiple courses consecutively
       this.closeConfirmationModal();
       this.isCourseModalOpen = true;
+      this.$emit('modal-open', true);
     },
     closeCourseModal() {
       this.isCourseModalOpen = false;
+      this.$emit('modal-open', false);
     },
     closeEditModal() {
       this.isEditSemesterOpen = false;
+      this.$emit('modal-open', false);
     },
     closeDeleteModal() {
       this.isDeleteSemesterOpen = false;
+      this.$emit('modal-open', false);
     },
     openSemesterModal() {
       // Delete confirmation for the use case of adding multiple semesters consecutively
@@ -362,6 +366,7 @@ export default Vue.extend({
     },
     openEditSemesterModal() {
       this.isEditSemesterOpen = true;
+      this.$emit('modal-open', true);
     },
     editSemester(seasonInput: FirestoreSemesterType, yearInput: number) {
       editSemester(

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -75,6 +75,7 @@
             @new-semester="openSemesterModal"
             @delete-semester="deleteSemester"
             @open-caution-modal="openCautionModal"
+            @modal-open="modalToggle"
           />
         </div>
         <div v-if="!compact" class="semesterView-empty" aria-hidden="true"></div>
@@ -181,16 +182,20 @@ export default Vue.extend({
     openCautionModal() {
       this.cautionText = `Unable to add course. Already in plan.`;
       this.isCautionModalOpen = true;
+      this.$emit('modal-open', true);
 
       setTimeout(() => {
         this.isCautionModalOpen = false;
+        this.$emit('modal-open', false);
       }, 3000);
     },
     openSemesterModal() {
       this.isSemesterModalOpen = true;
+      this.$emit('modal-open', true);
     },
     closeSemesterModal() {
       this.isSemesterModalOpen = false;
+      this.$emit('modal-open', false);
     },
     addSemester(type: FirestoreSemesterType, year: number) {
       addSemester(type, year, this.$gtag);
@@ -214,6 +219,9 @@ export default Vue.extend({
     getToggleTooltipText() {
       return `<div class="introjs-tooltipTop"><div class="introjs-customTitle">Toggle between Views</div><div class="introjs-customProgress">4/4</div>
       </div><div class = "introjs-bodytext">View semesters and courses in full or compact mode.</div>`;
+    },
+    modalToggle(isOpen: boolean) {
+      this.$emit('modal-open', isOpen);
     },
   },
 });

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -16,12 +16,14 @@
           :isOpeningRequirements="isOpeningRequirements"
           @editProfile="editProfile"
           @toggleRequirementsBar="toggleRequirementsBar"
+          :modalIsOpen="modalIsOpen"
         />
         <requirements
           class="dashboard-reqs"
           v-if="loaded && (!isTablet || (isOpeningRequirements && isTablet))"
           :startTour="startTour"
           @showTourEndWindow="showTourEnd"
+          @modal-open="modalToggle"
         />
       </div>
       <semester-view
@@ -132,6 +134,7 @@ export default Vue.extend({
       welcomeHidden: false,
       startTour: false,
       showTourEndWindow: false,
+      modalIsOpen: false,
     };
   },
   computed: {
@@ -207,6 +210,10 @@ export default Vue.extend({
     editProfile() {
       this.isOnboarding = true;
       this.isEditingProfile = true;
+    },
+
+    modalToggle(isOpen: boolean) {
+      this.modalIsOpen = isOpen;
     },
   },
 });

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -35,6 +35,7 @@
         :isBottomBar="hasBottomCourses"
         :isMobile="isMobile"
         @compact-updated="compactVal = $event"
+        @modal-open="modalToggle"
       />
     </div>
     <tour-window


### PR DESCRIPTION
### Summary
This PR:
- [x] Ensures that when you are on mobile and have the requirements bar open, the hamburger menu properly triggers the navbar
![image](https://user-images.githubusercontent.com/55263191/113493116-a8aa0d00-94aa-11eb-94e3-cee82ad60172.png)
- [x] When you open any modal it should be above everything else
![image](https://user-images.githubusercontent.com/55263191/113493107-96c86a00-94aa-11eb-8472-faf70ddbea64.png)
- [x] Works on Safari
![image](https://user-images.githubusercontent.com/55263191/113493136-d1320700-94aa-11eb-85ac-e7dbd1542b6b.png)
- [x] Fixed funky Safari Desktop modals
- [ ] Works on Safari mobile
![IMG_DADDCC07091B-1](https://user-images.githubusercontent.com/55263191/113493164-1fdfa100-94ab-11eb-8a32-16a6ec2b4139.jpeg)
For some reason, things look different on Safari on my MacBook and Safari on my iPhone. For now, the Hamburger button works and things look way better than they used to on Safari Desktop:
Before:
![image](https://user-images.githubusercontent.com/55263191/113493258-c62ba680-94ab-11eb-852d-7f77689f8ce6.png)
After:
![image](https://user-images.githubusercontent.com/55263191/113493302-1d317b80-94ac-11eb-9f44-e4e00a4ec5c8.png)

Majority of the main functionality on mobile/desktop is implemented, so i feel comfortable merging this despite the modals from within the requirements bar still not working 100% as desired. This PR allows the user to perform majority of the functionality.

Components inherit the z-index of their parents. Therefore, the modals within the requirement bar need to sit above everything, but the requirement bar needs to be a lower z-index than the navbar. This simply isn't possible with the architecture we have right now.
![image](https://user-images.githubusercontent.com/55263191/113485351-058dcf00-947b-11eb-8f94-43456aa9ce43.png)

This is a _temporary fix_ for launch. We're going to need to do a refactor sometime post launch.


### Test Plan 
1. Go on mobile
  - Go to requirements
  - Click on the hamburger menu again and ensure that it triggers the side nav bar
2. Open up every instance of a modal you're aware of and ensure that it shows up above the navbar
  - Repeat on mobile
  - Repeat on Safari

# NOTE
All the code in this PR should be removed sometime in the future with a giant refactor.

