### PR TITLE
Factor out requirement components in RequirementFulfillment (1/n)

### DIFF
--- a/src/components/Requirements/RequirementDisplayToggle.vue
+++ b/src/components/Requirements/RequirementDisplayToggle.vue
@@ -1,0 +1,119 @@
+<template>
+  <button
+    @click="$emit('on-toggle')"
+    class="dropdown row slightly-lower-opacity-on-hover"
+    aria-haspopup="true"
+    data-toggle="dropdown"
+  >
+    <div class="row depth-req">
+      <div class="btn">
+        <drop-down-arrow
+          :isFlipped="displayDescription"
+          :fillColor="isCompleted ? '#979797CC' : '#979797'"
+          :isSubReq="true"
+        />
+      </div>
+      <div class="requirement-name-container">
+        <p class="requirement-name-text">
+          <span>{{ requirementFulfillment.requirement.name }}</span>
+        </p>
+      </div>
+    </div>
+    <div class="col requirement-progress text-right">
+      {{ requirementFulfillmentProgress }}
+    </div>
+  </button>
+</template>
+
+<script lang="ts">
+import { PropType, defineComponent } from 'vue';
+import DropDownArrow from '@/components/DropDownArrow.vue';
+
+export default defineComponent({
+  components: { DropDownArrow },
+  props: {
+    requirementFulfillment: { type: Object as PropType<RequirementFulfillment>, required: true },
+    isCompleted: { type: Boolean, required: true },
+    displayDescription: { type: Boolean, required: true },
+  },
+  emits: ['on-toggle'],
+  computed: {
+    requirementFulfillmentProgress(): string {
+      return this.requirementFulfillment.fulfilledBy !== 'self-check'
+        ? `${this.requirementFulfillment.minCountFulfilled}/${this.requirementFulfillment.minCountRequired} ${this.requirementFulfillment.fulfilledBy}`
+        : 'self check';
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/assets/scss/_variables.scss';
+
+.dropdown {
+  background: none;
+  width: 100%;
+  border: none;
+  justify-content: space-between;
+  padding: 0;
+  align-items: center;
+  min-height: 2.25rem;
+}
+
+.btn {
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &-2 {
+    padding-top: 0px;
+    margin: 0px;
+  }
+}
+.btn:focus,
+.btn:active {
+  outline: none !important;
+  box-shadow: none;
+}
+
+.row {
+  margin: 0;
+}
+.row > div {
+  padding: 0;
+}
+
+.depth-req {
+  justify-content: flex-start;
+  align-items: center;
+  div:first-child {
+    margin: 0px;
+  }
+}
+
+.text-right {
+  color: $lightPlaceholderGray;
+}
+
+.requirement-name-container {
+  text-align: left;
+  margin-left: 11px;
+  max-width: 11rem;
+
+  .requirement-name-text {
+    font-style: normal;
+    font-weight: normal;
+    font-size: 14px;
+    line-height: 14px;
+    color: $lightPlaceholderGray;
+    margin: 0;
+  }
+}
+
+.requirement-progress {
+  font-size: 14px;
+  line-height: 14px;
+  margin-top: auto;
+  margin-bottom: auto;
+}
+</style>

--- a/src/components/Requirements/RequirementFulfillment.vue
+++ b/src/components/Requirements/RequirementFulfillment.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="subrequirement">
+  <div>
     <requirement-display-toggle
       :requirementFulfillment="requirementFulfillment"
       :isCompleted="isCompleted"

--- a/src/components/Requirements/RequirementInformation.vue
+++ b/src/components/Requirements/RequirementInformation.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <div>
+      {{ requirement.description }}
+      <a :style="{ color: `#${color}` }" :href="requirement.source" target="_blank">
+        <strong>Learn More</strong></a
+      >
+    </div>
+    <div v-if="requirement.checkerWarning" class="requirement-checker-warning">
+      <img
+        class="requirement-checker-warning-icon"
+        src="@/assets/images/warning.svg"
+        alt="warning icon"
+      />
+      {{ requirement.checkerWarning }}
+    </div>
+    <div v-if="requirement.fulfilledBy === 'self-check'" class="requirement-checker-warning">
+      <img
+        class="requirement-checker-warning-icon"
+        src="@/assets/images/warning.svg"
+        alt="warning icon"
+      />
+      This requirement is not included in the progress bar because we do not check if it is
+      completed.
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { PropType, defineComponent } from 'vue';
+
+export default defineComponent({
+  props: {
+    requirement: { type: Object as PropType<RequirementWithIDSourceType>, required: true },
+    color: { type: String, required: true },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/assets/scss/_variables.scss';
+
+.requirement-checker-warning {
+  color: $warning;
+  margin-top: 0.25rem;
+
+  &-icon {
+    float: left;
+    margin: 0.125rem 0.25rem 0 0;
+    width: 14px;
+    height: 14px;
+  }
+}
+</style>


### PR DESCRIPTION
### Summary <!-- Required -->

Depends on #473.

Factor out some display component inside `RequirementFulfillment` to make it smaller and more manageable.

- The toggle part with progress now goes into `RequirementDisplayToggle`.
- The description + warnings now goes into `RequirementInformation`

### Test Plan <!-- Required -->

The toggle and the basic information is still correctly displayed:

<img width="379" alt="Screen Shot 2021-04-21 at 14 59 32" src="https://user-images.githubusercontent.com/4290500/115606941-53e00200-a2b2-11eb-9eb8-c907a8755508.png">
<img width="385" alt="Screen Shot 2021-04-21 at 14 59 46" src="https://user-images.githubusercontent.com/4290500/115606942-54789880-a2b2-11eb-8412-7a905141c9ac.png">
