### PR TITLE
Implement GUI requirement debugger behind a flag

### DIFF
--- a/src/components/Requirements/RequirementDebugger.vue
+++ b/src/components/Requirements/RequirementDebugger.vue
@@ -1,0 +1,75 @@
+<template>
+  <svg class="debugger-svg" :width="900" :height="itemSize * 48 + 36">
+    <g v-for="(requirement, index) in requirementGraphForDisplay.requirements" :key="index">
+      <rect :x="0" :y="index * 48 + 16" :width="300" :height="32" class="requirement-box"></rect>
+      <text :x="8" :y="index * 48 + 36" :font-size="16">{{ requirement }}</text>
+    </g>
+    <g v-for="(course, index) in requirementGraphForDisplay.courses" :key="index">
+      <rect :x="600" :y="index * 48 + 16" :width="300" :height="32" class="course-box"></rect>
+      <text :x="608" :y="index * 48 + 36" :font-size="16" fill="white">{{ course }}</text>
+    </g>
+    <path v-for="(line, index) in lines" :key="index" :d="line" stroke="black" />
+  </svg>
+</template>
+<script lang="ts">
+import store from '@/store';
+import { defineComponent } from 'vue';
+
+type RequirementGraphForDisplay = {
+  requirements: readonly string[];
+  courses: readonly string[];
+  edges: readonly { readonly requirementIndex: number; readonly courseIndex: number }[];
+};
+
+function computeRequirementGraphForDisplay(): RequirementGraphForDisplay {
+  const graph = store.state.requirementFulfillmentGraph;
+  const requirements = graph.getAllRequirements();
+  const courses = graph.getAllCourses();
+  const requirementToIndexMap = new Map(requirements.map((it, index) => [it, index]));
+  const courseToIndexMap = new Map(courses.map((it, index) => [it.uniqueId, index]));
+  const edges = graph.getAllEdges().map(([requirement, course]) => {
+    const requirementIndex = requirementToIndexMap.get(requirement);
+    const courseIndex = courseToIndexMap.get(course.uniqueId);
+    if (requirementIndex == null || courseIndex == null) throw new Error();
+    return { requirementIndex, courseIndex };
+  });
+
+  return { requirements, courses: courses.map(it => it.code), edges };
+}
+
+export default defineComponent({
+  computed: {
+    requirementGraphForDisplay(): RequirementGraphForDisplay {
+      return computeRequirementGraphForDisplay();
+    },
+    itemSize(): number {
+      return Math.max(
+        this.requirementGraphForDisplay.requirements.length,
+        this.requirementGraphForDisplay.courses.length
+      );
+    },
+    lines(): readonly string[] {
+      return this.requirementGraphForDisplay.edges.map(
+        ({ requirementIndex, courseIndex }) =>
+          // See https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths
+          `M 300 ${requirementIndex * 48 + 32} L 600 ${courseIndex * 48 + 32}`
+      );
+    },
+  },
+});
+</script>
+<style scoped lang="scss">
+@import '@/assets/scss/_variables.scss';
+
+.debugger-svg {
+  overflow: visible;
+}
+
+.requirement-box {
+  fill: $einBlue;
+}
+
+.course-box {
+  fill: $yuxuanBlue;
+}
+</style>

--- a/src/components/Requirements/RequirementSideBar.vue
+++ b/src/components/Requirements/RequirementSideBar.vue
@@ -20,6 +20,23 @@
         data-step="2"
         data-tooltipClass="tooltipCenter"
       >
+        <button
+          class="requirement-debugger-toggler"
+          v-if="debuggerAllowed"
+          @click="toggleDebugger()"
+        >
+          Open Requirement Debugger
+        </button>
+        <teleport-modal
+          content-class="requirement-debugger-modal-content"
+          :isSimpleModal="true"
+          v-if="displayDebugger"
+        >
+          <button class="requirement-debugger-toggler" @click="toggleDebugger()">
+            Close Requirement Debugger
+          </button>
+          <requirement-debugger />
+        </teleport-modal>
         <div class="req" v-for="(req, index) in groupedRequirementFulfillmentReports" :key="index">
           <requirement-group
             :req="req"
@@ -97,8 +114,11 @@
 import draggable from 'vuedraggable';
 import { defineComponent } from 'vue';
 import introJs from 'intro.js';
+import { isRequirementDebuggerEnabled } from '@/debug-flags';
 
 import Course from '@/components/Course/Course.vue';
+import TeleportModal from '@/components/Modals/TeleportModal.vue';
+import RequirementDebugger from '@/components/Requirements/RequirementDebugger.vue';
 import RequirementGroup from '@/components/Requirements/RequirementGroup.vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 
