### PR TITLE
Adding empty semesters from entrance to grad semester for first-time users

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -112,7 +112,7 @@ import { PropType, defineComponent } from 'vue';
 import OnboardingBasic from '@/components/Modals/Onboarding/OnboardingBasic.vue';
 import OnboardingTransfer from '@/components/Modals/Onboarding/OnboardingTransfer.vue';
 import OnboardingReview from '@/components/Modals/Onboarding/OnboardingReview.vue';
-import { setOnboardingData } from '@/global-firestore-data';
+import { setOnboardingData, populateSemesters } from '@/global-firestore-data';
 import { getMajorFullName, getMinorFullName, getGradFullName } from '@/utilities';
 
 const placeholderText = 'Select one';
@@ -208,6 +208,8 @@ export default defineComponent({
     submitOnboarding() {
       this.clearTransferCreditIfGraduate();
       setOnboardingData(this.name, this.onboarding);
+      // indicates first time user onboarding
+      if (!isEditingProfile) populateSemesters(this.onboarding);
       this.$emit('onboard');
     },
     goBack() {

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -80,6 +80,27 @@ export const addSemester = (
   );
 };
 
+// function to add all the semesters a user will be enrolled in based on entrance and graduation time
+export const populateSemesters = (onboarding: AppOnboardingData): void => {
+  const entranceYear = parseInt(onboarding.entranceYear, 10);
+  const gradYear = parseInt(onboarding.gradYear, 10);
+
+  const entranceSem: FirestoreSemesterType = onboarding.entranceSem
+    ? onboarding.entranceSem
+    : 'Fall';
+  const gradSem: FirestoreSemesterType = onboarding.gradSem ? onboarding.gradSem : 'Spring';
+
+  const sems = [createSemester('Fall', entranceYear, []), createSemester('Spring', gradYear, [])];
+  if (entranceSem === 'Spring') sems.push(createSemester('Spring', entranceYear, []));
+  if (gradSem === 'Fall') sems.push(createSemester('Fall', gradYear, []));
+
+  for (let yr = entranceYear + 1; yr < gradYear; yr += 1) {
+    sems.push(createSemester('Spring', yr, []));
+    sems.push(createSemester('Fall', yr, []));
+  }
+  editSemesters(() => sems.sort(compareFirestoreSemesters));
+};
+
 export const deleteSemester = (type: FirestoreSemesterType, year: number, gtag?: GTag): void => {
   GTagEvent(gtag, 'delete-semester');
   const semester = store.state.semesters.find(sem => sem.type === type && sem.year === year);

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -118,7 +118,9 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
 // college and grad are optional fields: grad can be undefined if the user hasn't selected a grad program, and college can be undefined if the user has only selected a grad program.
 type AppOnboardingData = {
   readonly gradYear: string;
+  readonly gradSem?: FirestoreSemesterType;
   readonly entranceYear: string;
+  readonly entranceSem?: FirestoreSemesterType;
   readonly college?: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR implements functionality to pre-add empty semesters for first-time users, based on their entrance and graduation periods. Currently, since we only collect entrance and grad years, the default assumption is that the user is entering in the Fall and graduating in Spring.

I use the "isEditingProfile" boolean in `Onboarding.vue` to detect whether this is a first-time onboarding. If the boolean is false, I call the populateSemesters() function in `global-firestore-data.ts` through `Onboarding.vue`. This is a clean way, since it doesn't involve adding an unnecessary boolean to `AppOnboardingData`, or making additional Firestore calls.

- [x] Updated `AppOnboardingData` to have optional entrance/grad sem fields
- [x] Added populateSemesters() function in `global-firestore-data.ts`

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

TODOs for future PR:

- [ ] Collect entrance/grad semester info in onboarding and store it in AppOnboardingData
- [ ] Store entrance/grad semester in Firestore onboarding data?



### Test Plan <!-- Required -->
New user scenario (semesters auto-added):

Old semesters preserved when old user is going through onboarding again:


### Notes <!-- Optional -->
Currently, I only modified the AppOnboardingData type to store optional entrance and grad semesters. We could also modify the firestore onboarding data type to store this info in Firebase, but I don't think this information is being used anywhere else, so it might be unnecessary.