### PR TITLE
Delete sem z-index fix

### DIFF
--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -527,7 +527,7 @@ export default Vue.extend({
   .semester-modal {
     display: none; /* Hidden by default */
     position: fixed; /* Stay in place */
-    z-index: 1; /* Sit on top */
+    z-index: 2; /* Sit on top */
     left: 0;
     top: 0;
     width: 100%; /* Full width */


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes a bug where the delete semester modal does not properly display above the navbar like the rest of the modals now do.

(Before Images)
![image](https://user-images.githubusercontent.com/25535093/113500098-694ee100-94e9-11eb-991e-bb4918673473.png)
![image](https://user-images.githubusercontent.com/25535093/113500100-6bb13b00-94e9-11eb-80c7-7edaea953999.png)

### Test Plan <!-- Required -->

Test that this modal shows up above the nav-bar (and does not look like the above images) for both mobile and desktop.

### Notes <!-- Optional -->

Two things:
1. I thought I was running into this bug for the reset modal as well (and sent screenshots to @hahnbeelee) but I can't reproduce it anymore. Not sure if this could be at all related to this problem existing for Safari in #430 even though I'm on Chrome, or if I just imagined this problem? 
2. It's not a good sign that after all the z-index testing this modal still slipped through... there were also a ton of other random z-index modal styles I found throughout the codebase when trying to figure out which one would fix this issue. Should I make a notion item to try and re-factor modals more to remove outdated and duplicated code @tcho6319 ?
