### PR TITLE
Remove Button to Open Slot Settings Menu

### DIFF
--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -15,9 +15,7 @@
           /></span>
           {{ slotName }}
         </div>
-        <button class="reqCourse-button" @click="openSlotMenu">
-          <img src="@/assets/images/settingsBlue.svg" alt="Requirement slot settings" />
-        </button>
+        <button class="reqCourse-button" @click="onDeleteModalOpen">Delete ></button>
       </div>
       <div class="completed-reqCourses-course-object-wrapper">
         <req-course


### PR DESCRIPTION
### Summary

This pull request removes the button to open the slot settings menu on the requirements bar.

- [x] Deleted the blue settings icon button to open the slot menu
- [x] Added a "Delete >" button for deleting a course

Left is PR, right is master:
![Screen Shot 2021-05-25 at 11 55 42 AM](https://user-images.githubusercontent.com/54298311/119529462-232b3680-bd50-11eb-8e44-d55a4a0692f0.png)

### Test Plan <!-- Required -->
1. Click "Delete >", the DeleteCourseModal should pop up.
2. You should be able to delete the course when you click on "Yes" in the DeleteCourseModal. You should be able to close the DeleteCourseModal if you click "No", the "X" button in the upper right corner, or outside the modal. 
3. Try this for a regular course and an AP/IB course.
4. Make sure this works for mobile as well.

No other functionality should be altered.

### Notes

This is a quick fix before we push to prod for the end of the Spring 2021 semester. In the Fall 2021 semester, we will want to reinstate the button from #511 when we finish off the work from #512.
