### PR TITLE
Standardize CI node version and use npm cache

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
       - name: NPM Install
         run: npm install
       - name: Build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,9 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: '10.x'
+          cache: 'npm'
       - name: NPM Install
         run: npm install
       - name: Build

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -7,7 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
       - name: NPM Clean Install
         run: npm ci
       - name: Run Prettier Check
@@ -23,7 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
       - name: NPM Clean Install
         run: npm ci
       - name: Cypress Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
       - name: NPM Install
         run: npm install
       - name: Build


### PR DESCRIPTION
### Summary <!-- Required -->

Let's standardize the node version we use on CI. This updates the `setup-node` action to v2 and uses the node on CI by default (v14). `setup-node` action also allows you to cache `node_modules` now.

See https://github.com/actions/setup-node#caching-packages-dependencies

### Test Plan <!-- Required -->

It's first time running it with cache, so of course cache doesn't exist yet... So check with 👀 