### PR TITLE
Record user choice in both old and new data format for compatibility

### DIFF
--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -98,7 +98,7 @@ export default defineComponent({
         selectedCourse,
         store.state.groupedRequirementFulfillmentReport,
         store.state.toggleableRequirementChoices,
-        store.state.overriddenFulfillmentChoices
+        /* deprecated AppOverriddenFulfillmentChoices */ {}
       );
 
       const requirementsThatAllowDoubleCounting: string[] = [];

--- a/src/global-firestore-data/selectable-requirement-choices.ts
+++ b/src/global-firestore-data/selectable-requirement-choices.ts
@@ -1,23 +1,53 @@
-import { selectableRequirementChoicesCollection } from '../firebase-frontend-config';
+import { getCourseCodesArray } from '../requirements/requirement-frontend-computation';
+import { getFirestoreCourseOptInOptOutChoicesBuilder } from '../requirements/requirement-graph-builder-from-user-data';
+import {
+  db,
+  selectableRequirementChoicesCollection,
+  overriddenFulfillmentChoicesCollection,
+} from '../firebase-frontend-config';
 import store from '../store';
 
 const chooseSelectableRequirementOption = (
   selectableRequirementChoices: AppSelectableRequirementChoices
 ): void => {
-  selectableRequirementChoicesCollection
-    .doc(store.state.currentFirebaseUser.email)
-    .set(selectableRequirementChoices);
+  const courses = getCourseCodesArray(store.state.semesters, store.state.onboardingData);
+  const newFormatChoicesBuilder = getFirestoreCourseOptInOptOutChoicesBuilder(
+    courses,
+    store.state.onboardingData,
+    store.state.toggleableRequirementChoices,
+    selectableRequirementChoices,
+    /* deprecated AppOverriddenFulfillmentChoices */ {}
+  );
+  const overriddenFulfillmentChoices = Object.fromEntries(
+    courses.map(course => [course.uniqueId, newFormatChoicesBuilder(course)])
+  );
+
+  const batch = db.batch();
+  batch.set(
+    selectableRequirementChoicesCollection.doc(store.state.currentFirebaseUser.email),
+    selectableRequirementChoices
+  );
+  batch.set(
+    overriddenFulfillmentChoicesCollection.doc(store.state.currentFirebaseUser.email),
+    overriddenFulfillmentChoices
+  );
+  batch.commit();
 };
 
 export const addCourseToSelectableRequirements = (
   courseUniqueID: string | number,
   requirementID: string | undefined
 ): void => {
-  if (!requirementID) return;
-  chooseSelectableRequirementOption({
-    ...store.state.selectableRequirementChoices,
-    [courseUniqueID]: requirementID,
-  });
+  // Even when there is no change, we set the old data anyways,
+  // so it can trigger a save of user choice in new format.
+  chooseSelectableRequirementOption(
+    requirementID
+      ? {
+          ...store.state.selectableRequirementChoices,
+          [courseUniqueID]: requirementID,
+        }
+      : store.state.selectableRequirementChoices
+  );
 };
 
 export const deleteCourseFromSelectableRequirements = (courseUniqueID: string | number): void => {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds a compatibility layer for migration of user choice format. In short, this PR:

- does not change how requirement is computed
- does not change how user choice _that affects requirement computation_ is stored
- instead, it only modifies the new format in `user-overridden-requirement-choices` in parallel.

With this setup, this diff can go into prod at any time. New user data can be recorded once we push, which gives us a lot of flexibility of when we want to run the migration script: run it after release to prod, then there will be no need to run the migration script in the future (since with this PR prod data will self-correct), we can replace the entire old choice infra with new choice infra.

### Test Plan <!-- Required -->

After added MATH 4710 (won't change choice since it only connects to reqs that allow double counting), new `user-overridden-requirement-choices` appear in the DB:

<img width="1300" alt="Screen Shot 2021-11-05 at 17 21 37" src="https://user-images.githubusercontent.com/4290500/140580164-b4b46d98-2a6e-4064-a573-74345286b80b.png">

