### PR TITLE
Finish script to migrate engineering liberal studies data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ yarn-error.log*
 
 # Firebase service account, used for things like logging in for Cypress tests
 serviceAccount.json
+serviceAccountProd.json

--- a/src/firebase-admin-config.ts
+++ b/src/firebase-admin-config.ts
@@ -3,8 +3,9 @@ import * as path from 'path';
 import * as admin from 'firebase-admin';
 import { getTypedFirestoreDataConverter } from './firebase-config-common';
 
+const serviceAccountFilename = process.env.PROD ? 'serviceAccountProd.json' : 'serviceAccount.json';
 const serviceAccount = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '..', 'serviceAccount.json')).toString()
+  fs.readFileSync(path.join(__dirname, '..', serviceAccountFilename)).toString()
 );
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),

--- a/src/requirements/admin/migrate-engineering-liberal-arts-data.ts
+++ b/src/requirements/admin/migrate-engineering-liberal-arts-data.ts
@@ -95,7 +95,9 @@ async function runOnUser(userEmail: string, runOnDB: boolean) {
   console.log(choicesUpdates);
 
   if (runOnDB && Object.keys(choicesUpdates).length > 0) {
-    await selectableRequirementChoicesCollection.doc(userEmail).update(choicesUpdates);
+    await selectableRequirementChoicesCollection
+      .doc(userEmail)
+      .set({ ...selectableRequirementChoices, ...choicesUpdates });
   }
 }
 


### PR DESCRIPTION
### Summary <!-- Required -->

This PR finishes the script initially added in #542. The only real effective change is to add a more that actually modifies the database. I also tweaked some other logs produce by this script since I determined that they are all safe.

### Test Plan <!-- Required -->

`npm run ts-node -- src/requirements/admin/migrate-engineering-liberal-arts-data.ts --run-on-db` if you want to run the script.

### Notes

I have local changes that removes the `allowDoubleCounting` flag. However, it can't be included in this PR, since removing the flag will break the assumption of the script that engineering liberal studies is double-countable.

We would need a coordinated release done in short time after this is merged. The sequence would be:

1. Release everything on master to prod before this PR is approved and merged.
2. Approve and merge this PR.
3. Run this on prod
4. PR for removing `allowDoubleCounting` is created, approved and merge to master.
5. (Optional) Another PR to delete this script
5. Create another release that contains the PR in step 4 only.