### PR TITLE
Setup typed firebase admin database collections

### DIFF
--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -44,7 +44,7 @@ import SlotMenu from '@/components/Modals/SlotMenu.vue';
 import DeleteCourseModal from '@/components/Modals/DeleteCourseModal.vue';
 import store from '@/store';
 import { deleteCourseFromSemesters } from '@/global-firestore-data';
-import { onboardingDataCollection } from '@/firebaseConfig';
+import { onboardingDataCollection } from '@/firebase-frontend-config';
 import getCurrentSeason, { getCurrentYear, clickOutside } from '@/utilities';
 
 const transferCreditColor = 'DA4A4A'; // Arbitrary color for transfer credit

--- a/src/containers/Login.vue
+++ b/src/containers/Login.vue
@@ -150,7 +150,7 @@ import firebase from 'firebase/app';
 import CustomFooter from '@/components/Footer.vue';
 
 import { GTagLoginEvent } from '@/gtag';
-import * as fb from '@/firebaseConfig';
+import * as fb from '@/firebase-frontend-config';
 import store from '@/store';
 import { checkNotNull } from '@/utilities';
 

--- a/src/firebase-admin-config.ts
+++ b/src/firebase-admin-config.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as admin from 'firebase-admin';
+import { getTypedFirestoreDataConverter } from './firebase-config-common';
+
+const serviceAccount = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'serviceAccount.json')).toString()
+);
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
+});
+
+const db = admin.firestore();
+
+export const usernameCollection = db
+  .collection('user-name')
+  .withConverter(getTypedFirestoreDataConverter<FirestoreUserName>());
+
+export type SemesterDocumentData = { readonly semesters: readonly FirestoreSemester[] };
+export const semestersCollection = db
+  .collection('user-semesters')
+  .withConverter(getTypedFirestoreDataConverter<SemesterDocumentData>());
+
+export const toggleableRequirementChoicesCollection = db
+  .collection('user-toggleable-requirement-choices')
+  .withConverter(getTypedFirestoreDataConverter<AppToggleableRequirementChoices>());
+
+export const selectableRequirementChoicesCollection = db
+  .collection('user-selectable-requirement-choices')
+  .withConverter(getTypedFirestoreDataConverter<AppSelectableRequirementChoices>());
+
+export const subjectColorsCollection = db
+  .collection('user-subject-colors')
+  .withConverter(getTypedFirestoreDataConverter<Readonly<Record<string, string>>>());
+
+export type UniqueIncrementerDocumentData = { readonly uniqueIncrementer: number };
+export const uniqueIncrementerCollection = db
+  .collection('user-unique-incrementer')
+  .withConverter(getTypedFirestoreDataConverter<UniqueIncrementerDocumentData>());
+
+export const onboardingDataCollection = db
+  .collection('user-onboarding-data')
+  .withConverter(getTypedFirestoreDataConverter<FirestoreOnboardingUserData>());

--- a/src/firebase-config-common.ts
+++ b/src/firebase-config-common.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CommonDocumentData = { [field: string]: any };
+/** An interface for `FirestoreDataConverter` common to both frontend firebase and admin firebase. */
+export interface CommonFirestoreDataConverter<T> {
+  toFirestore(modelObject: T): CommonDocumentData;
+  fromFirestore(snapshot: { data(): CommonDocumentData }): T;
+}
+
+export const getTypedFirestoreDataConverter = <T>(): CommonFirestoreDataConverter<T> => ({
+  fromFirestore(snapshot) {
+    return snapshot.data() as T;
+  },
+  toFirestore(userData) {
+    return userData;
+  },
+});
+
+export type SemesterDocumentData = { readonly semesters: readonly FirestoreSemester[] };
+export type UniqueIncrementerDocumentData = { readonly uniqueIncrementer: number };

