### PR TITLE
always expand bottom bar when clicking course

### DIFF
--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -66,6 +66,7 @@ export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
       vueForBottomBar.bottomCourseFocus = i;
       return;
     }
+    vueForBottomBar.isExpanded = true;
   }
 
   if (vueForBottomBar.bottomCourses.length === 0) {


### PR DESCRIPTION
### Summary <!-- Required -->

https://www.notion.so/courseplan/clicking-on-a-course-when-bottom-bar-is-already-open-but-uncollapsed-doesn-t-open-it-7914556251d14f02b2d44b8983f1bdd5

### Test Plan <!-- Required -->

Play around with bottom bar on staging to make sure the only changed behavior is clicking course while bottom bar is closed will open the bottom bar and focus the course.

