### PR TITLE
Onboarding modal refactor

### DIFF
--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -11,28 +11,26 @@
       <div class="onboarding-transferCredits onboarding-inputs">
         <div
           class="onboarding-inputWrapper onboarding-inputWrapper--college onboarding-inputWrapper--description"
+          @on-remove="removeExam"
+          @on-add="addExam"
         >
           <onboarding-transfer-credits-source
             examName="AP"
             :exams="examsAP"
             :subjects="subjectsAP"
-            :getSelectableOptions="getSelectableOptions"
-            :selectSubject="selectAPSubject"
-            :scoresDropdown="{ scores: scoresAP, selectScore: selectAPScore }"
-            :removeExam="removeExam"
-            :hasExams="hasExams"
-            :addExam="addExam"
+            :scores="scoresAP"
+            :placeholderText="placeholderText"
+            @on-subject-select="selectAPSubject"
+            @on-score-select="selectAPScore"
           />
           <onboarding-transfer-credits-source
             examName="IB"
             :exams="examsIB"
             :subjects="subjectsIB"
-            :getSelectableOptions="getSelectableOptions"
-            :selectSubject="selectIBSubject"
-            :scoresDropdown="{ scores: scoresIB, selectScore: selectIBScore }"
-            :removeExam="removeExam"
-            :hasExams="hasExams"
-            :addExam="addExam"
+            :scores="scoresIB"
+            :placeholderText="placeholderText"
+            @on-subject-select="selectIBSubject"
+            @on-score-select="selectIBScore"
           />
         </div>
         <div class="onboarding-transferCreditDescription">
@@ -52,8 +50,6 @@ import { PropType, defineComponent } from 'vue';
 import { examData as reqsData, ExamRequirements } from '@/requirements/data/exams/ExamCredit';
 import OnboardingTransferSwimming from './OnboardingTransferSwimming.vue';
 import OnboardingTransferCreditsSource from './OnboardingTransferCreditsSource.vue';
