### PR TITLE
⚡️ Speed up type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "req-graph-dump": "ts-node -T -P tsconfig.node.json src/requirements/requirement-graph-dumper.ts",
     "lint": "eslint . --cache",
     "tsc": "tsc",
-    "type-check": "tsc && vti diagnostics",
+    "type-check": "vue-tsc --noEmit",
     "build:staging": "vite build --mode staging",
     "format": "prettier --write \"**/*.{js,ts,css,scss,html,vue}\"",
     "format:check": "prettier --check \"**/*.{js,ts,css,scss,html,vue}\"",

--- a/src/assets/courses/full-courses.json.d.ts
+++ b/src/assets/courses/full-courses.json.d.ts
@@ -1,0 +1,3 @@
+declare const json: Readonly<Record<string, readonly CornellCourseRosterCourse[]>>;
+
+export default json;

--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts">
-import { PropType, defineComponent } from 'vue';
+import { CSSProperties, PropType, defineComponent } from 'vue';
 import CourseMenu from '@/components/Modals/CourseMenu.vue';
 import CourseCaution from '@/components/Course/CourseCaution.vue';
 import {
@@ -87,10 +87,10 @@ export default defineComponent({
       return `${this.courseObj.credits} credits`;
     },
 
-    cssVars(): { '--bg-color': string } {
+    cssVars(): CSSProperties {
       return {
         '--bg-color': `#${this.courseObj.color}`,
-      };
+      } as CSSProperties;
     },
   },
   methods: {

--- a/src/components/Modals/NewCourse/EditSingleRequirement.vue
+++ b/src/components/Modals/NewCourse/EditSingleRequirement.vue
@@ -2,7 +2,7 @@
   <div
     class="edit-requirement"
     :class="{ 'edit-requirement-selected': selected, 'edit-requirement-pointer': isClickable }"
-    v-on="isClickable ? { click: () => onClick() } : { click: $event => $event.preventDefault() }"
+    @click="onClick"
   >
     <img
       v-if="selected"
@@ -37,8 +37,12 @@ export default defineComponent({
     },
   },
   methods: {
-    onClick() {
-      this.$emit('on-select');
+    onClick(event: Event) {
+      if (this.isClickable) {
+        this.$emit('on-select');
+      } else {
+        event.preventDefault();
+      }
     },
   },
 });

--- a/src/components/Requirements/ReqCourse.vue
+++ b/src/components/Requirements/ReqCourse.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { CSSProperties, defineComponent } from 'vue';
 
 export default defineComponent({
   props: {
@@ -40,11 +40,11 @@ export default defineComponent({
     compact: { type: Boolean, required: true },
   },
   computed: {
-    borderColorCSSvar(): { '--border-color': string } {
-      return { '--border-color': `#${this.color}` };
+    borderColorCSSvar(): CSSProperties {
+      return { '--border-color': `#${this.color}` } as CSSProperties;
     },
-    courseColorCSSvar(): { '--bg-color': string } {
-      return { '--bg-color': `#${this.color}` };
+    courseColorCSSvar(): CSSProperties {
+      return { '--bg-color': `#${this.color}` } as CSSProperties;
     },
   },
 });

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -22,7 +22,7 @@
       >
         <p
           :style="{
-            'font-weight': '500',
+            'font-weight': 500,
             color: `#${getReqColor(req.groupName, onboardingData)}`,
           }"
           class="college-title-top"
@@ -51,7 +51,7 @@
       >
         <p
           :style="{
-            'font-weight': id === displayedMajorIndex ? '500' : '',
+            'font-weight': id === displayedMajorIndex ? 500 : undefined,
             color:
               id === displayedMajorIndex ? `#${getReqColor(req.groupName, onboardingData)}` : '',
           }"
@@ -94,7 +94,7 @@
       >
         <p
           :style="{
-            'font-weight': id === displayedMinorIndex ? '500' : '',
+            'font-weight': id === displayedMinorIndex ? 500 : undefined,
             color:
               id === displayedMinorIndex ? `#${getReqColor(req.groupName, onboardingData)}` : '',
           }"
@@ -115,7 +115,7 @@
       >
         <p
           :style="{
-            'font-weight': '500',
+            'font-weight': 500,
             color: `#${getReqColor(req.groupName, onboardingData)}`,
           }"
           class="grad-title-top"

--- a/src/requirements/decorated-requirements.json.d.ts
+++ b/src/requirements/decorated-requirements.json.d.ts
@@ -1,0 +1,4 @@
+import { DecoratedRequirementsJson } from './types';
+
+const decoratedRequirementJson: DecoratedRequirementsJson;
+export default decoratedRequirementJson;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "resolveJsonModule": true,
     "baseUrl": ".",
     "types": [
       "webpack-env",


### PR DESCRIPTION
### Summary <!-- Required -->

This PR aims to speed up type checking on command line to greatly improve dev experience. On my machine, it reduces the total time from 50s to 13s.

It contains two main changes:
- Disable `resolveJsonModule` in tsconfig and replaces it with manual type definition `d.ts` files for those json. Our json is big and TS spends a lot of time type checking them. In the end, TypeScript still cannot correctly decides its type due to our usage of discriminated union in the json. Therefore, it does not provide any type safety. It's better to just declare their types manually and make typescript skip checking its content. This change speeds up TS files checking from 5s to 3s on my machine.
- Replace `vti` with `vue-tsc`. `vue-tsc` comes with vite's template, and it's much faster than `vti`. From now on, we should use [this plugin](https://github.com/johnsoncodehk/volar) instead of `Vetur`. This provides most of the speedup. It seems to be stricter than `vti` so I think it's a good thing.

### Test Plan <!-- Required -->

CI.

I also tested manually to add some type error to both ts files and vue files like `const a: number = 'dddd'`. Both errors can be caught.