### PR TITLE
Use `CYPRESS_TEST_UID` from the repo

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Cypress Test
         run: npm run cypress:e2e
         env:
-          CYPRESS_TEST_UID: ${{ secrets.CYPRESS_TEST_UID }}
           SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CORNELLDTI_COURSEPLAN_DEV }}
       - name: Upload recordings if tests fail
         if: ${{ failure() }}


### PR DESCRIPTION
### Summary <!-- Required -->

Looks like we are running on different accounts for cypress tests, which causes the tests to fail on CI but not locally... Not sure how that happens. Let's all use the `CYPRESS_TEST_UID` from the repo.

### Test Plan <!-- Required -->

A side by side comparison to prove my point above (left CI, right local):
<img width="2496" alt="Screen Shot 2021-11-04 at 15 51 17" src="https://user-images.githubusercontent.com/4290500/140410913-5c0124d1-f380-4004-9ddf-b06a319fbb1c.png">


