### PR TITLE
Add privacy policy page

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -13,12 +13,7 @@
         </p>
       </div>
       <div class="col-3 footer">
-        <a
-          class="footer"
-          target="_blank"
-          href="https://app.termly.io/document/privacy-policy/fcecc0e8-8af2-472d-8d27-b6b89d02a2be"
-          >Privacy Policy</a
-        >
+        <a class="footer" target="_blank" href="/policy">Privacy Policy</a>
       </div>
     </div>
   </div>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -22,10 +22,10 @@ export default Vue.extend({});
   max-width: 100%;
 }
 .top-bar {
-  padding: 59px 0px 0px 104px;
+  padding: 3.75rem 0px 0px 6.5rem;
 
   @media (max-width: 1154px) {
-    padding: 59px 104px 0px 104px;
+    padding: 3.75rem 6.5rem 0px 6.5rem;
     display: flex;
     flex-direction: column;
   }
@@ -33,7 +33,7 @@ export default Vue.extend({});
 
 @media (max-width: 1154px) {
   .top-bar {
-    padding: 50px;
+    padding: 3.125rem;
   }
 }
 </style>

--- a/src/containers/Policy.vue
+++ b/src/containers/Policy.vue
@@ -38,6 +38,7 @@
       <ul>
         <li>Name</li>
         <li>Email</li>
+        <li>Academic information, such as major, AP/IB test scores, and courses taken</li>
       </ul>
       <h4>Legitimate Reasons for Processing Your Personal Information</h4>
       <p>

--- a/src/containers/Policy.vue
+++ b/src/containers/Policy.vue
@@ -1,0 +1,264 @@
+<template>
+  <div>
+    <top-bar class="top" />
+    <div class="content">
+      <h2>Privacy Policy</h2>
+      <p>
+        Your privacy is important to us. It is Cornell Design Tech Initiative&#39;s policy to
+        respect your privacy and comply with any applicable law and regulation regarding any
+        personal information we may collect about you, including across our website,
+        <a href="https://courseplan.io/">https://courseplan.io/</a>, and other sites we own and
+        operate.
+      </p>
+      If you have any questions or concerns about this privacy notice, or our practices with regards
+      to your personal information, please contact us at
+      <a href="mailto: courseplan@cornelldti.org">courseplan@cornelldti.org</a>
+      <p>This policy is effective as of 4 April 2021 and was last updated on 4 April 2021.</p>
+
+      <h3>Information We Collect</h3>
+      <p>
+        Information we collect includes both information you knowingly and actively provide us when
+        using or participating in any of our services and promotions, and any information
+        automatically sent by your devices in the course of accessing our products and services.
+      </p>
+      <h4>Log Data</h4>
+      <p>
+        When you visit our website, our servers may automatically log the standard data provided by
+        your web browser. It may include your device’s Internet Protocol (IP) address, your browser
+        type and version, the pages you visit, the time and date of your visit, the time spent on
+        each page, other details about your visit, and technical details that occur in conjunction
+        with any errors you may encounter.
+      </p>
+      <p>
+        Please be aware that while this information may not be personally identifying by itself, it
+        may be possible to combine it with other data to personally identify individual persons.
+      </p>
+      <h4>Personal Information</h4>
+      <p>We may ask for personal information which may include one or more of the following:</p>
+      <ul>
+        <li>Name</li>
+        <li>Email</li>
+      </ul>
+      <h4>Legitimate Reasons for Processing Your Personal Information</h4>
+      <p>
+        We only collect and use your personal information when we have a legitimate reason for doing
+        so. In which instance, we only collect personal information that is reasonably necessary to
+        provide our services to you.
+      </p>
+      <h4>Collection and Use of Information</h4>
+      <p>
+        We may collect personal information from you when you do any of the following on our
+        website:
+      </p>
+      <ul>
+        <li>Use a mobile device or web browser to access our content</li>
+        <li>Contact us via email, social media, or on any similar technologies</li>
+        <li>When you mention us on social media</li>
+      </ul>
+      <p>
+        We may collect, hold, use, and disclose information for the following purposes, and personal
+        information will not be further processed in a manner that is incompatible with these
+        purposes:
+      </p>
+      <ul>
+        <li>to contact and communicate with you</li>
+        <li>
+          for analytics, market research, and business development, including to operate and improve
+          our website, associated applications, and associated social media platforms
+        </li>
+        <li>
+          to enable you to access and use our website, associated applications, and associated
+          social media platforms
+        </li>
+        <li>for internal record keeping and administrative purposes</li>
+        <li>to comply with our legal obligations and resolve any disputes that we may have</li>
+        <li>
+          for security and fraud prevention, and to ensure that our sites and apps are safe, secure,
+          and used in line with our terms of use
+        </li>
+      </ul>
+      <p>
+        We use Hotjar in order to better understand our users’ needs and to optimize this service
+        and experience. Hotjar is a technology service that helps us better understand our users’
+        experience (e.g. how much time they spend on which pages, which links they choose to click,
+        what users do and don’t like, etc.) and this enables us to build and maintain our service
+        with user feedback. Hotjar uses cookies and other technologies to collect data on our users’
+        behavior and their devices. This includes a device's IP address (processed during your
+        session and stored in a de-identified form), device screen size, device type (unique device
+        identifiers), browser information, geographic location (country only), and the preferred
+        language used to display our website. Hotjar stores this information on our behalf in a
+        pseudonymized user profile. Hotjar is contractually forbidden to sell any of the data
+        collected on our behalf. For further details, please see the ‘about Hotjar’ section of
+        <a href="https://help.hotjar.com/hc/en-us/categories/115001323967-About-Hotjar"
+          >Hotjar’s support site.</a
+        >
+      </p>
+      <p>
+        Please be aware that we may combine information we collect about you with general
+        information or research data we receive from other trusted sources.
+      </p>
+      <h4>Security of Your Personal Information</h4>
+      <p>
+        When we collect and process personal information, and while we retain this information, we
+        will protect it within commercially acceptable means to prevent loss and theft, as well as
+        unauthorized access, disclosure, copying, use, or modification.
+      </p>
+      <p>
+        Although we will do our best to protect the personal information you provide to us, we
+        advise that no method of electronic transmission or storage is 100% secure, and no one can
+        guarantee absolute data security. We will comply with laws applicable to us in respect of
+        any data breach.
+      </p>
+      <p>
+        You are responsible for selecting any password and its overall security strength, ensuring
+        the security of your own information within the bounds of our services.
+      </p>
+      <h4>How Long We Keep Your Personal Information</h4>
+      <p>
+        We keep your personal information only for as long as we need to. This time period may
+        depend on what we are using your information for, in accordance with this privacy policy. If
+        your personal information is no longer required, we will delete it or make it anonymous by
+        removing all details that identify you.
+      </p>
+      <p>
+        However, if necessary, we may retain your personal information for our compliance with a
+        legal, accounting, or reporting obligation or for archiving purposes in the public interest,
+        scientific, or historical research purposes or statistical purposes.
+      </p>
+      <h3>Children’s Privacy</h3>
+      <p>
+        We do not aim any of our products or services directly at children under the age of 13, and
+        we do not knowingly collect personal information about children under 13.
+      </p>
+      <h3>Disclosure of Personal Information to Third Parties</h3>
+      <p>
+        We only share and disclose your information with the following third parties. If we have
+        processed your data based on your consent and you wish to revoke your consent, please
+        contact us using the contact details provided at the end.
+      </p>
+      <ul>
+        <li>Cloud Computing Services</li>
+        Google Cloud Platform
+        <li>Functionality and Infrastructure Optimization</li>
+        Cloud Firestore and Cloud Functions for Firebase
+        <li>User Account Registration and Authentication</li>
+        Google OAuth 2.0
+        <li>Web and Mobile Analytics</li>
+        Google Analytics and Hotjar
+      </ul>
+
+      <h3>International Transfers of Personal Information</h3>
+      <p>
+        The personal information we collect is stored and/or processed where we or our partners,
+        affiliates, and third-party providers maintain facilities. Please be aware that the
+        locations to which we store, process, or transfer your personal information may not have the
+        same data protection laws as the country in which you initially provided the information. If
+        we transfer your personal information to third parties in other countries: (i) we will
+        perform those transfers in accordance with the requirements of applicable law; and (ii) we
+        will protect the transferred personal information in accordance with this privacy policy.
+      </p>
+      <h3>Your Rights and Controlling Your Personal Information</h3>
+      <p>
+        You always retain the right to withhold personal information from us, with the understanding
+        that your experience of our website may be affected. We will not discriminate against you
+        for exercising any of your rights over your personal information. If you do provide us with
+        personal information you understand that we will collect, hold, use and disclose it in
+        accordance with this privacy policy. You retain the right to request details of any personal
+        information we hold about you.
+      </p>
+      <p>
+        If we receive personal information about you from a third party, we will protect it as set
+        out in this privacy policy. If you are a third party providing personal information about
+        somebody else, you represent and warrant that you have such person’s consent to provide the
+        personal information to us.
+      </p>
+      <p>
+        If you have previously agreed to us using your personal information for direct marketing
+        purposes, you may change your mind at any time. We will provide you with the ability to
+        unsubscribe from our email-database or opt out of communications. Please be aware we may
+        need to request specific information from you to help us confirm your identity.
+      </p>
+      <p>
+        If you believe that any information we hold about you is inaccurate, out of date,
+        incomplete, irrelevant, or misleading, please contact us using the details provided in this
+        privacy policy. We will take reasonable steps to correct any information found to be
+        inaccurate, incomplete, misleading, or out of date.
+      </p>
+      <p>
+        If you believe that we have breached a relevant data protection law and wish to make a
+        complaint, please contact us using the details below and provide us with full details of the
+        alleged breach. We will promptly investigate your complaint and respond to you, in writing,
+        setting out the outcome of our investigation and the steps we will take to deal with your
+        complaint. You also have the right to contact a regulatory body or data protection authority
+        in relation to your complaint.
+      </p>
+      <h3>Use of Cookies</h3>
+      <p>
+        We use &ldquo;cookies&rdquo; to collect information about you and your activity across our
+        site. A cookie is a small piece of data that our website stores on your computer, and
+        accesses each time you visit, so we can understand how you use our site. This helps us serve
+        you content based on preferences you have specified.
+      </p>
+      <h3>Limits of Our Policy</h3>
+      <p>
+        Our website may link to external sites that are not operated by us. Please be aware that we
+        have no control over the content and policies of those sites, and cannot accept
+        responsibility or liability for their respective privacy practices.
+      </p>
+      <h3>Changes to This Policy</h3>
+      <p>
+        At our discretion, we may change our privacy policy to reflect updates to our business
+        processes, current acceptable practices, or legislative or regulatory changes. If we decide
+        to change this privacy policy, we will post the changes here at the same link by which you
+        are accessing this privacy policy.
+      </p>
+      <p>
+        If required by law, we will get your permission or give you the opportunity to opt in to or
+        opt out of, as applicable, any new uses of your personal information.
+      </p>
+      <h3>Contact Us</h3>
+      <p>
+        For any questions or concerns regarding your privacy, you may contact us using the following
+        details:
+      </p>
+      <p><a href="mailto: courseplan@cornelldti.org">courseplan@cornelldti.org</a></p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+import TopBar from '@/components/TopBar.vue';
+
+export default Vue.extend({
+  components: { TopBar },
+});
+</script>
+
+<style scoped lang="scss">
+.content {
+  margin: 2rem 6.5rem;
+}
+
+h2 {
+  font-size: 2rem;
+}
+
+h3 {
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+h4 {
+  font-size: 1.2rem;
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+@media (max-width: 1154px) {
+  .content {
+    margin: 0 3.125rem 2rem 3.125rem;
+  }
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import Router from 'vue-router';
 import Login from '@/containers/Login.vue';
 import Dashboard from '@/containers/Dashboard.vue';
 import Page404 from '@/containers/404.vue';
+import Policy from '@/containers/Policy.vue';
 import store from '../store';
 
 Vue.use(Router);
@@ -23,6 +24,11 @@ const router = new Router({
       meta: {
         requiresAuth: true,
       },
+    },
+    {
+      path: '/policy',
+      name: 'Policy',
+      component: Policy,
     },
     {
       path: '/*',


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request adds our own privacy policy page to CoursePlan

- [x] Add privacy policy page to router and add link to footer
- [x] Update privacy policy text as provided by @einc 
- [x] Slightly style html text and update top bar styling

![image](https://user-images.githubusercontent.com/25535093/113497879-ecfed280-94d5-11eb-834f-5f2ee5b1caa3.png)

### Test Plan <!-- Required -->

1. Confirm that the new privacy policy page can be reached by clicking on the link in the footer.
2. Confirm that the styling looks nice
3. Confirm the 404 page can still be accessed by typing in a malformed url, and that it still looks the same.
4. Confirm that CoursePlan can still be logged in and out of.

### Notes <!-- Optional -->

We switched from using term.ly to this page on our own domain because term.ly was not allowing us to use their own page without paying. The html they provided to copy was extremely malformed, and was unable to be fixed in 30 minutes. Instead, @einc generated this text with getterms.io with some of the term.ly text (like hotjar) copied in.
