### PR TITLE
Styling Bug Fix: Remove Bootstrap

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,11 +14,6 @@
     <link
       type="text/css"
       rel="stylesheet"
-      href="//unpkg.com/bootstrap/dist/css/bootstrap.min.css"
-    />
-    <link
-      type="text/css"
-      rel="stylesheet"
       href="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.css"
     />
 

--- a/src/assets/scss/_global.scss
+++ b/src/assets/scss/_global.scss
@@ -262,3 +262,9 @@ form {
     opacity: 0.8;
   }
 }
+
+.row > * {
+  flex-shrink: 0;
+  max-width: 100%;
+  width: auto;
+}

--- a/src/assets/scss/_global.scss
+++ b/src/assets/scss/_global.scss
@@ -262,9 +262,3 @@ form {
     opacity: 0.8;
   }
 }
-
-.row > * {
-  flex-shrink: 0;
-  max-width: 100%;
-  width: auto;
-}


### PR DESCRIPTION
### Summary
Fixes this styling bug:
![image](https://user-images.githubusercontent.com/55263191/117349154-12864f80-ae79-11eb-8931-26e105adac9a.png)

We are assuming this happened because the bootstrap updated post our push to prod.

Initially I tried to override it, but then I realized we always make our own styles and never refer to bootstrap styling. So, I just got rid of it because it seemed like a very outdated addition and after getting rid of it, nothing seems to change on the frontend styling.

### Test Plan
- Inspect all aspects of the frontend and make sure none of the styling looks off (bottom bar, req bar, onboarding, modals)
- Inspect mobile view

### Notes
[The PR where the Bootstrap was added](https://github.com/cornell-dti/course-plan/pull/5/files#diff-fc211eca36b0b8e521eb5d0f4347adbcac3ca210ba294cd0330e07a3d16e8308)