@@ -114,6 +134,7 @@ export type ShowAllCourses = {
 };
 
 type Data = {
+  displayDebugger: boolean;
   displayedMajorIndex: number;
   displayedMinorIndex: number;
   numOfColleges: number;
@@ -134,7 +155,14 @@ tour.setOption('exitOnOverlayClick', 'false');
 const maxSeeAllCoursesPerPage = 24;
 
 export default defineComponent({
-  components: { draggable, Course, DropDownArrow, RequirementGroup },
+  components: {
+    draggable,
+    Course,
+    DropDownArrow,
+    RequirementDebugger,
+    RequirementGroup,
+    TeleportModal,
+  },
   props: {
     startTour: { type: Boolean, required: true },
   },
@@ -143,6 +171,7 @@ export default defineComponent({
   },
   data(): Data {
     return {
+      displayDebugger: false,
       displayedMajorIndex: 0,
       displayedMinorIndex: 0,
       numOfColleges: 1,
@@ -170,6 +199,9 @@ export default defineComponent({
     },
   },
   computed: {
+    debuggerAllowed(): boolean {
+      return isRequirementDebuggerEnabled();
+    },
     semesters(): readonly FirestoreSemester[] {
       return store.state.semesters;
     },
@@ -196,6 +228,9 @@ export default defineComponent({
     },
   },
   methods: {
+    toggleDebugger(): void {
+      this.displayDebugger = !this.displayDebugger;
+    },
     // TODO CHANGE FOR MULTIPLE COLLEGES & GRAD PROGRAMS
     showMajorOrMinorRequirements(id: number, group: string): boolean {
       // colleges and programs should always be shown as there can only be 1
@@ -289,6 +324,10 @@ export default defineComponent({
 
 <style scoped lang="scss">
 @import '@/assets/scss/_variables.scss';
+.requirement-debugger-toggler {
+  background: $medGray;
+  color: white;
+}
 .separator {
   height: 1px;
   width: 100%;
@@ -440,5 +479,16 @@ h1.title {
     width: 100%;
     height: calc(100vh - 4.5rem);
   }
+}
+</style>
+<style lang="scss">
+.modal-content.requirement-debugger-modal-content {
+  display: flex;
+  align-items: center;
+  background: white;
+  padding: 2em;
+  width: calc(100% - 10em);
+  height: 100vh;
+  overflow: scroll;
 }
 </style>

--- a/src/debug-flags.ts
+++ b/src/debug-flags.ts
@@ -1,0 +1,24 @@
+const GK_RDB = 'CP_GK-RDB'; // Requirement DeBugger
+
+export const isRequirementDebuggerEnabled = (): boolean => localStorage.getItem(GK_RDB) === 'true';
+
+const enableRequirementDebugger = (): void => {
+  localStorage.setItem(GK_RDB, 'true');
+  window.location.reload();
+};
+const disableRequirementDebugger = (): void => {
+  localStorage.removeItem(GK_RDB);
+  window.location.reload();
+};
+
+const GateKeeper = { enableRequirementDebugger, disableRequirementDebugger };
+
+declare global {
+  interface Window {
+    GK: typeof GateKeeper;
+  }
+}
+
+export const registerGateKeeper = (): void => {
+  window.GK = GateKeeper;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import router from './router/index';
 import store from './store';
 
 import * as fb from './firebaseConfig';
+import { registerGateKeeper } from './debug-flags';
 
 // handle page reloads
 let app: VueApp | undefined;
@@ -28,3 +29,5 @@ fb.auth.onAuthStateChanged(() => {
     app.mount('#app');
   }
 });
+
+registerGateKeeper();

--- a/src/requirements/requirement-graph.ts
+++ b/src/requirements/requirement-graph.ts
@@ -23,6 +23,20 @@ export default class RequirementFulfillmentGraph<
 
   private readonly courseToRequirementsMap: Map<number, Set<Requirement>> = new Map();
 
+  public getAllRequirements(): readonly Requirement[] {
+    return Array.from(this.requirementToCoursesMap.keys());
+  }
+
+  public getAllCourses(): readonly Course[] {
+    const coursesMap = new Map<number, Course>();
+    Array.from(this.requirementToCoursesMap.values()).forEach(map => {
+      map.forEach((course, id) => {
+        coursesMap.set(id, course);
+      });
+    });
+    return Array.from(coursesMap.values());
+  }
+
   public getAllEdges(): readonly (readonly [Requirement, Course])[] {
     const edges: (readonly [Requirement, Course])[] = [];
     this.requirementToCoursesMap.forEach((courses, requirement) => {


### PR DESCRIPTION
### Summary <!-- Required -->

It's currently a pain to debug what's going on with requirement. Sometimes we might wonder whether the graph algorithm is wrong or when the frontend adapter is wrong. To dig into the problem, we usually need to console log the requirement graph piece by piece, since the requirement graph object is not really serializable. For example, if we suspect that computation related to class `CS 4120` is wrong, we have to

```js
console.log(graph.getRequirementsByCourses('CS 4120'));
```

If our assumption is wrong, then we have to repeat this for every single course until we find what the problem is. Figuring out exactly going wrong might take several guesses, since the requirement algorithm is non-local. User decision will impact more than one edges.

Now imagine you can see what's going on in the entire graph, just like how you visualize the requirement bipartite graph in your head. With this tooling, you can stare at the graph to find out what's going on without need to open your code editor! Plus, you can debug this in prod with prod data!

This PR achieves the vision described above by implementing a GUI-based requirement debugger. I implemented a Vue component dynamically generating an SVG with requirements on one side and courses on the other, and edges connecting them. It is a simple query against the requirement graph in the VueX store.

To prevent normal user seeing this, it's gated behind a `localStorage` key (`CP_GK-RDB`). Technically it's not entirely secret from the end user, since they can set the flag by themselves and see it, but there is no security issue if the user decides to play with it.
I registered some helper command so that you can easily toggle it in the developer console by

```js
GK.enableRequirementDebugger()
GK.disableRequirementDebugger()
```



### Test Plan <!-- Required -->

https://user-images.githubusercontent.com/4290500/133685239-043c9d59-22c7-4919-bc8b-eae8d1d79d0c.mov



