### PR TITLE
Fix typo in CS 3410/3420 slot name

### DIFF
--- a/src/requirements/data/majors/cs.ts
+++ b/src/requirements/data/majors/cs.ts
@@ -35,7 +35,7 @@ const csRequirements: readonly CollegeOrMajorRequirement[] = [
     ),
     fulfilledBy: 'courses',
     perSlotMinCount: [1, 1, 1, 1, 1],
-    slotNames: ['CS 2800 or CS 2802', 'CS 3110', 'CS 3410 or CS 3410', 'CS 4820', 'CS 4410'],
+    slotNames: ['CS 2800 or CS 2802', 'CS 3110', 'CS 3410 or CS 3420', 'CS 4820', 'CS 4410'],
   },
   {
     name: 'CS Electives',


### PR DESCRIPTION
### Summary <!-- Required -->

Fix typo in the CS 3410/3420 requirement slot name and re-run `req gen`

### Test Plan <!-- Required -->

Confirm the slot name is fixed locally

![image](https://user-images.githubusercontent.com/25535093/139751471-0ded2ea6-4c7f-4685-b071-3c0d5b80655d.png)
![image](https://user-images.githubusercontent.com/25535093/139751482-d31db2a2-98b9-4b8f-a320-0a80b852d89a.png)