### PR TITLE
[easy] Remove simplified course json generator

### DIFF
--- a/src/requirements/courses-json-generator.ts
+++ b/src/requirements/courses-json-generator.ts
@@ -2,24 +2,6 @@ import { writeFileSync } from 'fs';
 import { courseCodeToDataAndOfferedMap } from './filtered-course-data';
 import { Course } from './types';
 
-export type CourseJson = {
-  [courseCode: string]: {
-    i: number; // course id
-    t: string; // title
-    r: string; // roster (aka semester)
-  };
-};
-
-const courseJson: CourseJson = Object.fromEntries(
-  Array.from(courseCodeToDataAndOfferedMap.values()).map(
-    ([semester, course]) =>
-      [
-        `${course.subject} ${course.catalogNbr}`,
-        { i: course.crseId, t: course.titleLong, r: semester },
-      ] as const
-  )
-);
-
 const fullCourseJson = (() => {
   const json: Record<number, Course & { roster: string }[]> = {};
 
@@ -32,5 +14,4 @@ const fullCourseJson = (() => {
   return json;
 })();
 
-writeFileSync('src/assets/courses/courses.json', JSON.stringify(courseJson));
 writeFileSync('src/assets/courses/full-courses.json', JSON.stringify(fullCourseJson));


### PR DESCRIPTION
### Summary <!-- Required -->

We are always using the full json now, so let's remove this dead code.

### Test Plan <!-- Required -->

Note that `src/assets/courses/courses.json` no longer exists in the repo, which shows that the generator code is indeed dead.