### PR TITLE
Release Fixes (Duplicate semesters, broken course menu)

### DIFF
--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -26,7 +26,7 @@
       @delete-course="deleteCourse"
       @color-course="colorCourse"
       @edit-course-credit="editCourseCredit"
-      :getCreditRange="getCreditRange"
+      :getCreditRange="getCreditRange || []"
       v-click-outside="closeMenuIfOpen"
     />
   </div>

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -52,7 +52,7 @@
         class="courseMenu-section"
         @mouseover="setDisplayEditCourseCredits(true)"
         @mouseleave="setDisplayEditCourseCredits(false)"
-        v-if="getCreditRange[0] != getCreditRange[1]"
+        v-if="getCreditRange && getCreditRange[0] != getCreditRange[1]"
       >
         <img
           v-if="isLeft"

--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -127,6 +127,7 @@ export default Vue.extend({
       default: null,
     },
     isEdit: { type: Boolean, default: false },
+    isSemesterAdd: { type: Boolean, default: false },
     year: { type: Number, default: 0 },
     type: { type: String as PropType<FirestoreSemesterType>, default: '' },
     isCourseModelSelectingSemester: { type: Boolean, default: false },
@@ -286,6 +287,10 @@ export default Vue.extend({
         this.seasonText = '';
       } else {
         this.yearText = 0;
+      }
+
+      if (this.isSemesterAdd) {
+        this.$emit('updateSemProps', this.seasonPlaceholder, Number(this.yearPlaceholder));
       }
     },
     resetDropdowns() {

--- a/src/components/Modals/NewSemesterModal.vue
+++ b/src/components/Modals/NewSemesterModal.vue
@@ -12,6 +12,7 @@
     <new-semester
       :currentSemesters="semesters"
       :isEdit="false"
+      :isSemesterAdd="true"
       :isCourseModelSelectingSemester="false"
       @duplicateSemester="disableButton"
       @updateSemProps="updateSemProps"


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes release issues found after launching the site but before removing the final whitelist.

- [x] Prevents duplicate semesters by resetting sem and year when dropdowns are reset for the new semester modal
- [x] Fixes issue where old courses that do not have credit ranges defined do not prevent the edit color/delete course menu from opening

![image](https://user-images.githubusercontent.com/25535093/113520663-aefbc000-9562-11eb-963e-50b8bccfb50f.png)

Remaining TODOs:

- [ ] Slacked issues

### Test Plan <!-- Required -->

1. Confirm duplicate semesters cannot be created like they can on courseplan.io: Delete all of your semesters, than add a semester of any season/year besides Spring 2021, then open the add semester modal and click add immediately. This fix should make it Spring 2021 instead of a duplicate sem.
2. Confirm these dropdowns still work and reset when modals are clicked outside of and submitted for the other places it is used in the code (edit semester and add course from self check).
3. Confirm that for a course like INFO 4998, when added to your plan, credits can still be edited.
4. Now delete the "creditRange" field from that course on the dev firebase and reload the page. Confirm that credits cannot be edited but colors can change and the course can be deleted


### Notes
- Should I make an item for solving the credit issue with a script long term?