### PR TITLE
[easy] No longer mark engineering liberal studies data as allow double counting

### DIFF
--- a/src/requirements/data/colleges/en.ts
+++ b/src/requirements/data/colleges/en.ts
@@ -113,7 +113,6 @@ const engineeringRequirements: readonly CollegeOrMajorRequirement[] = [
         ) || courseIsForeignLang(course),
     ],
     fulfilledBy: 'courses',
-    allowCourseDoubleCounting: true,
     perSlotMinCount: [6],
     slotNames: ['Course'],
     additionalRequirements: {


### PR DESCRIPTION
### Summary <!-- Required -->

To be merged after #554 is run on prod data.

### Test Plan <!-- Required -->

👀 