### PR TITLE
Compound Requirements Progress Bug

### DIFF
--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -217,7 +217,9 @@ export default defineComponent({
     requirementFulfilled(): number {
       let fulfilled = 0;
       this.req.reqs.forEach(req => {
-        if (req.minCountFulfilled >= req.minCountRequired) fulfilled += 1;
+        [req, ...Object.values(req.additionalRequirements || {})].forEach(reqOrNestedReq => {
+          if (reqOrNestedReq.minCountFulfilled >= reqOrNestedReq.minCountRequired) fulfilled += 1;
+        });
       });
       return fulfilled;
     },


### PR DESCRIPTION
### Summary <!-- Required -->

Fix bug where individual compound requirements do not count toward requirements fulfillment.

In prod, a compound requirement like engineering liberal studies will count as "fulfilled" on the progress bar text if the main requirement is complete, but now, each additional requirement will also increase fulfillment counter by 1. The progress bar and the denominator has always counted each part of the compounded requirement, leading to the screenshotted issue.

![image](https://user-images.githubusercontent.com/25535093/139940890-ffa5dd55-7bf5-4bdb-9024-534d06978f1f.png)

### Test Plan <!-- Required -->

1. Confirm that completely fulfilling engineering requirements leads to the progress bar saying "15/15"
![image](https://user-images.githubusercontent.com/25535093/139941373-0d650e81-9e9a-44d1-98ae-868d75c21f3c.png)

2. Confirm that fulfilling only some of "Liberal Studies" leads to the right fulfillment count, and that the count and progress bar update if a part of the compounded requirement is then fulfilled.
![image](https://user-images.githubusercontent.com/25535093/139941154-34862f1c-3b58-4afc-92d7-a4179a39d735.png)
