### PR TITLE
[easy] Add delete-semester-courses gtag event, alphabetize gtags

### DIFF
--- a/src/global-firestore-data/semesters.ts
+++ b/src/global-firestore-data/semesters.ts
@@ -128,8 +128,12 @@ export const deleteCourseFromSemester = (
   deleteCourseFromSelectableRequirements(courseUniqueID);
 };
 
-export const deleteAllCoursesFromSemester = (season: FirestoreSemesterType, year: number): void => {
-  // TODO add gtag event
+export const deleteAllCoursesFromSemester = (
+  season: FirestoreSemesterType,
+  year: number,
+  gtag?: GTag
+): void => {
+  GTagEvent(gtag, 'delete-semester-courses');
   const semester = store.state.semesters.find(sem => sem.type === season && sem.year === year);
   if (semester) {
     deleteCoursesFromSelectableRequirements(semester.courses.map(course => course.uniqueID));

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -20,6 +20,7 @@ type EventType =
   | 'delete-semester' // User deletes a semester
   | 'add-course' // User adds a course
   | 'delete-course' // User deletes a course
+  | 'delete-semester-courses' // User deletes all courses in a semester
   | 'course-edit-color' // User edits the course color
   | 'start-walkthrough' // User clicks to start the walkthrough
   | 'skip-walkthrough' // User clicks to skip the walkthrough
@@ -89,6 +90,13 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: EventType): void =>
     case 'delete-course':
       eventPayload = {
         event_category: 'course',
+        event_label: 'delete',
+        value: 1,
+      };
+      break;
+    case 'delete-semester-courses':
+      eventPayload = {
+        event_category: 'semester-courses',
         event_label: 'delete',
         value: 1,
       };

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -13,28 +13,28 @@ export const GTagLoginEvent = (gtag: GTag | undefined, method: string): void => 
 };
 
 type EventType =
-  | 'logout' // User logs out
-  | 'to-compact' // User sets the semester view to compact
-  | 'to-not-compact' // User sets the semester view to default
-  | 'add-semester' // User adds a semester
-  | 'delete-semester' // User deletes a semester
   | 'add-course' // User adds a course
-  | 'delete-course' // User deletes a course
-  | 'delete-semester-courses' // User deletes all courses in a semester
-  | 'course-edit-color' // User edits the course color
-  | 'start-walkthrough' // User clicks to start the walkthrough
-  | 'skip-walkthrough' // User clicks to skip the walkthrough
-  | 'onboarding-edit-basic-information' // User clicks to edit basic info on the review page of Onboarding
-  | 'onboarding-edit-transfer-credits' // User clicks to edit transfer credits on the review page of Onboarding
+  | 'add-modal-edit-requirements' // User clicks Edit Requirements on Add Modal
+  | 'add-semester' // User adds a semester
+  | 'bottom-bar-close' // User collapses or closes the Bottom Bar
   | 'bottom-bar-CU-reviews-link' // User clicks CU Reviews link on Bottom Bar
-  | 'bottom-bar-view-course-information-on-roster' // User clicks View Course Information on Roster link on Bottom Bar
-  | 'bottom-bar-see-more' // User clicks on the See More tab of the Bottom Bar
   | 'bottom-bar-delete-tab' // User deletes a tab on the Bottom Bar
   | 'bottom-bar-open' // User opens or expands the Bottom Bar
-  | 'bottom-bar-close' // User collapses or closes the Bottom Bar
-  | 'add-modal-edit-requirements' // User clicks Edit Requirements on Add Modal
+  | 'bottom-bar-see-more' // User clicks on the See More tab of the Bottom Bar
+  | 'bottom-bar-view-course-information-on-roster' // User clicks View Course Information on Roster link on Bottom Bar
+  | 'course-edit-color' // User edits the course color
+  | 'delete-course' // User deletes a course
+  | 'delete-semester' // User deletes a semester
+  | 'delete-semester-courses' // User deletes all courses in a semester
+  | 'logout' // User logs out
+  | 'onboarding-edit-basic-information' // User clicks to edit basic info on the review page of Onboarding
+  | 'onboarding-edit-transfer-credits' // User clicks to edit transfer credits on the review page of Onboarding
+  | 'requirements-bar-course-drag-and-drop' // User drags and drops a course from the Requirements Bar
   | 'requirements-bar-filled-requirements-toggle' // User toggles the SHOW/HIDE of Filled Requirements section on Requirements Bar
-  | 'requirements-bar-course-drag-and-drop'; // User drags and drops a course from the Requirements Bar
+  | 'skip-walkthrough' // User clicks to skip the walkthrough
+  | 'start-walkthrough' // User clicks to start the walkthrough
+  | 'to-compact' // User sets the semester view to compact
+  | 'to-not-compact'; // User sets the semester view to default
 
 /**
  * GTagEvent represents a gtag event.
@@ -45,24 +45,17 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: EventType): void =>
   if (!gtag) return;
   let eventPayload: EventPayload | undefined;
   switch (eventType) {
-    case 'logout':
+    case 'add-course':
       eventPayload = {
-        event_category: 'engagement',
-        event_label: 'logout',
+        event_category: 'course',
+        event_label: 'add',
         value: 1,
       };
       break;
-    case 'to-compact':
+    case 'add-modal-edit-requirements':
       eventPayload = {
-        event_category: 'views',
-        event_label: 'compact',
-        value: 1,
-      };
-      break;
-    case 'to-not-compact':
-      eventPayload = {
-        event_category: 'views',
-        event_label: 'not-compact',
+        event_category: 'add-modal',
+        event_label: 'edit-requirements',
         value: 1,
       };
       break;
@@ -73,66 +66,10 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: EventType): void =>
         value: 1,
       };
       break;
-    case 'delete-semester':
+    case 'bottom-bar-close':
       eventPayload = {
-        event_category: 'semester',
-        event_label: 'delete',
-        value: 1,
-      };
-      break;
-    case 'add-course':
-      eventPayload = {
-        event_category: 'course',
-        event_label: 'add',
-        value: 1,
-      };
-      break;
-    case 'delete-course':
-      eventPayload = {
-        event_category: 'course',
-        event_label: 'delete',
-        value: 1,
-      };
-      break;
-    case 'delete-semester-courses':
-      eventPayload = {
-        event_category: 'semester-courses',
-        event_label: 'delete',
-        value: 1,
-      };
-      break;
-    case 'course-edit-color':
-      eventPayload = {
-        event_category: 'course',
-        event_label: 'edit-color',
-        value: 1,
-      };
-      break;
-    case 'start-walkthrough':
-      eventPayload = {
-        event_category: 'walkthrough',
-        event_label: 'start',
-        value: 1,
-      };
-      break;
-    case 'skip-walkthrough':
-      eventPayload = {
-        event_category: 'walkthrough',
-        event_label: 'skip',
-        value: 1,
-      };
-      break;
-    case 'onboarding-edit-basic-information':
-      eventPayload = {
-        event_category: 'onboarding',
-        event_label: 'edit-basic-information',
-        value: 1,
-      };
-      break;
-    case 'onboarding-edit-transfer-credits':
-      eventPayload = {
-        event_category: 'onboarding',
-        event_label: 'edit-transfer-credits',
+        event_category: 'bottom-bar',
+        event_label: 'close',
         value: 1,
       };
       break;
@@ -140,20 +77,6 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: EventType): void =>
       eventPayload = {
         event_category: 'bottom-bar',
         event_label: 'CU-reviews-link',
-        value: 1,
-      };
-      break;
-    case 'bottom-bar-view-course-information-on-roster':
-      eventPayload = {
-        event_category: 'bottom-bar',
-        event_label: 'view-course-information-on-roster',
-        value: 1,
-      };
-      break;
-    case 'bottom-bar-see-more':
-      eventPayload = {
-        event_category: 'bottom-bar',
-        event_label: 'see-more',
         value: 1,
       };
       break;
@@ -171,17 +94,73 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: EventType): void =>
         value: 1,
       };
       break;
-    case 'bottom-bar-close':
+    case 'bottom-bar-see-more':
       eventPayload = {
         event_category: 'bottom-bar',
-        event_label: 'close',
+        event_label: 'see-more',
         value: 1,
       };
       break;
-    case 'add-modal-edit-requirements':
+    case 'bottom-bar-view-course-information-on-roster':
       eventPayload = {
-        event_category: 'add-modal',
-        event_label: 'edit-requirements',
+        event_category: 'bottom-bar',
+        event_label: 'view-course-information-on-roster',
+        value: 1,
+      };
+      break;
+    case 'course-edit-color':
+      eventPayload = {
+        event_category: 'course',
+        event_label: 'edit-color',
+        value: 1,
+      };
+      break;
+    case 'delete-course':
+      eventPayload = {
+        event_category: 'course',
+        event_label: 'delete',
+        value: 1,
+      };
+      break;
+    case 'delete-semester':
+      eventPayload = {
+        event_category: 'semester',
+        event_label: 'delete',
+        value: 1,
+      };
+      break;
+    case 'delete-semester-courses':
+      eventPayload = {
+        event_category: 'semester-courses',
+        event_label: 'delete',
+        value: 1,
+      };
+      break;
+    case 'logout':
+      eventPayload = {
+        event_category: 'engagement',
+        event_label: 'logout',
+        value: 1,
+      };
+      break;
+    case 'onboarding-edit-basic-information':
+      eventPayload = {
+        event_category: 'onboarding',
+        event_label: 'edit-basic-information',
+        value: 1,
+      };
+      break;
+    case 'onboarding-edit-transfer-credits':
+      eventPayload = {
+        event_category: 'onboarding',
+        event_label: 'edit-transfer-credits',
+        value: 1,
+      };
+      break;
+    case 'requirements-bar-course-drag-and-drop':
+      eventPayload = {
+        event_category: 'requirements-bar',
+        event_label: 'course-drag-and-drop',
         value: 1,
       };
       break;
@@ -192,10 +171,31 @@ export const GTagEvent = (gtag: GTag | undefined, eventType: EventType): void =>
         value: 1,
       };
       break;
-    case 'requirements-bar-course-drag-and-drop':
+    case 'skip-walkthrough':
       eventPayload = {
-        event_category: 'requirements-bar',
-        event_label: 'course-drag-and-drop',
+        event_category: 'walkthrough',
+        event_label: 'skip',
+        value: 1,
+      };
+      break;
+    case 'start-walkthrough':
+      eventPayload = {
+        event_category: 'walkthrough',
+        event_label: 'start',
+        value: 1,
+      };
+      break;
+    case 'to-compact':
+      eventPayload = {
+        event_category: 'views',
+        event_label: 'compact',
+        value: 1,
+      };
+      break;
+    case 'to-not-compact':
+      eventPayload = {
+        event_category: 'views',
+        event_label: 'not-compact',
         value: 1,
       };
       break;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds the `delete-semester-courses` gtag event and alphabetizes the gtags in the code.

- [x] add `delete-semester-courses` gtag event and use it in `deleteAllCoursesFromSemester()`
- [x] alphabetize gtag ordering in `gtag.ts` to reduce merge conflicts

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
This is a low-risk change because it only touches analytics data. Devs can double check that I didn't miss any gtags and they are correctly ordered.

### Notes
`deleteAllCoursesFromSemester()` is currently not used.
