### PR TITLE
[easy] Setup compound requirements types and generator

### DIFF
--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -17,6 +17,28 @@ type RequirementCommon = {
   readonly checkerWarning?: string;
 };
 
+type RequirementFulfillmentInformationCourseBase<T> = {
+  readonly fulfilledBy: 'courses';
+  /** The minimum number of courses/credits required to fulfill each sub-requirement. */
+  readonly perSlotMinCount: readonly number[];
+  /** The name of each slot, used for display only. */
+  readonly slotNames: readonly string[];
+  /** When we care more about how many slots are filled with some courses */
+  readonly minNumberOfSlots?: number;
+} & T;
+
+type RequirementFulfillmentInformationCreditBase<T> = {
+  readonly fulfilledBy: 'credits';
+  /** The minimum number of courses/credits required to fulfill each sub-requirement. */
+  readonly perSlotMinCount: readonly number[];
+  /** When we care more about how many slots are filled with some courses */
+  readonly minNumberOfSlots?: number;
+} & T;
+
+type RequirementFulfillmentInformationCourseOrCreditBase<T> =
+  | RequirementFulfillmentInformationCourseBase<T>
+  | RequirementFulfillmentInformationCreditBase<T>;
+
 /**
  * @param T additional information only attached to credits and courses type.
  */
@@ -26,21 +48,19 @@ type RequirementFulfillmentInformation<T = Record<string, unknown>> =
       // Currently unused.
       readonly minCount?: number;
     }
-  | ({
-      readonly fulfilledBy: 'courses';
-      /** The minimum number of courses/credits required to fulfill each sub-requirement. */
-      readonly perSlotMinCount: readonly number[];
-      /** The name of each slot, used for display only. */
-      readonly slotNames: readonly string[];
-      /** When we care more about how many slots are filled with some courses */
-      readonly minNumberOfSlots?: number;
+  | (RequirementFulfillmentInformationCourseBase<T> & {
+      /**
+       * Compound requirements only.
+       * It is a map from additional requirement name and corresponding courses/checkers.
+       */
+      readonly additionalRequirements?: {
+        readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
+      };
     } & T)
-  | ({
-      readonly fulfilledBy: 'credits';
-      /** The minimum number of courses/credits required to fulfill each sub-requirement. */
-      readonly perSlotMinCount: readonly number[];
-      /** When we care more about how many slots are filled with some courses */
-      readonly minNumberOfSlots?: number;
+  | (RequirementFulfillmentInformationCreditBase<T> & {
+      readonly additionalRequirements?: {
+        readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
+      };
     } & T)
   | {
       readonly fulfilledBy: 'toggleable';

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -54,10 +54,23 @@ const decorateRequirementWithCourses = (
       return requirement;
     case 'courses':
     case 'credits': {
-      const { checker, ...rest } = requirement;
+      const { checker, additionalRequirements, ...rest } = requirement;
       return {
         ...rest,
         courses: getEligibleCoursesFromRequirementCheckers(checker),
+        additionalRequirements:
+          additionalRequirements &&
+          Object.fromEntries(
+            Object.entries(additionalRequirements).map(
+              ([name, { checker: additionalChecker, ...additionalRequirementRest }]) => [
+                name,
+                {
+                  ...additionalRequirementRest,
+                  courses: getEligibleCoursesFromRequirementCheckers(additionalChecker),
+                },
+              ]
+            )
+          ),
       };
     }
     case 'toggleable': {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR setups up the type definition and requirement json generator, and does nothing else. It doesn't build relevant frontend UI, and doesn't change any requirement data. Therefore, running `npm run req-gen` results in zero requirement json change.

I added an optional field `additionalRequirements` that is a mapping from additional requirement name to additional checkers. For example, in the future, the enginnering liberal studies' requirement would be like:

```ts
{
  name: 'ENG liberal studies',
  checkers: [the checker accepts all categories],
  perSlotMinCount: [6],
  // ...
  additionalRequirements: {
    '3 categories:': {
      checker: [checker for SBA, checker for KCM, ...],
      perSlotMinCount: [1,1,...],
      minNumberOfSlots: 3,
      // ...
    },
    '2 2000+ level:': {
      checker: [checker for all catogories and 2000+],
      perSlotMinCount: [2],
      // ...
    },
  }
}
```

### Test Plan <!-- Required -->

👀 