### PR TITLE
Fix deployment of firebase functions to work for windows machines

### DIFF
--- a/functions/deployment-template/package.json
+++ b/functions/deployment-template/package.json
@@ -5,5 +5,8 @@
   "main": "index.js",
   "scripts": {
     "deploy": "firebase deploy --only functions"
+  },
+  "engines": {
+    "node": "10"
   }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -662,6 +662,132 @@
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "optional": true
     },
+    "esbuild": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.12.tgz",
+      "integrity": "sha512-vTKKUt+yoz61U/BbrnmlG9XIjwpdIxmHB8DlPR0AAW6OdS+nBQBci6LUHU2q9WbBobMEIQxxDpKbkmOGYvxsow==",
+      "requires": {
+        "esbuild-android-arm64": "0.13.12",
+        "esbuild-darwin-64": "0.13.12",
+        "esbuild-darwin-arm64": "0.13.12",
+        "esbuild-freebsd-64": "0.13.12",
+        "esbuild-freebsd-arm64": "0.13.12",
+        "esbuild-linux-32": "0.13.12",
+        "esbuild-linux-64": "0.13.12",
+        "esbuild-linux-arm": "0.13.12",
+        "esbuild-linux-arm64": "0.13.12",
+        "esbuild-linux-mips64le": "0.13.12",
+        "esbuild-linux-ppc64le": "0.13.12",
+        "esbuild-netbsd-64": "0.13.12",
+        "esbuild-openbsd-64": "0.13.12",
+        "esbuild-sunos-64": "0.13.12",
+        "esbuild-windows-32": "0.13.12",
+        "esbuild-windows-64": "0.13.12",
+        "esbuild-windows-arm64": "0.13.12"
+      }
+    },
+    "esbuild-android-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.12.tgz",
+      "integrity": "sha512-TSVZVrb4EIXz6KaYjXfTzPyyRpXV5zgYIADXtQsIenjZ78myvDGaPi11o4ZSaHIwFHsuwkB6ne5SZRBwAQ7maw==",
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.12.tgz",
+      "integrity": "sha512-c51C+N+UHySoV2lgfWSwwmlnLnL0JWj/LzuZt9Ltk9ub1s2Y8cr6SQV5W3mqVH1egUceew6KZ8GyI4nwu+fhsw==",
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.12.tgz",
+      "integrity": "sha512-JvAMtshP45Hd8A8wOzjkY1xAnTKTYuP/QUaKp5eUQGX+76GIie3fCdUUr2ZEKdvpSImNqxiZSIMziEiGB5oUmQ==",
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.12.tgz",
+      "integrity": "sha512-r6On/Skv9f0ZjTu6PW5o7pdXr8aOgtFOEURJZYf1XAJs0IQ+gW+o1DzXjVkIoT+n1cm3N/t1KRJfX71MPg/ZUA==",
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.12.tgz",
+      "integrity": "sha512-F6LmI2Q1gii073kmBE3NOTt/6zLL5zvZsxNLF8PMAwdHc+iBhD1vzfI8uQZMJA1IgXa3ocr3L3DJH9fLGXy6Yw==",
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.12.tgz",
+      "integrity": "sha512-U1UZwG3UIwF7/V4tCVAo/nkBV9ag5KJiJTt+gaCmLVWH3bPLX7y+fNlhIWZy8raTMnXhMKfaTvWZ9TtmXzvkuQ==",
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.12.tgz",
+      "integrity": "sha512-YpXSwtu2NxN3N4ifJxEdsgd6Q5d8LYqskrAwjmoCT6yQnEHJSF5uWcxv783HWN7lnGpJi9KUtDvYsnMdyGw71Q==",
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.12.tgz",
+      "integrity": "sha512-SyiT/JKxU6J+DY2qUiSLZJqCAftIt3uoGejZ0HDnUM2MGJqEGSGh7p1ecVL2gna3PxS4P+j6WAehCwgkBPXNIw==",
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.12.tgz",
+      "integrity": "sha512-sgDNb8kb3BVodtAlcFGgwk+43KFCYjnFOaOfJibXnnIojNWuJHpL6aQJ4mumzNWw8Rt1xEtDQyuGK9f+Y24jGA==",
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.12.tgz",
+      "integrity": "sha512-qQJHlZBG+QwVIA8AbTEtbvF084QgDi4DaUsUnA+EolY1bxrG+UyOuGflM2ZritGhfS/k7THFjJbjH2wIeoKA2g==",
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.12.tgz",
+      "integrity": "sha512-2dSnm1ldL7Lppwlo04CGQUpwNn5hGqXI38OzaoPOkRsBRWFBozyGxTFSee/zHFS+Pdh3b28JJbRK3owrrRgWNw==",
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.12.tgz",
+      "integrity": "sha512-D4raxr02dcRiQNbxOLzpqBzcJNFAdsDNxjUbKkDMZBkL54Z0vZh4LRndycdZAMcIdizC/l/Yp/ZsBdAFxc5nbA==",
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.12.tgz",
+      "integrity": "sha512-KuLCmYMb2kh05QuPJ+va60bKIH5wHL8ypDkmpy47lzwmdxNsuySeCMHuTv5o2Af1RUn5KLO5ZxaZeq4GEY7DaQ==",
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.12.tgz",
+      "integrity": "sha512-jBsF+e0woK3miKI8ufGWKG3o3rY9DpHvCVRn5eburMIIE+2c+y3IZ1srsthKyKI6kkXLvV4Cf/E7w56kLipMXw==",
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.12.tgz",
+      "integrity": "sha512-L9m4lLFQrFeR7F+eLZXG82SbXZfUhyfu6CexZEil6vm+lc7GDCE0Q8DiNutkpzjv1+RAbIGVva9muItQ7HVTkQ==",
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.12.tgz",
+      "integrity": "sha512-k4tX4uJlSbSkfs78W5d9+I9gpd+7N95W7H2bgOMFPsYREVJs31+Q2gLLHlsnlY95zBoPQMIzHooUIsixQIBjaQ==",
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.12.tgz",
+      "integrity": "sha512-2tTv/BpYRIvuwHpp2M960nG7uvL+d78LFW/ikPItO+2GfK51CswIKSetSpDii+cjz8e9iSPgs+BU4o8nWICBwQ==",
+      "optional": true
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "lint": "eslint .",
-    "predeploy": "../node_modules/.bin/esbuild --bundle --platform=node --outdir=deployment-template index.ts",
+    "predeploy": "esbuild --bundle --platform=node --outdir=deployment-template index.ts",
     "serve": "firebase serve --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
