### PR TITLE
Remove whitelist and landingEmails

### DIFF
--- a/src/containers/Login.vue
+++ b/src/containers/Login.vue
@@ -151,6 +151,8 @@ import CustomFooter from '@/components/Footer.vue';
 
 import { GTagLoginEvent } from '@/gtag';
 import * as fb from '@/firebaseConfig';
+import store from '@/store';
+import { checkNotNull } from '@/utilities';
 
 type Data = {
   loginForm: { email: string; password: string };
@@ -183,9 +185,14 @@ export default Vue.extend({
       fb.auth
         .signInWithPopup(provider)
         .then(user => {
-          if (user == null) {
+          if (user == null || user.user == null) {
             return;
           }
+          const simplifiedUser = {
+            displayName: checkNotNull(user.user.displayName),
+            email: checkNotNull(user.user.email),
+          };
+          store.commit('setCurrentFirebaseUser', simplifiedUser);
           this.performingRequest = false;
           this.$router.push('/');
           GTagLoginEvent(this.$gtag, 'Google');

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -111,6 +111,3 @@ export const onboardingDataCollection = db
       return userData;
     },
   });
-
-export const whitelistCollection = db.collection('cpWhitelist');
-export const landingEmailsCollection = db.collection('landingEmails');


### PR DESCRIPTION
### Summary 

This pull request removes the whitelist and unused landing emails (since the landing page no longer collects emails). **Once this PR is merged, CP would in effect be open to anyone with Gmail.**

- [x] removed mentions of whitelist in code
- [x] removed mentions of landingEmails

Remaining TODOs:

- [x] resolve router error: When I log into CP with my gmail, I am logged in successfully. However, once I logout and then log in again, I get the following error message. After receiving that error message, if I try to log in again, it works. I'm stuck on this rn, but if anyone has any insights, please lmk!

![Screen Shot 2021-04-04 at 2 56 38 PM](https://user-images.githubusercontent.com/54298311/113518859-dfd5f800-9556-11eb-8a3c-6d6cdc7d236e.png)


### Test Plan
1. CP members: You should be able to log into CP with your Cornell Gmail.
2. You should also be able to log into CP with another Gmail (i.e. one that is not on the cp whitelist)
3. Even better, if you have a Gmail that has not been on any whitelist (alpha, beta, cp), you should still be able to log in.

