### PR TITLE
Add semester season property from semester type

### DIFF
--- a/src/requirements/admin/semester-season-migration.ts
+++ b/src/requirements/admin/semester-season-migration.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+
+import { usernameCollection, semestersCollection } from '../../firebase-admin-config';
+
+/**
+ * Perform migration of semester type to semester season
+ */
+async function runOnUser(userEmail: string, runOnDB: boolean) {
+  const semesters = await semestersCollection
+    .doc(userEmail)
+    .get()
+    .then(it => {
+      const data = it.data();
+      return (data && data.semesters) || [];
+    });
+
+  console.group(`Running on ${userEmail}...`);
+  const newSemesters = semesters.map(semester =>
+    // each semester should have type but not necessarily season
+    ({ ...semester, season: semester.season || semester.type })
+  );
+  console.log(semesters, '=>', newSemesters);
+  console.groupEnd();
+
+  if (runOnDB) {
+    await semestersCollection.doc(userEmail).update({ semesters: newSemesters });
+  }
+}
+
+async function main() {
+  let userEmail = process.argv[2];
+  const runOnDB = process.argv.includes('--run-on-db');
+  if (userEmail != null && userEmail !== '--run-on-db') {
+    await runOnUser(userEmail, runOnDB);
+    return;
+  }
+  const collection = await usernameCollection.get();
+  const userEmails = collection.docs.map(it => it.id);
+  for (userEmail of userEmails) {
+    console.group(`Running on ${userEmail}...`);
+    // Intentionally await in a loop to have no interleaved console logs.
+    // eslint-disable-next-line no-await-in-loop
+    await runOnUser(userEmail, runOnDB);
+    console.groupEnd();
+  }
+}
+
+main();


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is a script to migrate all old instances of semester type to semester season. After this, the schema will include identical values for `type` and `season` (instead of just including `type`). I ran it on dev, it just needs to be run on prod.

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

Depends on #546 

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
`npm run ts-node -- src/requirements/admin/semester-season-migration <user email>` to dry-run on a single user.  
`npm run ts-node -- src/requirements/admin/semester-season-migration --run-on-db` to run on the entire database.  


![Pasted Graphic](https://user-images.githubusercontent.com/34158284/142075782-5177b39b-e9df-400d-a8bf-cafc444cd948.png)