@@ -12,6 +12,7 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
+    "esbuild": "^0.13.12",
     "firebase-admin": "^9.12.0",
     "firebase-functions": "^3.15.7"
   }


### PR DESCRIPTION
### Summary <!-- Required -->

Fix deployment of firebase functions to work for windows machines, broken in #539 with the error `'..' is not recognized as an internal or external command,`

- [x] `npm install esbuild` in the firebase functions folder so it can be called without filepaths (see below notes for rationale)
- [x] Add `engines: node 10` to package to resolve the below error

![image](https://user-images.githubusercontent.com/25535093/139779845-1b52954a-8b77-49a0-ba46-5186442f4be0.png)

### Test Plan <!-- Required -->

Confirm TrackUsers can be deployed to the dev env from the `functions` folder with `npm run deploy` and then successfully run and tested [here](https://console.cloud.google.com/functions/details/us-central1/TrackUsers?authuser=0&project=cornelldti-courseplan-dev&tab=testing) on both Windows and MacOS machines 

Windows:
![image](https://user-images.githubusercontent.com/25535093/139780103-7e2e0050-4786-4449-ac97-b0d085730a54.png)

Mac: Could @SamChou19815 or @hahnbeelee test this?

### Notes <!-- Optional -->

Notes on why the above changes were made instead of alternatives...

1. Trying to use the `cd` command to go into the existing directory with `esbuild` before calling it directly led to the deployment working, but the function failed to run on the cloud console - still not sure why.
2. Replacing the forward slashes with escaped back slashes worked locally, but doubt that this would work on Mac machines
3. Installing `esbuild` globally with `npm` worked as well, but this would require all other developers to do so or it would break on their machines. 
