### PR TITLE
[easy] Remove outdated docs and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ View documentation on updating requirements data.
 
 ## Project installation
 
-```
+```shell
 npm install
 ```
 
 ## Run locally
 
-```
+```shell
 npm run serve
 ```
 
@@ -78,7 +78,3 @@ Then access http://localhost:8080/
 - **Brandon Hong** - PMM
 - **Boon Palipatana** - TPM
 - **Han Wang** - PM
-
-### Customize configuration
-
-See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  publicPath: '',
-  configureWebpack: {
-    devtool: 'source-map',
-  },
-};


### PR DESCRIPTION
### Summary <!-- Required -->

We no longer use `vue-cli`.

### Test Plan <!-- Required -->

CI and 👀 .