### PR TITLE
Add script to update a&s college for old users

### DIFF
--- a/functions/updateArts.js
+++ b/functions/updateArts.js
@@ -23,7 +23,7 @@ const transformData = oldColleges => {
     }
   });
 
-  return { colleges };
+  return colleges;
 };
 
 if (process.argv[2] === '--dry-run') {

--- a/functions/updateArts.js
+++ b/functions/updateArts.js
@@ -44,7 +44,7 @@ if (process.argv[2] === '--dry-run') {
     userColleges.forEach(doc => {
       const old = doc.data().colleges;
       const colleges = transformData(old);
-      doc.ref.set({ colleges });
+      doc.ref.update({ colleges });
     });
   });
 }

--- a/functions/updateArts.js
+++ b/functions/updateArts.js
@@ -1,0 +1,50 @@
+const admin = require('firebase-admin');
+const fs = require('fs');
+const serviceAccount = require('./service-account.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
+});
+
+const db = admin.firestore();
+const onboardingCollection = db.collection('user-onboarding-data');
+
+// const oldFullName = 'Arts and Sciences';
+const oldAcronym = 'AS';
+const newAcronym = 'AS1'; // Before Fall 2020
+
+const transformData = oldColleges => {
+  const colleges = JSON.parse(JSON.stringify(oldColleges));
+
+  colleges.forEach(college => {
+    if (college.acronym == oldAcronym) {
+      college.acronym = newAcronym;
+    }
+  });
+
+  return { colleges };
+};
+
+if (process.argv[2] === '--dry-run') {
+  onboardingCollection.get().then(userColleges => {
+    const oldColleges = {};
+    const newColleges = {};
+    userColleges.forEach(doc => {
+      const old = doc.data().colleges;
+      oldColleges[doc.id] = old;
+      const colleges = transformData(old);
+      newColleges[doc.id] = colleges;
+    });
+    fs.writeFileSync('old-colleges.json', JSON.stringify(oldColleges, undefined, 2));
+    fs.writeFileSync('new-colleges.json', JSON.stringify(newColleges, undefined, 2));
+  });
+} else {
+  onboardingCollection.get().then(userColleges => {
+    userColleges.forEach(doc => {
+      const old = doc.data().colleges;
+      const colleges = transformData(old);
+      doc.ref.set({ colleges });
+    });
+  });
+}


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request creates a script that will update existing CoursePlan user data on prod to use the new A&S requirements (before Fall 2020) instead of the old college requirements, heavily based on #446 

### Test Plan <!-- Required -->

- [x] Run dry run and confirm the output is as expected
- [x] Run to update prod data and close PR (without merging)

### Notes <!-- Optional -->

I have not written a firebase function before and have yet to test this, want to get some eyes on it first.
