### PR TITLE
npm install in functions with npm 16

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "cypress-firebase": "^2.0.0",
         "esbuild": "^0.13.12",
         "firebase-admin": "^9.12.0",
         "firebase-functions": "^3.15.7"
@@ -676,6 +677,14 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cypress-firebase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-firebase/-/cypress-firebase-2.0.0.tgz",
+      "integrity": "sha512-QbhsC9ouZDsre29pQEZTZrls9gBcz9p/vs/OxS7FFpU3C+g3pKBpVhWgp59j1U2UyuCfO5ZEw4EPRTIMJbpKHg==",
+      "peerDependencies": {
+        "firebase-admin": "^8 || ^9"
       }
     },
     "node_modules/date-and-time": {
@@ -3045,7 +3054,8 @@
     "cypress-firebase": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cypress-firebase/-/cypress-firebase-2.0.0.tgz",
-      "integrity": "sha512-QbhsC9ouZDsre29pQEZTZrls9gBcz9p/vs/OxS7FFpU3C+g3pKBpVhWgp59j1U2UyuCfO5ZEw4EPRTIMJbpKHg=="
+      "integrity": "sha512-QbhsC9ouZDsre29pQEZTZrls9gBcz9p/vs/OxS7FFpU3C+g3pKBpVhWgp59j1U2UyuCfO5ZEw4EPRTIMJbpKHg==",
+      "requires": {}
     },
     "date-and-time": {
       "version": "2.0.1",


### PR DESCRIPTION
### Summary <!-- Required -->

Fixes the current failed CI check on master (merged in a branch without passing the new CI check) by updating to npm 16 locally, then running `npm install` in the functions folder

### Test Plan <!-- Required -->

Ensure this branch passes the CI (specifically `check-lockfile`)

### Notes <!-- Optional -->

Should there be an announcement in cp-dev that everyone should update their npm version to 16?
