### PR TITLE
Disable scroll behind teleport modal by preventing events

### DIFF
--- a/src/components/Modals/TeleportModal.vue
+++ b/src/components/Modals/TeleportModal.vue
@@ -8,6 +8,9 @@
         'teleport-transparentBackground': hasClickableTransparentBackground,
       }"
       @click="closeOnClickOutside"
+      @wheel.prevent
+      @touchmove.prevent
+      @scroll.prevent
       ref="modalBackground"
     >
       <div


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request disables scrolling behind any teleport modals on CoursePlan by preventing scrolling events on the TeleportModal as seen on the second answer on [this stackoverflow post](https://stackoverflow.com/questions/56739111/prevent-scrolling-in-vuejs/56739601). See below for other failed implementations and the cons of this working approach.

### Test Plan <!-- Required -->

Confirm that after opening a teleport modal (such as the new semester modal or the add modal from the requirements sidebar) when you have enough courses/semesters to have a scrollable semester view, is not able to be scrolled by moving your mouse. Also check that it works the same on mobile.

### Notes <!-- Optional -->

After trying other approaches, this seemed like the best one that I could successfully implement, but please let me know if you think otherwise!

The cons of this approach are
- It prevents modals themselves from being scrollable. Thus, if we ever had any teleport modal with a large height, this implementation would need to change to allow it to be scrolled. Furthermore, this means we cannot use this to prevent scrolling behind the Onboarding modal.
- The scrollbar is still visible on the right of the screen and can be dragged by the user to still scroll.

The other approach I tried was changing the CSS on the main div in `App.vue` to be ` height: 100vh; overflow-y: hidden;` when a modal is teleported. This did prevent scrolling successfully and resolved the above cons, but the different ways I tried of determining whether a modal was teleported failed.
- Teleport modal visibility is handled in the parent of each modal. Thus, to determine if a modal is open using events and applying styling to `App.vue`, we would need to pass events up from a large number of components significantly down the tree, undoing one of the reasons why we switched to Teleport in the first place.
- I also tried using refs to determine if a TeleportModal was visible or if the target in `App.vue` contained any innerHTML. For the former, I referenced [this stackoverflow post](https://stackoverflow.com/questions/51225378/how-to-watch-child-properties-changes-from-parent-component) to add a watch in `App.vue` and turn on/off a disable scrolling class, but was unable to get the watch working correctly. 

Let me know if I should try exploring either of these other 2 options again or if I missed anything! Otherwise this should work just with the cons as mentioned.