### PR TITLE
[easy] Limit cypress test concurrency

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -36,6 +36,7 @@ jobs:
         run: exit $(git status --porcelain | wc -l)
   frontend-tests:
     runs-on: ubuntu-latest
+    concurrency: cypress-tests
     steps:
       - uses: actions/checkout@master
       - name: Set up Node


### PR DESCRIPTION
### Summary <!-- Required -->

Our cypress test is not concurrency-safe, since the test will change data of the same account in the database. So tests of two PRs opened simultaneously will be interfering with each other, causing unnecessary failures.

This PR limits the number of concurrent running frontend tests to be 1.

### Test Plan <!-- Required -->

See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency