### PR TITLE
Set CUReviews data to N/A for new FA21 courses

### DIFF
--- a/src/components/BottomBar/BottomBarCourseReview.vue
+++ b/src/components/BottomBar/BottomBarCourseReview.vue
@@ -142,6 +142,7 @@ export default defineComponent({
 
 .details {
   padding: 20px;
+  width: 100%;
 
   &-head {
     margin-top: 10px;

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -54,7 +54,15 @@ const getReviews = (
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ subject: subject.toLowerCase(), number }),
-  }).then(res => res.json().then(reviews => reviews.result));
+  }).then(res =>
+    res
+      .json()
+      .then(reviews =>
+        reviews.result
+          ? reviews.result
+          : { classRating: null, classDifficulty: null, classWorkload: null }
+      )
+  );
 
 export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
   vueForBottomBar.isExpanded = true;

--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <button
     class="bottombartab full-opacity-on-hover"
     :style="{ background: `#${color}` }"
     @click="$emit('on-change-focus')"
@@ -14,7 +14,7 @@
         alt="x to delete bottom bar tab"
       />
     </button>
-  </div>
+  </button>
 </template>
 
 <script lang="ts">

--- a/src/components/BottomBar/BottomBarTab.vue
+++ b/src/components/BottomBar/BottomBarTab.vue
@@ -50,6 +50,11 @@ export default defineComponent({
   padding-left: 8px;
   padding-right: 8px;
 
+  &:hover {
+    filter: brightness(95%);
+    transition: all 0.2s ease;
+  }
+
   &-wrapper {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request resolves the remaining issue in #485 - that the bottom bar could not be opened for new FA21 courses because there is no data for them yet on CUReviews. Also resolves related bottom bar bugs

- [x] Set CUReviews data to null when the course does not exist on CUReviews yet
- [x] Fix bug where courses with no descriptions in the bottom bar (like some of the new courses) are styled the same
- [x] Explore bottom bar tabs as buttons 

![image](https://user-images.githubusercontent.com/25535093/116795887-29f2c080-aaa6-11eb-8fe9-4a7ed06f9121.png)

### Test Plan <!-- Required -->

1. Ensure that clicking a new FA21 course like INFO 5101 or MUSIC 6270 opens up the bottom bar with "N/A" for each CUReviews field, and that the CUReviews link goes to their 404 page.
2. Ensure clicking a course with data such as CS 2110 still displays CUReviews data as expected, and switching tabs between that course and the new course still preserves the right data in the bottom bar.

### Notes <!-- Optional -->

Per the TPM of CUReviews, course data is usually added at the beginning of the semester (although they might do so soon because of a bug they are having), so this fix should be useful in future semesters as we add future semester data.
