### PR TITLE
[easy] Fix typo in ENGRC requirement warning

### DIFF
--- a/src/requirements/data/colleges/en.ts
+++ b/src/requirements/data/colleges/en.ts
@@ -225,7 +225,7 @@ const engineeringRequirements: readonly CollegeOrMajorRequirement[] = [
     perSlotMinCount: [1],
     slotNames: ['Course'],
     checkerWarning:
-      'We do check that your selected course fulfills the guidelines of this requirement.',
+      'We do not check that your selected course fulfills the guidelines of this requirement.',
     allowCourseDoubleCounting: true,
   },
 ];


### PR DESCRIPTION
### Summary <!-- Required -->

Fix typo in the ENGRC requirement warning to clarify we do not check check every piece of info.

### Test Plan <!-- Required -->

Confirm the new description shows up on CoursePlan

![image](https://user-images.githubusercontent.com/25535093/140948885-6711f1e9-1ec3-451a-a6fb-f87e4c83098c.png)