-
-const placeholderText = 'Select one';
 
 type TransferClassWithOptionalCourse = {
   class: string;
@@ -118,6 +114,7 @@ export default defineComponent({
     },
   },
   data(): Data {
+    const placeholderText = 'Select one';
     const examsAP: FirestoreAPIBExam[] = [];
     const examsIB: FirestoreAPIBExam[] = [];
     this.onboardingData.exam.forEach(exam => {
@@ -155,10 +152,10 @@ export default defineComponent({
   methods: {
     getExamCredit,
     getTransferClassSearchboxPlaceholder(text: string): string {
-      return text !== placeholderText ? text : '"CS1110", "Multivariable Calculus", etc';
+      return text !== this.placeholderText ? text : '"CS1110", "Multivariable Calculus", etc';
     },
     transferClassSearchboxClassname(text: string): string {
-      return text !== placeholderText
+      return text !== this.placeholderText
         ? 'new-course-onboarding'
         : 'new-course-onboarding new-course-onboarding-empty';
     },
@@ -183,7 +180,7 @@ export default defineComponent({
       this.updateTransfer();
     },
     addExam(type: 'AP' | 'IB') {
-      const exam = { type, subject: placeholderText, score: 0 };
+      const exam = { type, subject: this.placeholderText, score: 0 };
       (type === 'AP' ? this.examsAP : this.examsIB).push(exam);
     },
     removeExam(type: 'AP' | 'IB', index: number) {
@@ -200,7 +197,7 @@ export default defineComponent({
       this.updateTransfer();
     },
     addTransfer() {
-      this.classes.push({ class: placeholderText, credits: 0 });
+      this.classes.push({ class: this.placeholderText, credits: 0 });
     },
     updateTransfer() {
       this.$emit('updateTransfer', [...this.examsAP, ...this.examsIB], this.tookSwimTest);
@@ -212,31 +209,6 @@ export default defineComponent({
       classes[id] = { class: courseCode, course, credits: creditsC };
       this.classes = classes;
       this.updateTransfer();
-    },
-    getSelectableOptions(
-      // exams already picked
-      selectedExams: readonly FirestoreAPIBExam[],
-      // array of ap/ib exams
-      allSubjects: readonly string[],
-      choice: string
-    ) {
-      const selectedExamsNames = selectedExams.map(exam => exam.subject);
-      const selectableOptions: string[] = [];
-      // copy all of the possible options over but exclude already selected ones
-      for (const subject of allSubjects) {
-        // don't include selected ones
-        if (!selectedExamsNames.includes(subject)) {
-          selectableOptions.push(subject);
-        }
-      }
-      // add the current selection associated with this input into the availableChoices
-      if (choice !== placeholderText) {
-        selectableOptions.push(choice);
-      }
-      return selectableOptions;
-    },
-    hasExams(exams: readonly FirestoreAPIBExam[], exam: FirestoreAPIBExam): boolean {
-      return !(exams.length === 1 && exam.subject === placeholderText);
     },
   },
 });

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -215,7 +215,7 @@ export default defineComponent({
     },
     getSelectableOptions(
       // exams already picked
-      selectedExams: FirestoreAPIBExam[],
+      selectedExams: readonly FirestoreAPIBExam[],
       // array of ap/ib exams
       allSubjects: readonly string[],
       choice: string
@@ -235,7 +235,7 @@ export default defineComponent({
       }
       return selectableOptions;
     },
-    hasExams(exams: FirestoreAPIBExam[], exam: FirestoreAPIBExam): boolean {
+    hasExams(exams: readonly FirestoreAPIBExam[], exam: FirestoreAPIBExam): boolean {
       return !(exams.length === 1 && exam.subject === placeholderText);
     },
   },

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -12,82 +12,28 @@
         <div
           class="onboarding-inputWrapper onboarding-inputWrapper--college onboarding-inputWrapper--description"
         >
-          <div class="onboarding-subHeader">
-            <span class="onboarding-subHeader--font">AP Credits</span>
-          </div>
-          <div class="onboarding-subsection onboarding-transferCreditsSection">
-            <div class="onboarding-section" v-for="(exam, index) in examsAP" :key="index">
-              <div class="onboarding-selectWrapperRow">
-                <onboarding-transfer-exam-property-dropdown
-                  property-name="Subject"
-                  :columnWide="true"
-                  :availableOptions="getSelectableOptions(examsAP, subjectsAP, exam.subject)"
-                  :choice="exam.subject"
-                  @on-select="subject => selectAPSubject(subject, index)"
-                />
-                <onboarding-transfer-exam-property-dropdown
-                  property-name="Score"
-                  :columnWide="false"
-                  :availableOptions="scoresAP"
-                  :choice="exam.score"
-                  @on-select="score => selectAPScore(score, index)"
-                />
-                <div class="onboarding-select--column-removeExam">
-                  <button
-                    class="onboarding-remove"
-                    @click="removeExam('AP', index)"
-                    v-if="hasExams(examsAP, exam)"
-                  >
-                    <img
-                      src="@/assets/images/x-green.svg"
-                      :alt="`x to remove AP exam ${exam.type} ${exam.subject}`"
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div class="onboarding-addRemoveWrapper">
-              <button class="onboarding-add" @click="addExam('AP')">+ another subject</button>
-            </div>
-          </div>
-          <div class="onboarding-subHeader">
-            <span class="onboarding-subHeader--font">IB Credits</span>
-          </div>
-          <div class="onboarding-inputs onboarding-transferCreditsSection">
-            <div class="onboarding-section" v-for="(exam, index) in examsIB" :key="index">
-              <div class="onboarding-selectWrapperRow">
-                <onboarding-transfer-exam-property-dropdown
-                  property-name="Subject"
-                  :columnWide="true"
-                  :availableOptions="getSelectableOptions(examsIB, subjectsIB, exam.subject)"
-                  :choice="exam.subject"
-                  @on-select="subject => selectIBSubject(subject, index)"
-                />
-                <onboarding-transfer-exam-property-dropdown
-                  property-name="Score"
-                  :columnWide="false"
-                  :availableOptions="scoresIB"
-                  :choice="exam.score"
-                  @on-select="score => selectIBScore(score, index)"
-                />
-                <div class="onboarding-select--column-removeExam">
-                  <button
-                    class="onboarding-remove"
-                    @click="removeExam('IB', index)"
-                    v-if="hasExams(examsIB, exam)"
-                  >
-                    <img
-                      src="@/assets/images/x-green.svg"
-                      :alt="`x to remove IB exam ${exam.type} ${exam.subject}`"
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div class="onboarding-addRemoveWrapper">
-              <button class="onboarding-add" @click="addExam('IB')">+ another subject</button>
-            </div>
-          </div>
+          <onboarding-transfer-credits-source
+            examName="AP"
+            :exams="examsAP"
+            :subjects="subjectsAP"
+            :getSelectableOptions="getSelectableOptions"
+            :selectSubject="selectAPSubject"
+            :scoresDropdown="{ scores: scoresAP, selectScore: selectAPScore }"
+            :removeExam="removeExam"
+            :hasExams="hasExams"
+            :addExam="addExam"
+          />
+          <onboarding-transfer-credits-source
+            examName="IB"
+            :exams="examsIB"
+            :subjects="subjectsIB"
+            :getSelectableOptions="getSelectableOptions"
+            :selectSubject="selectIBSubject"
+            :scoresDropdown="{ scores: scoresIB, selectScore: selectIBScore }"
+            :removeExam="removeExam"
+            :hasExams="hasExams"
+            :addExam="addExam"
+          />
         </div>
         <div class="onboarding-transferCreditDescription">
           *To add credit from external institutions, please add the equivalent Cornell course to
@@ -105,7 +51,7 @@
 import { PropType, defineComponent } from 'vue';
 import { examData as reqsData, ExamRequirements } from '@/requirements/data/exams/ExamCredit';
 import OnboardingTransferSwimming from './OnboardingTransferSwimming.vue';
-import OnboardingTransferExamPropertyDropdown from './OnboardingTransferExamPropertyDropdown.vue';
+import OnboardingTransferCreditsSource from './OnboardingTransferCreditsSource.vue';
 
 const placeholderText = 'Select one';
 
@@ -163,10 +109,13 @@ export const getExamCredit = (exam: FirestoreAPIBExam): number => {
 export default defineComponent({
   components: {
     OnboardingTransferSwimming,
-    OnboardingTransferExamPropertyDropdown,
+    OnboardingTransferCreditsSource,
   },
   props: {
-    onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
+    onboardingData: {
+      type: Object as PropType<AppOnboardingData>,
+      required: true,
+    },
   },
   data(): Data {
     const examsAP: FirestoreAPIBExam[] = [];

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -11,8 +11,6 @@
       <div class="onboarding-transferCredits onboarding-inputs">
         <div
           class="onboarding-inputWrapper onboarding-inputWrapper--college onboarding-inputWrapper--description"
-          @on-remove="removeExam"
-          @on-add="addExam"
         >
           <onboarding-transfer-credits-source
             examName="AP"
@@ -22,6 +20,8 @@
             :placeholderText="placeholderText"
             @on-subject-select="selectAPSubject"
             @on-score-select="selectAPScore"
+            @on-remove="removeExam"
+            @on-add="addExam"
           />
           <onboarding-transfer-credits-source
             examName="IB"
@@ -31,6 +31,8 @@
             :placeholderText="placeholderText"
             @on-subject-select="selectIBSubject"
             @on-score-select="selectIBScore"
+            @on-remove="removeExam"
+            @on-add="addExam"
           />
         </div>
         <div class="onboarding-transferCreditDescription">

--- a/src/components/Modals/Onboarding/OnboardingTransferCreditsSource.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransferCreditsSource.vue
@@ -1,0 +1,119 @@
+<template>
+  <div>
+    <div class="onboarding-subHeader">
+      <span class="onboarding-subHeader--font">{{ examName }} Credits</span>
+    </div>
+    <div class="onboarding-subsection onboarding-transferCreditsSection">
+      <div class="onboarding-section" v-for="(exam, index) in exams" :key="index">
+        <div class="onboarding-selectWrapperRow">
+          <onboarding-transfer-exam-property-dropdown
+            property-name="Subject"
+            :columnWide="true"
+            :availableOptions="getSelectableOptions(exams, subjects, exam.subject)"
+            :choice="exam.subject"
+            @on-select="subject => selectSubject(subject, index)"
+          />
+          <onboarding-transfer-exam-property-dropdown
+            v-if="scoresDropdown"
+            property-name="Score"
+            :columnWide="false"
+            :availableOptions="scoresDropdown.scores"
+            :choice="exam.score"
+            @on-select="score => scoresDropdown.selectScore(score, index)"
+          />
+          <div class="onboarding-select--column-removeExam">
+            <button
+              class="onboarding-remove"
+              @click="removeExam(examName, index)"
+              v-if="hasExams(exams, exam)"
+            >
+              <img
+                src="@/assets/images/x-green.svg"
+                :alt="`x to remove ${examName} exam ${exam.type} ${exam.subject}`"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="onboarding-addRemoveWrapper">
+        <button class="onboarding-add" @click="addExam(examName)">+ another subject</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import OnboardingTransferExamPropertyDropdown from './OnboardingTransferExamPropertyDropdown.vue';
+
+/** Represents an exam one can take for transfer credit */
+type Exam = 'AP' | 'IB';
+
+type GetSelectableOptions = (
+  selectedExams: FirestoreAPIBExam[],
+  allSubjects: readonly string[],
+  choice: string
+) => readonly string[];
+
+type SelectSubject = (subject: string, i: number) => void;
+
+/** Represents the information needed to represent a score dropdown menu */
+type ScoreDropdown = {
+  /** The scores achievable on the test */
+  readonly scores: readonly number[];
+  /** A callback to execute upon selection of a score */
+  readonly selectScore: (score: number, index: number) => void;
+};
+
+type RemoveExam = (name: Exam, index: number) => void;
+
+type HasExams = (exams: FirestoreAPIBExam[], exam: FirestoreAPIBExam) => boolean;
+
+type AddExam = (name: Exam) => void;
+
+export default defineComponent({
+  components: {
+    OnboardingTransferExamPropertyDropdown,
+  },
+  props: {
+    examName: { type: String as PropType<Exam>, required: true },
+    exams: {
+      type: Array as PropType<readonly FirestoreAPIBExam[]>,
+      required: true,
+    },
+    subjects: {
+      type: Array as PropType<readonly string[]>,
+      required: true,
+    },
+    getSelectableOptions: {
+      type: Function as PropType<GetSelectableOptions>,
+      required: true,
+    },
+    selectSubject: {
+      type: Function as PropType<SelectSubject>,
+      required: true,
+    },
+    scoresDropdown: {
+      type: Object as PropType<ScoreDropdown>,
+      required: false,
+      default: undefined,
+    },
+    removeExam: {
+      type: Function as PropType<RemoveExam>,
+      required: true,
+    },
+    hasExams: {
+      type: Function as PropType<HasExams>,
+      required: true,
+    },
+    addExam: {
+      type: Function as PropType<AddExam>,
+      required: true,
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/components/Modals/Onboarding/Onboarding.scss';
+</style>

--- a/src/components/Modals/Onboarding/OnboardingTransferCreditsSource.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransferCreditsSource.vue
@@ -14,12 +14,12 @@
             @on-select="subject => selectSubject(subject, index)"
           />
           <onboarding-transfer-exam-property-dropdown
-            v-if="scoresDropdown !== undefined"
+            v-if="scoresDropdown"
             property-name="Score"
             :columnWide="false"
             :availableOptions="scoresDropdown.scores"
             :choice="exam.score"
-            @on-select="score => scoresDropdown.selectScore(score, index)"
+            @on-select="score => onSelect(score, index)"
           />
           <div class="onboarding-select--column-removeExam">
             <button
@@ -53,7 +53,7 @@ type GetSelectableOptions = (
   selectedExams: readonly FirestoreAPIBExam[],
   allSubjects: readonly string[],
   choice: string
-) => readonly string[];
+) => string[];
 
 type SelectSubject = (subject: string, i: number) => void;
 
@@ -109,6 +109,11 @@ export default defineComponent({
     addExam: {
       type: Function as PropType<AddExam>,
       required: true,
+    },
+  },
+  methods: {
+    onSelect(score: number, index: number) {
+      if (this.scoresDropdown) this.scoresDropdown.selectScore(score, index);
     },
   },
 });

--- a/src/components/Modals/Onboarding/OnboardingTransferCreditsSource.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransferCreditsSource.vue
@@ -14,7 +14,7 @@
             @on-select="subject => selectSubject(subject, index)"
           />
           <onboarding-transfer-exam-property-dropdown
-            v-if="scoresDropdown"
+            v-if="scoresDropdown !== undefined"
             property-name="Score"
             :columnWide="false"
             :availableOptions="scoresDropdown.scores"
@@ -50,7 +50,7 @@ import OnboardingTransferExamPropertyDropdown from './OnboardingTransferExamProp
 type Exam = 'AP' | 'IB';
 
 type GetSelectableOptions = (
-  selectedExams: FirestoreAPIBExam[],
+  selectedExams: readonly FirestoreAPIBExam[],
   allSubjects: readonly string[],
   choice: string
 ) => readonly string[];
@@ -67,7 +67,7 @@ type ScoreDropdown = {
 
 type RemoveExam = (name: Exam, index: number) => void;
 
-type HasExams = (exams: FirestoreAPIBExam[], exam: FirestoreAPIBExam) => boolean;
+type HasExams = (exams: readonly FirestoreAPIBExam[], exam: FirestoreAPIBExam) => boolean;
 
 type AddExam = (name: Exam) => void;
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request refactors the transfer credit onboarding modal by factoring out the frontend code for AP and IB score input into one component. I'm going to add another input for CASE exams, so I thought it would be better to get this refactor out of the way now (instead of having to duplicate the same code used for AP/IB). No changes are visible to the client, and the modal looks the same as it did before.

<img width="1440" alt="Screen Shot 2021-10-25 at 10 26 16 AM" src="https://user-images.githubusercontent.com/73757337/138714234-cdd42971-f846-4887-af14-f3006382b955.png">
<img width="1440" alt="Screen Shot 2021-10-25 at 10 27 29 AM" src="https://user-images.githubusercontent.com/73757337/138714430-5aaaebd5-da05-4451-b7a8-78f3b2ba9ec8.png">
