### PR TITLE
Style add semester buttons the same

### DIFF
--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -404,7 +404,7 @@ export default Vue.extend({
     border-radius: 8px;
     min-height: 2.5rem;
     min-width: 9rem;
-    color: #ffffff;
+    color: $white;
     border: none;
     position: absolute;
     top: -3.3rem;

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -251,6 +251,7 @@ export default Vue.extend({
     min-width: 9rem;
     color: $white;
     border: none;
+    font-size: 16px;
   }
 
   &-settings {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request updates the add semester button styles so that the two different versions look the same

![image](https://user-images.githubusercontent.com/25535093/113500377-710f8500-94eb-11eb-9ed2-fe72b12e2f95.png)
![image](https://user-images.githubusercontent.com/25535093/113500384-81bffb00-94eb-11eb-9594-872ac84b7675.png)

### Test Plan <!-- Required -->

Confirm that the new semester button looks the same (font size) when you have semesters in your plan and when you have deleted all of your semesters.
