### PR TITLE
Add graduation year

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -121,7 +121,8 @@ export default Vue.extend({
       if (
         this.name.firstName === '' ||
         this.name.lastName === '' ||
-        this.onboarding.college === ''
+        this.onboarding.college === '' ||
+        this.onboarding.gradYear === ''
       ) {
         this.isError = true;
       } else {

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -132,6 +132,7 @@ export default Vue.extend({
             lastName: this.name.lastName,
           })
           .set(onboardingDataCollection.doc(store.state.currentFirebaseUser.email), {
+            gradYear: this.onboarding.gradYear,
             colleges: [{ acronym: this.onboarding.college }],
             majors: this.onboarding.major.map(acronym => ({ acronym })),
             minors: this.onboarding.minor.map(acronym => ({ acronym })),
@@ -153,13 +154,14 @@ export default Vue.extend({
       this.currentPage = this.currentPage === FINAL_PAGE ? FINAL_PAGE : this.currentPage + 1;
     },
     updateBasic(
+      gradYear: number,
       college: string,
       major: readonly string[],
       minor: readonly string[],
       name: FirestoreUserName
     ) {
       this.name = name;
-      this.onboarding = { ...this.onboarding, college, major, minor };
+      this.onboarding = { ...this.onboarding, gradYear, college, major, minor };
     },
     updateTransfer(
       exams: readonly FirestoreAPIBExam[],

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -154,7 +154,7 @@ export default Vue.extend({
       this.currentPage = this.currentPage === FINAL_PAGE ? FINAL_PAGE : this.currentPage + 1;
     },
     updateBasic(
-      gradYear: number,
+      gradYear: string,
       college: string,
       major: readonly string[],
       minor: readonly string[],

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -37,6 +37,19 @@
       <div class="onboarding-inputs">
         <div class="onboarding-inputWrapper onboarding-inputWrapper--college">
           <label class="onboarding-label"
+            >Graduation Year<span class="onboarding-required-star">*</span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="semesters"
+              :choice="semesters"
+              :cannotBeRemoved="true"
+              @on-select="selectGraduationYear"
+            />
+          </div>
+        </div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--college">
+          <label class="onboarding-label"
             >College<span class="onboarding-required-star">*</span></label
           >
           <div class="onboarding-selectWrapper">
@@ -91,6 +104,7 @@
 import Vue, { PropType } from 'vue';
 import reqsData from '@/requirements/typed-requirement-json';
 import { clickOutside } from '@/utilities';
+import store from '@/store';
 import OnboardingBasicMultiDropdown from './OnboardingBasicMultiDropdown.vue';
 import OnboardingBasicSingleDropdown from './OnboardingBasicSingleDropdown.vue';
 
@@ -112,6 +126,7 @@ export default Vue.extend({
       middleName: this.userName.middleName,
       lastName: this.userName.lastName,
       placeholderText,
+      gradYear: this.onboardingData.gradYear,
       collegeAcronym: this.onboardingData.college,
       majorAcronyms,
       minorAcronyms,
@@ -146,11 +161,15 @@ export default Vue.extend({
       });
       return minors;
     },
+    semesters(): readonly number[] {
+      return store.state.semesters.map(sem => sem.year);
+    },
   },
   methods: {
     updateBasic() {
       this.$emit(
         'updateBasic',
+        this.gradYear,
         this.collegeAcronym,
         this.majorAcronyms.filter(it => it !== ''),
         this.minorAcronyms.filter(it => it !== ''),
@@ -173,6 +192,10 @@ export default Vue.extend({
           this.majorAcronyms[x] = '';
         }
       }
+    },
+    selectGraduationYear(year: number) {
+      this.gradYear = year;
+      this.updateBasic();
     },
     selectCollege(acronym: string) {
       this.collegeAcronym = acronym;

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -44,6 +44,7 @@
               :availableChoices="semesters"
               :choice="gradYear"
               :cannotBeRemoved="true"
+              :scrollToIndex="6"
               @on-select="selectGraduationYear"
             />
           </div>
@@ -62,9 +63,7 @@
           </div>
         </div>
         <div class="onboarding-inputWrapper onboarding-inputWrapper--college">
-          <label class="onboarding-label"
-            >Major<span class="onboarding-required-star">*</span></label
-          >
+          <label class="onboarding-label">Major</label>
           <onboarding-basic-multi-dropdown
             :availableChoices="majors"
             :dropdownChoices="majorAcronyms"

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -42,7 +42,7 @@
           <div class="onboarding-selectWrapper">
             <onboarding-basic-single-dropdown
               :availableChoices="semesters"
-              :choice="semesters"
+              :choice="gradYear"
               :cannotBeRemoved="true"
               @on-select="selectGraduationYear"
             />
@@ -104,7 +104,6 @@
 import Vue, { PropType } from 'vue';
 import reqsData from '@/requirements/typed-requirement-json';
 import { clickOutside } from '@/utilities';
-import store from '@/store';
 import OnboardingBasicMultiDropdown from './OnboardingBasicMultiDropdown.vue';
 import OnboardingBasicSingleDropdown from './OnboardingBasicSingleDropdown.vue';
 
@@ -161,8 +160,15 @@ export default Vue.extend({
       });
       return minors;
     },
-    semesters(): readonly number[] {
-      return store.state.semesters.map(sem => sem.year);
+    semesters(): Readonly<Record<string, string>> {
+      const semsDict: Record<string, string> = {};
+      const yearRange = 6;
+      const curYear = new Date().getFullYear();
+      for (let i = -yearRange; i <= yearRange; i += 1) {
+        const yr = String(curYear + i);
+        semsDict[yr] = yr;
+      }
+      return semsDict;
     },
   },
   methods: {
@@ -193,7 +199,7 @@ export default Vue.extend({
         }
       }
     },
-    selectGraduationYear(year: number) {
+    selectGraduationYear(year: string) {
       this.gradYear = year;
       this.updateBasic();
     },

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -44,7 +44,7 @@
               :availableChoices="semesters"
               :choice="gradYear"
               :cannotBeRemoved="true"
-              :scrollToIndex="6"
+              :scrollBottomToIndex="9"
               @on-select="selectGraduationYear"
             />
           </div>

--- a/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
@@ -25,6 +25,7 @@
           v-for="(fullName, key) in availableChoices"
           :key="key"
           class="onboarding-dropdown-content-item"
+          ref="scrollRef"
           @click="onSelect(key)"
         >
           {{ fullName }}
@@ -57,6 +58,7 @@ export default Vue.extend({
     },
     choice: { type: String, required: true },
     cannotBeRemoved: { type: Boolean, required: true },
+    scrollToIndex: { type: Number, default: 0 },
   },
   data() {
     return {
@@ -82,6 +84,14 @@ export default Vue.extend({
       } else {
         this.boxBorder = yuxuanBlue;
         this.arrowColor = yuxuanBlue;
+      }
+
+      // scroll to the middle of the year div after visible (on the next tick)
+      if (!contentShown && this.scrollToIndex > 0) {
+        this.$nextTick(() => {
+          const el = (this.$refs.scrollRef as Element[])[this.scrollToIndex];
+          el.scrollIntoView({ behavior: 'auto' });
+        });
       }
     },
     closeDropdownIfOpen() {

--- a/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
@@ -58,7 +58,7 @@ export default Vue.extend({
     },
     choice: { type: String, required: true },
     cannotBeRemoved: { type: Boolean, required: true },
-    scrollToIndex: { type: Number, default: 0 },
+    scrollBottomToIndex: { type: Number, default: 0 },
   },
   data() {
     return {
@@ -86,11 +86,11 @@ export default Vue.extend({
         this.arrowColor = yuxuanBlue;
       }
 
-      // scroll to the middle of the year div after visible (on the next tick)
-      if (!contentShown && this.scrollToIndex > 0) {
+      // scroll the bottom of the graduation year dropdown to scrollBottomToIndex
+      if (!contentShown && this.scrollBottomToIndex > 0) {
         this.$nextTick(() => {
-          const el = (this.$refs.scrollRef as Element[])[this.scrollToIndex];
-          el.scrollIntoView({ behavior: 'auto' });
+          const el = (this.$refs.scrollRef as Element[])[this.scrollBottomToIndex];
+          el.scrollIntoView({ behavior: 'auto', block: 'nearest' });
         });
       }
     },

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -58,9 +58,7 @@
             </div>
           </div>
           <div class="onboarding-selectWrapper-review">
-            <label class="onboarding-label"
-              >Major<span class="onboarding-required-star">*</span></label
-            >
+            <label class="onboarding-label">Major</label>
             <div v-for="(major, index) in onboardingData.major" :key="index">
               <label class="onboarding-label--review">{{ getMajorFullName(major) }}</label>
             </div>

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -43,6 +43,14 @@
         <div class="onboarding-selectWrapper">
           <div class="onboarding-selectWrapper-review">
             <label class="onboarding-label"
+              >Graduation Year<span class="onboarding-required-star">*</span></label
+            >
+            <div>
+              <label class="onboarding-label--review">{{ gradYearText }}</label>
+            </div>
+          </div>
+          <div class="onboarding-selectWrapper-review">
+            <label class="onboarding-label"
               >College<span class="onboarding-required-star">*</span></label
             >
             <div>
@@ -165,6 +173,9 @@ export default Vue.extend({
       return this.onboardingData.college !== ''
         ? getCollegeFullName(this.onboardingData.college)
         : placeholderText;
+    },
+    gradYearText(): string {
+      return this.onboardingData.gradYear !== '' ? this.onboardingData.gradYear : placeholderText;
     },
     totalCredits(): number {
       let count = 0;

--- a/src/requirements/__test__/exam-credit.test.ts
+++ b/src/requirements/__test__/exam-credit.test.ts
@@ -161,6 +161,7 @@ it("Some colleges don't have an equivalent course", () => {
  */
 it('Exam is counted correctly for one major', () => {
   const userData: AppOnboardingData = {
+    gradYear: '2020',
     college: 'EN',
     major: ['CS'],
     exam: [{ type: 'AP', score: 5, subject: 'Computer Science A' }],
@@ -176,6 +177,7 @@ it('Exam is counted correctly for one major', () => {
 
 it('Two exams are counted correctly for one major', () => {
   const userData: AppOnboardingData = {
+    gradYear: '2020',
     college: 'EN',
     major: ['CS'],
     exam: [
@@ -194,6 +196,7 @@ it('Two exams are counted correctly for one major', () => {
 
 it('One exam is only counted once for multiple majors', () => {
   const userData: AppOnboardingData = {
+    gradYear: '2020',
     college: 'EN',
     major: ['CS', 'Biological Sciences'],
     exam: [{ type: 'AP', score: 5, subject: 'Computer Science A' }],
@@ -210,6 +213,7 @@ it('One exam is only counted once for multiple majors', () => {
 
 it('Equivalent course appears if it matches one major but not the other', () => {
   let userData: AppOnboardingData = {
+    gradYear: '2020',
     college: 'EN',
     major: ['Biological Sciences'],
     exam: [{ type: 'AP', score: 4, subject: 'Statistics' }],
@@ -222,6 +226,7 @@ it('Equivalent course appears if it matches one major but not the other', () => 
   expect(courseEquivalents.length).toBe(0);
 
   userData = {
+    gradYear: '2020',
     college: 'EN',
     major: ['CS', 'Biological Sciences'],
     exam: [{ type: 'AP', score: 4, subject: 'Statistics' }],

--- a/src/store.ts
+++ b/src/store.ts
@@ -213,7 +213,7 @@ const autoRecomputeDerivedData = (): (() => void) =>
 
 const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
   // TODO: take into account multiple colleges
-  gradYear: 'gradYear' in data ? data.gradYear : String(new Date().getFullYear()),
+  gradYear: data.gradYear ? data.gradYear : '',
   college: data.colleges[0].acronym,
   major: data.majors.map(({ acronym }) => acronym),
   minor: data.minors.map(({ acronym }) => acronym),

--- a/src/store.ts
+++ b/src/store.ts
@@ -64,7 +64,7 @@ const store: TypedVuexStore = new TypedVuexStore({
     currentFirebaseUser: null!,
     userName: { firstName: '', middleName: '', lastName: '' },
     onboardingData: {
-      gradYear: 2020,
+      gradYear: '',
       college: '',
       major: [],
       minor: [],
@@ -213,6 +213,7 @@ const autoRecomputeDerivedData = (): (() => void) =>
 
 const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
   // TODO: take into account multiple colleges
+  gradYear: 'gradYear' in data ? data.gradYear : String(new Date().getFullYear()),
   college: data.colleges[0].acronym,
   major: data.majors.map(({ acronym }) => acronym),
   minor: data.minors.map(({ acronym }) => acronym),

--- a/src/store.ts
+++ b/src/store.ts
@@ -64,6 +64,7 @@ const store: TypedVuexStore = new TypedVuexStore({
     currentFirebaseUser: null!,
     userName: { firstName: '', middleName: '', lastName: '' },
     onboardingData: {
+      gradYear: 2020,
       college: '',
       major: [],
       minor: [],

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -45,6 +45,7 @@ type FirestoreTransferClass = {
 };
 type FirestoreOnboardingUserData = {
   readonly class: readonly FirestoreTransferClass[];
+  readonly gradYear: number;
   readonly colleges: readonly FirestoreCollegeOrMajorOrMinor[];
   readonly majors: readonly FirestoreCollegeOrMajorOrMinor[];
   readonly minors: readonly FirestoreCollegeOrMajorOrMinor[];
@@ -98,6 +99,7 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
 }
 
 type AppOnboardingData = {
+  readonly gradYear: number;
   readonly college: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -45,7 +45,7 @@ type FirestoreTransferClass = {
 };
 type FirestoreOnboardingUserData = {
   readonly class: readonly FirestoreTransferClass[];
-  readonly gradYear: number;
+  readonly gradYear: string;
   readonly colleges: readonly FirestoreCollegeOrMajorOrMinor[];
   readonly majors: readonly FirestoreCollegeOrMajorOrMinor[];
   readonly minors: readonly FirestoreCollegeOrMajorOrMinor[];
@@ -99,7 +99,7 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
 }
 
 type AppOnboardingData = {
-  readonly gradYear: number;
+  readonly gradYear: string;
   readonly college: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];


### PR DESCRIPTION
### Summary <!-- Required -->

Adds graduation field to onboarding.

https://www.notion.so/courseplan/Add-Graduation-Year-6b8a28de1ca14eb3b08b3fc8fe00cf03

### Test Plan <!-- Required -->

Playtest on staging make sure nothing is broken.

Tests for Will's changes
1. Delete your onboarding data and ensure there is no graduation year by default (so for new users). Then confirm you cannot submit onboarding without inputting it.
2. Delete just the "gradYear" field from your onboarding (to simulate existing users) and ensure graduation year is still not selected by default.
3. Note that only required courses have the * mark on them (major asterisks removed)
4. Ensure the grad year dropdown autoscrolls to 2021

### Will's Notes
1. Because the onboarding modal can be clicked outside for existing users, we have no way to force users who have used our beta to input their graduation years. If this is important, we should force them to do so if the field is empty with some new modal in the future. Is this something I should make an item for to explore?
2. ~~The autoscroll, implemented the same as the add-semester modal, does not work as well for the onboarding modal because it is vertically larger than a screen, so it also scrolls the whole modal and not just the dropdown. If this is not visually pleasing, I could either try to change the scroll to be `smooth` instead of `auto` or remove it entirely.~~ FIXED

### Breaking Changes 

Adds new `'gradYear' : string` field to firestore and vuex onboarding data types.
