### PR TITLE
Make all TS/JS/Vue files covered by the same eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: 'module',
     extraFileExtensions: ['.vue'],
-    project: ['./tsconfig.json', './tsconfig.node.json'],
   },
   env: {
     browser: true,
@@ -76,29 +75,15 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx', '*.vue'],
       rules: {
-        'import/extensions': [
-          'error',
-          'always',
-          {
-            js: 'never',
-            ts: 'never',
-            vue: 'always',
-          },
-        ],
+        'import/extensions': ['error', 'always', { js: 'never', ts: 'never', vue: 'always' }],
       },
     },
     {
       files: ['*.js'],
       rules: {
-        'import/extensions': [
-          'error',
-          'always',
-          {
-            js: 'never',
-            ts: 'never',
-            vue: 'never',
-          },
-        ],
+        '@typescript-eslint/no-var-requires': 'off',
+        'import/extensions': ['error', 'always', { js: 'never', ts: 'never', vue: 'never' }],
+        'import/no-unresolved': 'off',
       },
     },
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 .vscode
 .firebase
 requirement-generator-dist/
+.eslintcache
 
 # local env files
 .env.local

--- a/cypress/integration/test.spec.ts
+++ b/cypress/integration/test.spec.ts
@@ -9,6 +9,7 @@ before('Visit site logged in', () => {
   cy.visit('localhost:8080/login');
   cy.login(Cypress.env('TEST_UID'));
   cy.visit('localhost:8080');
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(5000); // ensure the page has time to load
 });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,12 +2,13 @@ const functions = require('firebase-functions');
 
 // The Firebase Admin SDK to access the Firebase Realtime Database.
 const admin = require('firebase-admin');
+
 admin.initializeApp();
 const db = admin.firestore();
 const usernameCollection = db.collection('user-name');
 const semestersCollection = db.collection('user-semesters');
 
-let average = array => array.reduce((a, b) => a + b) / array.length;
+const average = array => array.reduce((a, b) => a + b) / array.length;
 function typeToMonth(type) {
   switch (type) {
     case 'Spring':
@@ -19,23 +20,23 @@ function typeToMonth(type) {
     case 'Winter':
       return 12;
     default:
+      throw new Error();
   }
 }
 function isOld(semester) {
-  var currentTime = new Date();
-  var month = currentTime.getMonth() + 1;
-  var year = currentTime.getFullYear();
+  const currentTime = new Date();
+  const month = currentTime.getMonth() + 1;
+  const year = currentTime.getFullYear();
   if (semester.year > year) {
     return false;
-  } else if (semester.year < year) {
-    return true;
-  } else {
-    if (typeToMonth(semester.type) <= month) {
-      return true;
-    } else {
-      return false;
-    }
   }
+  if (semester.year < year) {
+    return true;
+  }
+  if (typeToMonth(semester.type) <= month) {
+    return true;
+  }
+  return false;
 }
 /**
  * TrackUsers returns user metrics based on
@@ -98,6 +99,7 @@ exports.TrackUsers = functions.https.onRequest(async (req, res) => {
 
   Promise.all([usernamePromise, semesterPromise]).then(promiseResponses => {
     const response = Object.assign({}, ...promiseResponses);
+    // eslint-disable-next-line no-console
     console.log(response);
     res.send(response);
     return response;

--- a/functions/rename-requirement-and-slot-name.js
+++ b/functions/rename-requirement-and-slot-name.js
@@ -61,19 +61,16 @@ const updateObjectValue = doc => {
 /**
  * Updates the exam property in the user-onboarding-data collection.
  */
-const updateExamProperty = doc => {
-  return doc.map(exam => {
-    return {
-      ...exam,
-      optIn: isChangingReqName
-        ? updateObjectProperty(exam.optIn)
-        : updateOnboardingSlotName(exam.optIn),
-      optOut: isChangingReqName
-        ? updateObjectProperty(exam.optOut)
-        : updateOnboardingSlotName(exam.optOut),
-    };
-  });
-};
+const updateExamProperty = doc =>
+  doc.map(exam => ({
+    ...exam,
+    optIn: isChangingReqName
+      ? updateObjectProperty(exam.optIn)
+      : updateOnboardingSlotName(exam.optIn),
+    optOut: isChangingReqName
+      ? updateObjectProperty(exam.optOut)
+      : updateOnboardingSlotName(exam.optOut),
+  }));
 
 const updateOnboardingSlotName = doc => {
   const newDoc = {};
@@ -129,7 +126,6 @@ if (process.argv[2] === '--dry-run') {
       JSON.stringify(newUserOnboardingData, undefined, 2)
     );
   });
-  return;
 } else {
   userOverriddenReqsCollection.get().then(userData => {
     Promise.all(

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build --mode production",
     "courses-gen": "ts-node -T -P tsconfig.node.json src/requirements/courses-json-generator.ts",
     "req-gen": "ts-node -T -P tsconfig.node.json src/requirements/requirement-json-generator.ts",
-    "lint": "vue-cli-service lint",
+    "lint": "eslint . --cache",
     "tsc": "tsc",
     "type-check": "tsc && vti diagnostics",
     "build:staging": "vue-cli-service build --mode staging",


### PR DESCRIPTION
### Summary <!-- Required -->

Use `eslint` directly instead of `vue-cli-service`'s lint command. It ensures that we are running linter on all files.
Also fixed a bunch of linter errors after this change.

### Test Plan <!-- Required -->

`npm run lint` passes.