### PR TITLE
Post launch identified bugs (Total credit denominator, edit semester dropdowns)

### DIFF
--- a/src/components/Modals/NewSemester.vue
+++ b/src/components/Modals/NewSemester.vue
@@ -290,7 +290,7 @@ export default defineComponent({
         this.yearText = 0;
       }
 
-      if (this.isSemesterAdd) {
+      if (this.isSemesterAdd || this.isEdit) {
         this.$emit('updateSemProps', this.seasonPlaceholder, Number(this.yearPlaceholder));
       }
     },

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -106,10 +106,7 @@ const getTotalCreditsFulfillmentStatistics = (
 
   let minCountFulfilled = 0;
   const minCountRequired = 120;
-  const eligibleCourses =
-    college === 'AG'
-      ? courses.filter(course => !course.code.startsWith('PE '))
-      : courses.filter(courseIsAllEligible);
+  const eligibleCourses = courses.filter(courseIsAllEligible);
 
   eligibleCourses.forEach(course => {
     minCountFulfilled += course.credits;

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -105,8 +105,7 @@ const getTotalCreditsFulfillmentStatistics = (
   }
 
   let minCountFulfilled = 0;
-  let minCountRequired = 120;
-  const courseCodeSet = new Set<string>();
+  const minCountRequired = 120;
   const eligibleCourses =
     college === 'AG'
       ? courses.filter(course => !course.code.startsWith('PE '))
@@ -114,11 +113,6 @@ const getTotalCreditsFulfillmentStatistics = (
 
   eligibleCourses.forEach(course => {
     minCountFulfilled += course.credits;
-    if (courseCodeSet.has(course.code)) {
-      minCountRequired += course.credits;
-    } else {
-      courseCodeSet.add(course.code);
-    }
   });
 
   return {

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -44,8 +44,8 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-AG-total-credits',
         description:
           '120 academic credits are required for graduation. ' +
-          'A minimum of 100 credits must be in courses for which a letter grade was recieved. ' +
-          'PE courses do not count.',
+          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits. ' +
+          'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'http://courses.cornell.edu/content.php?catoid=41&navoid=11561',
       };
       break;
@@ -55,7 +55,8 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-AS1-total-credits',
         description:
           '120 academic credits are required. ' +
-          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits.',
+          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits. ' +
+          'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'http://courses.cornell.edu/content.php?catoid=41&navoid=11570#credit-req',
       };
       break;
@@ -75,7 +76,8 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-HE-total-credits',
         description:
           '120 academic credits are required. ' +
-          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits.',
+          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits. ' +
+          'Repeated courses may not apply to this requirement, but we do not check this.',
         source:
           'http://courses.cornell.edu/content.php?catoid=41&navoid=11600#Cornell_Credit_Requirements',
       };
@@ -86,7 +88,8 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-IL-total-credits',
         description:
           '120 academic credits are required. ' +
-          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits.',
+          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits. ' +
+          'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'http://courses.cornell.edu/content.php?catoid=41&navoid=11587',
       };
       break;
@@ -96,7 +99,8 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-BU-total-credits',
         description:
           '120 academic credits are required. ' +
-          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits.',
+          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits. ' +
+          'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'http://courses.cornell.edu/content.php?catoid=41&navoid=11715',
       };
       break;


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes two bugs identified by our users after the launch. [120 credits](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=01b596c8bca94d3cba14015f85ea0c65), [dropdown](https://www.notion.so/courseplan/82bf355c4b7b49f99691eb9f3afb203c?v=5da9d646f3ef424bbceb1ca0e8e00cf8&p=9e3425f540cc4cdf83f33281f266501c)

- [x] Stop the `minCountRequired` from incrementing. (We seem to have identified the bug incorrectly, it was not courses with customizable credits that was the issue, but duplicate courses in general, which tend to be things with editable credits like INFO 4998).
- [x] Reset edit semester data when the modal is clicked outside, like new semester.

![image](https://user-images.githubusercontent.com/25535093/114765250-ed4b6900-9d32-11eb-8681-bb6cc7355474.png)

### Test Plan <!-- Required -->

1. Add duplicate courses to your plan (some with editable credits like INFO 4998 and some without) and confirm the "120" for Total Academic Credits never changes
2.  Change the year or semester on the edit semester modal, close the modal without submitting, open it up, and submit. If the semester is unchanged (aka uses the dropdown defaults) then the bug is fixed.
3. Confirm edit semester, add semester, and add course from self check dropdown still works as expected.