--- a/src/firebase-frontend-config.ts
+++ b/src/firebase-frontend-config.ts
@@ -1,0 +1,69 @@
+import firebase from 'firebase/app';
+
+import 'firebase/auth';
+import 'firebase/firestore';
+import 'firebase/functions';
+import {
+  getTypedFirestoreDataConverter,
+  SemesterDocumentData,
+  UniqueIncrementerDocumentData,
+} from './firebase-config-common';
+
+let config;
+if (process.env.VUE_APP_FIREBASE_MODE === 'prod') {
+  // Production config
+  config = {
+    apiKey: 'AIzaSyDkKOpImjbjS2O0RhIQNJLQXx2SuYbxsfU',
+    authDomain: 'cornell-courseplan.firebaseapp.com',
+    databaseURL: 'https://cornell-courseplan.firebaseio.com',
+    projectId: 'cornell-courseplan',
+    storageBucket: '',
+    messagingSenderId: '1031551180906',
+    appId: '1:1031551180906:web:bdcea6ec074e673ea72a13',
+    measurementId: 'G-8B1JVCBX0Z',
+  };
+} else {
+  config = {
+    apiKey: 'AIzaSyAfePy1Tbrqm55bYR7BHHl50r-9NTVj0Rs',
+    authDomain: 'cornelldti-courseplan-dev.firebaseapp.com',
+    databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
+    projectId: 'cornelldti-courseplan-dev',
+    storageBucket: '',
+    messagingSenderId: '321304703190',
+    appId: '1:321304703190:web:2f2fefb4a0284465b99977',
+  };
+}
+
+firebase.initializeApp(config);
+
+// firebase utils
+export const db = firebase.firestore();
+export const auth = firebase.auth();
+
+export const usernameCollection = db
+  .collection('user-name')
+  .withConverter(getTypedFirestoreDataConverter<FirestoreUserName>());
+
+export const semestersCollection = db
+  .collection('user-semesters')
+  .withConverter(getTypedFirestoreDataConverter<SemesterDocumentData>());
+
+export const toggleableRequirementChoicesCollection = db
+  .collection('user-toggleable-requirement-choices')
+  .withConverter(getTypedFirestoreDataConverter<AppToggleableRequirementChoices>());
+
+export const selectableRequirementChoicesCollection = db
+  .collection('user-selectable-requirement-choices')
+  .withConverter(getTypedFirestoreDataConverter<AppSelectableRequirementChoices>());
+
+export const subjectColorsCollection = db
+  .collection('user-subject-colors')
+  .withConverter(getTypedFirestoreDataConverter<Readonly<Record<string, string>>>());
+
+export const uniqueIncrementerCollection = db
+  .collection('user-unique-incrementer')
+  .withConverter(getTypedFirestoreDataConverter<UniqueIncrementerDocumentData>());
+
+export const onboardingDataCollection = db
+  .collection('user-onboarding-data')
+  .withConverter(getTypedFirestoreDataConverter<FirestoreOnboardingUserData>());

--- a/src/global-firestore-data.ts
+++ b/src/global-firestore-data.ts
@@ -9,7 +9,7 @@ import {
   toggleableRequirementChoicesCollection,
   selectableRequirementChoicesCollection,
   uniqueIncrementerCollection,
-} from './firebaseConfig';
+} from './firebase-frontend-config';
 import store from './store';
 import { GTag, GTagEvent } from './gtag';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import App from './App.vue';
 import router from './router/index';
 import store from './store';
 
-import * as fb from './firebaseConfig';
+import * as fb from './firebase-frontend-config';
 import { registerGateKeeper } from './debug-flags';
 
 // handle page reloads

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import { Store } from 'vuex';
 
-import * as fb from './firebaseConfig';
+import * as fb from './firebase-frontend-config';
 import getCourseEquivalentsFromUserExams from './requirements/data/exams/ExamCredit';
 import computeGroupedRequirementFulfillmentReports from './requirements/requirement-frontend-computation';
 import RequirementFulfillmentGraph from './requirements/requirement-graph';


### PR DESCRIPTION
### Summary <!-- Required -->

To make the infrastructure to support requirement-graph-aware data migrations, we first need a way to access the database by `firebase-admin`, ideally in a typed way. This PR sets up such files using firestore API's `typeConverter`. I will explain the details in comments below.

### Test Plan <!-- Required -->

Everything compiles. Things run fine on CI.