### PR TITLE
Fix duplicate bottom courses

### DIFF
--- a/src/components/BottomBar/BottomBarCourseReview.vue
+++ b/src/components/BottomBar/BottomBarCourseReview.vue
@@ -119,17 +119,14 @@ export default defineComponent({
       return `https://www.cureviews.org/course/${subject}/${number}`;
     },
     CUROverallRating(): string | number {
-      if (this.courseObj.overallRating === 0) return '';
       if (!this.courseObj.overallRating) return 'N/A';
       return Math.round(this.courseObj.overallRating * 10) / 10;
     },
     CURDifficulty(): string | number {
-      if (this.courseObj.difficulty === 0) return '';
       if (!this.courseObj.difficulty) return 'N/A';
       return Math.round(this.courseObj.difficulty * 10) / 10;
     },
     CURWorkload(): string | number {
-      if (this.courseObj.workload === 0) return '';
       if (!this.courseObj.workload) return 'N/A';
       return Math.round(this.courseObj.workload * 10) / 10;
     },

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -54,11 +54,14 @@ const getReviews = (
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ subject: subject.toLowerCase(), number }),
-  }).then(res => res.ok && res.json().then(reviews => reviews.result)) || {
-    classRating: null,
-    classDifficulty: null,
-    classWorkload: null,
-  };
+  }).then(
+    res =>
+      (res.ok && res.json().then(reviews => reviews.result)) || {
+        classRating: null,
+        classDifficulty: null,
+        classWorkload: null,
+      }
+  );
 
 export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
   vueForBottomBar.isExpanded = true;

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -6,7 +6,6 @@ import {
   cornellCourseRosterCourseDetailedInformationToPartialBottomCourseInformation,
   firestoreSemesterCourseToBottomBarCourse,
 } from '../../user-data-converter';
-import { reviewColors } from '@/assets/constants/colors';
 
 export type BottomBarState = {
   bottomCourses: readonly AppBottomBarCourse[];

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -6,6 +6,7 @@ import {
   cornellCourseRosterCourseDetailedInformationToPartialBottomCourseInformation,
   firestoreSemesterCourseToBottomBarCourse,
 } from '../../user-data-converter';
+import { reviewColors } from '@/assets/constants/colors';
 
 export type BottomBarState = {
   bottomCourses: readonly AppBottomBarCourse[];
@@ -54,18 +55,15 @@ const getReviews = (
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ subject: subject.toLowerCase(), number }),
-  }).then(res =>
-    res
-      .json()
-      .then(reviews =>
-        reviews.result
-          ? reviews.result
-          : { classRating: null, classDifficulty: null, classWorkload: null }
-      )
-  );
+  }).then(res => res.ok && res.json().then(reviews => reviews.result)) || {
+    classRating: null,
+    classDifficulty: null,
+    classWorkload: null,
+  };
 
 export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
   vueForBottomBar.isExpanded = true;
+
   for (let i = 0; i < vueForBottomBar.bottomCourses.length; i += 1) {
     const existingCourse = vueForBottomBar.bottomCourses[i];
     // Must check both uniqueID and code (e.g. CS 1110) to handle req courses that share uniqueID -1
@@ -75,32 +73,40 @@ export const addCourseToBottomBar = (course: FirestoreSemesterCourse): void => {
     }
   }
 
-  if (vueForBottomBar.bottomCourses.length === 0) {
-    vueForBottomBar.isExpanded = true;
-  }
+  vueForBottomBar.bottomCourses = [
+    firestoreSemesterCourseToBottomBarCourse(course),
+    ...vueForBottomBar.bottomCourses,
+  ];
+  vueForBottomBar.bottomCourseFocus = 0;
 
-  const bottomBarCourse = firestoreSemesterCourseToBottomBarCourse(course);
-  const [subject, number] = bottomBarCourse.code.split(' ');
+  const [subject, number] = course.code.split(' ');
   Promise.all([
     getReviews(subject, number).then(({ classRating, classDifficulty, classWorkload }) => {
-      bottomBarCourse.overallRating = classRating;
-      bottomBarCourse.difficulty = classDifficulty;
-      bottomBarCourse.workload = classWorkload;
+      const bottomBarCourse = vueForBottomBar.bottomCourses.find(
+        ({ uniqueID, code }) => uniqueID === course.uniqueID && code === course.code
+      );
+      if (bottomBarCourse) {
+        bottomBarCourse.overallRating = classRating;
+        bottomBarCourse.difficulty = classDifficulty;
+        bottomBarCourse.workload = classWorkload;
+      }
     }),
     getDetailedInformationForBottomBar(course.lastRoster, subject, number).then(
       ({ description, prereqs, enrollment, lectureTimes, instructors, distributions }) => {
-        bottomBarCourse.description = description;
-        bottomBarCourse.prereqs = prereqs;
-        bottomBarCourse.enrollment = enrollment;
-        bottomBarCourse.lectureTimes = lectureTimes;
-        bottomBarCourse.instructors = instructors;
-        bottomBarCourse.distributions = distributions;
+        const bottomBarCourse = vueForBottomBar.bottomCourses.find(
+          ({ uniqueID, code }) => uniqueID === course.uniqueID && code === course.code
+        );
+        if (bottomBarCourse) {
+          bottomBarCourse.description = description;
+          bottomBarCourse.prereqs = prereqs;
+          bottomBarCourse.enrollment = enrollment;
+          bottomBarCourse.lectureTimes = lectureTimes;
+          bottomBarCourse.instructors = instructors;
+          bottomBarCourse.distributions = distributions;
+        }
       }
     ),
-  ]).then(() => {
-    vueForBottomBar.bottomCourses = [bottomBarCourse, ...vueForBottomBar.bottomCourses];
-    vueForBottomBar.bottomCourseFocus = 0;
-  });
+  ]);
 };
 
 export const toggleBottomBar = (gtag?: GTag): void => {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the bottom bar bug where duplicate courses can show up by clicking a course card multiple times in quick succession.

- [x] fixed bug by moving array update out of promise
- [x] open & update bottom bar regardless of promise status (eg. if the fetches are slow)
- [x] added CUReviews failsafe so `N/A` shows up if CUReviews is down or our URL is wrong

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Try reproducing the bug on master & this branch, and don't encounter the bug on this branch.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
There will need to be more changes if we want to distinguish between "no data" (N/A) and "loading". I think it's fine how it is for now.