### PR TITLE
[easy] Remove transferCourse from onboarding data

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -264,22 +264,16 @@ export default defineComponent({
     // clear transfer credits if the student is only in a graduate program, but previously set transfer credits
     clearTransferCreditIfGraduate() {
       if (this.onboarding.grad !== '' && this.onboarding.college === '') {
-        this.updateTransfer([], [], 'no');
+        this.updateTransfer([], 'no');
       }
     },
-    updateTransfer(
-      exams: readonly FirestoreAPIBExam[],
-      classes: readonly FirestoreTransferClass[],
-      tookSwim: 'yes' | 'no'
-    ) {
+    updateTransfer(exams: readonly FirestoreAPIBExam[], tookSwim: 'yes' | 'no') {
       const userExams = exams.filter(
         ({ subject, score }) => score !== 0 && subject !== placeholderText
       );
-      const userClasses = classes.filter(it => it.class !== placeholderText);
       this.onboarding = {
         ...this.onboarding,
         exam: userExams,
-        transferCourse: userClasses,
         tookSwim,
       };
     },

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -218,9 +218,6 @@ export default defineComponent({
       this.onboardingData.exam.forEach(exam => {
         count += getExamCredit(exam);
       });
-      this.onboardingData.transferCourse.forEach(clas => {
-        count += clas.credits;
-      });
       return count;
     },
     isGraduateOnly(): boolean {

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -177,9 +177,6 @@ export default defineComponent({
     examsAP.push({ type: 'AP', subject: placeholderText, score: 0 });
     examsIB.push({ type: 'IB', subject: placeholderText, score: 0 });
     const transferClasses: TransferClassWithOptionalCourse[] = [];
-    this.onboardingData.transferCourse.forEach(course => {
-      transferClasses.push(course);
-    });
     transferClasses.push({ class: placeholderText, credits: 0 });
     return {
       tookSwimTest:
@@ -257,12 +254,7 @@ export default defineComponent({
       this.classes.push({ class: placeholderText, credits: 0 });
     },
     updateTransfer() {
-      this.$emit(
-        'updateTransfer',
-        [...this.examsAP, ...this.examsIB],
-        this.classes,
-        this.tookSwimTest
-      );
+      this.$emit('updateTransfer', [...this.examsAP, ...this.examsIB], this.tookSwimTest);
     },
     onCourseSelection(id: number, course: CornellCourseRosterCourse) {
       const courseCode = `${course.subject} ${course.catalogNbr}`;

--- a/src/global-firestore-data/onboarding-data.ts
+++ b/src/global-firestore-data/onboarding-data.ts
@@ -16,7 +16,6 @@ const setOnboardingData = (name: FirestoreUserName, onboarding: AppOnboardingDat
       minors: onboarding.minor.map(acronym => ({ acronym })),
       gradPrograms: onboarding.grad ? [{ acronym: onboarding.grad }] : [],
       exam: onboarding.exam,
-      class: onboarding.transferCourse,
       tookSwim: onboarding.tookSwim,
     })
     .then(() => {

--- a/src/requirements/__test__/exam-credit.test.ts
+++ b/src/requirements/__test__/exam-credit.test.ts
@@ -167,7 +167,6 @@ it('Exam is counted correctly for one major', () => {
     major: ['CS'],
     exam: [{ type: 'AP', score: 5, subject: 'Computer Science A' }],
     minor: [],
-    transferCourse: [],
     tookSwim: 'no',
   };
   const courseEquivalents = getCourseEquivalentsFromUserExams(userData);
@@ -187,7 +186,6 @@ it('Two exams are counted correctly for one major', () => {
       { type: 'AP', score: 5, subject: 'Chemistry' },
     ],
     minor: [],
-    transferCourse: [],
     tookSwim: 'no',
   };
   const courseEquivalents = getCourseEquivalentsFromUserExams(userData);
@@ -204,7 +202,6 @@ it('One exam is only counted once for multiple majors', () => {
     major: ['CS', 'Biological Sciences'],
     exam: [{ type: 'AP', score: 5, subject: 'Computer Science A' }],
     minor: [],
-    transferCourse: [],
     tookSwim: 'no',
   };
   const courseEquivalents = getCourseEquivalentsFromUserExams(userData);
@@ -222,7 +219,6 @@ it('Equivalent course appears if it matches one major but not the other', () => 
     major: ['Biological Sciences'],
     exam: [{ type: 'AP', score: 4, subject: 'Statistics' }],
     minor: [],
-    transferCourse: [],
     tookSwim: 'no',
   };
   let courseEquivalents = getCourseEquivalentsFromUserExams(userData);
@@ -238,7 +234,6 @@ it('Equivalent course appears if it matches one major but not the other', () => 
     major: ['CS', 'Biological Sciences'],
     exam: [{ type: 'AP', score: 4, subject: 'Statistics' }],
     minor: [],
-    transferCourse: [],
     tookSwim: 'no',
   };
   courseEquivalents = getCourseEquivalentsFromUserExams(userData);

--- a/src/store.ts
+++ b/src/store.ts
@@ -83,7 +83,6 @@ const store: TypedVuexStore = new TypedVuexStore({
       minor: [],
       grad: '',
       exam: [],
-      transferCourse: [],
       tookSwim: 'no',
     },
     semesters: [],

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -152,6 +152,5 @@ export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppO
       ? data.gradPrograms[0].acronym
       : undefined,
   exam: 'exam' in data ? [...data.exam] : [],
-  transferCourse: 'class' in data ? [...data.class] : [],
   tookSwim: 'tookSwim' in data ? data.tookSwim : 'no',
 });

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -45,13 +45,7 @@ type FirestoreAPIBExam = {
   readonly optOut?: FirestoreAPIBOverriddenFulfillments;
 };
 type FirestoreCollegeMajorMinorOrGrad = { readonly acronym: string };
-type FirestoreTransferClass = {
-  readonly class: string;
-  readonly course: CornellCourseRosterCourse;
-  readonly credits: number;
-};
 type FirestoreOnboardingUserData = {
-  readonly class: readonly FirestoreTransferClass[];
   readonly gradYear: string;
   readonly entranceYear: string;
   readonly colleges: readonly FirestoreCollegeMajorMinorOrGrad[];
@@ -126,7 +120,6 @@ type AppOnboardingData = {
   readonly minor: readonly string[];
   readonly grad?: string;
   readonly exam: readonly FirestoreAPIBExam[];
-  readonly transferCourse: readonly FirestoreTransferClass[];
   readonly tookSwim: 'yes' | 'no';
 };
 


### PR DESCRIPTION
### Summary <!-- Required -->

Last semester we decided to tell user to just add transfer classes as normal classes, so these fields are unused. 

<img width="563" alt="Screen Shot 2021-10-21 at 09 51 30" src="https://user-images.githubusercontent.com/4290500/138291841-fbe82122-a481-480d-857f-f4f75ec43a55.png">

### Test Plan <!-- Required -->

Deleted code shows that we never really add any new classes to the array.

Go through onboarding once to ensure it still works.