### PR TITLE
Fix Mobile Navbar Click Outside

### DIFF
--- a/src/components/Course/CourseBaseTooltip.vue
+++ b/src/components/Course/CourseBaseTooltip.vue
@@ -96,7 +96,7 @@ export default defineComponent({
   border-width: 0.313rem;
   border-style: solid;
   border-color: transparent transparent white transparent;
-  z-index: 3;
+  z-index: 4;
 }
 
 /** The element that produces a gray triangle */

--- a/src/components/Modals/TeleportModal.vue
+++ b/src/components/Modals/TeleportModal.vue
@@ -117,7 +117,7 @@ export default defineComponent({
   width: 100vw;
   min-height: 100vh;
   background-color: rgba(0, 0, 0, 0.7);
-  z-index: 3;
+  z-index: 4;
   padding: 1rem;
 
   &-simple {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,56 +1,58 @@
 <template>
-  <nav class="navbar" v-click-outside="closeMenuIfOpen">
-    <div
-      class="navbar-iconWrapper hamburger full-opacity-on-hover"
-      data-cyId="navbar-menuButton"
-      @click="menuOpen = !menuOpen"
-    ></div>
-    <div class="navbar-top">
-      <div class="navbar-iconWrapper course-plan-logo no-hover">
-        <img class="navbar-icon" src="@/assets/images/branding/logo.svg" alt="Courseplan logo" />
+  <div>
+    <nav class="navbar" v-click-outside="closeMenuIfOpen">
+      <div
+        class="navbar-iconWrapper hamburger full-opacity-on-hover"
+        data-cyId="navbar-menuButton"
+        @click="menuOpen = !menuOpen"
+      ></div>
+      <div class="navbar-top">
+        <div class="navbar-iconWrapper course-plan-logo no-hover">
+          <img class="navbar-icon" src="@/assets/images/branding/logo.svg" alt="Courseplan logo" />
+        </div>
+        <button
+          class="navbar-iconWrapper desktop profile-icon full-opacity-on-hover"
+          @click="editProfile"
+          data-cyId="editProfile"
+        ></button>
       </div>
-      <button
-        class="navbar-iconWrapper desktop profile-icon full-opacity-on-hover"
-        @click="editProfile"
-        data-cyId="editProfile"
-      ></button>
-    </div>
-    <div class="navbar-bottom">
-      <button
-        class="navbar-iconWrapper desktop logout-icon full-opacity-on-hover"
-        @click="logout"
-      />
-    </div>
-    <div v-if="menuOpen" class="navbar-menu" data-cyId="navbar-menu">
-      <button
-        class="nav-mobile-button"
-        data-cyId="navbar-viewRequirements"
-        @click="toggleRequirementsMobile"
-      >
-        <div class="navbar-iconWrapper requirements-bar" />
-        <span class="nav-mobile-button-text">
-          {{ isDisplayingRequirementsMobile ? 'View Schedule' : 'View Requirements' }}
-        </span>
-      </button>
-      <button class="nav-mobile-button" data-cyId="navbar-editProfile" @click="editProfile">
-        <div class="navbar-iconWrapper profile-mobile-icon" />
-        <span class="nav-mobile-button-text">Edit Profile</span>
-      </button>
-      <button class="nav-mobile-button" @click="logout">
-        <div class="navbar-iconWrapper logout-mobile-icon" />
-        <span class="nav-mobile-button-text">Log Out</span>
-      </button>
-      <div class="nav-menu-spacing" />
-      <a
-        class="nav-menu-dti-link"
-        href="https://www.cornelldti.org/projects/courseplan/"
-        target="_black"
-        rel="noopener noreferrer"
-        >Cornell DTI @ 2021</a
-      >
-    </div>
-  </nav>
-  <div v-if="menuOpen" class="navbar-menu-background-shadow" />
+      <div class="navbar-bottom">
+        <button
+          class="navbar-iconWrapper desktop logout-icon full-opacity-on-hover"
+          @click="logout"
+        />
+      </div>
+      <div v-if="menuOpen" class="navbar-menu" data-cyId="navbar-menu">
+        <button
+          class="nav-mobile-button"
+          data-cyId="navbar-viewRequirements"
+          @click="toggleRequirementsMobile"
+        >
+          <div class="navbar-iconWrapper requirements-bar" />
+          <span class="nav-mobile-button-text">
+            {{ isDisplayingRequirementsMobile ? 'View Schedule' : 'View Requirements' }}
+          </span>
+        </button>
+        <button class="nav-mobile-button" data-cyId="navbar-editProfile" @click="editProfile">
+          <div class="navbar-iconWrapper profile-mobile-icon" />
+          <span class="nav-mobile-button-text">Edit Profile</span>
+        </button>
+        <button class="nav-mobile-button" @click="logout">
+          <div class="navbar-iconWrapper logout-mobile-icon" />
+          <span class="nav-mobile-button-text">Log Out</span>
+        </button>
+        <div class="nav-menu-spacing" />
+        <a
+          class="nav-menu-dti-link"
+          href="https://www.cornelldti.org/projects/courseplan/"
+          target="_black"
+          rel="noopener noreferrer"
+          >Cornell DTI @ 2021</a
+        >
+      </div>
+    </nav>
+    <div v-if="menuOpen" class="navbar-menu-background-shadow" />
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="navbar">
+  <nav class="navbar" v-click-outside="closeMenuIfOpen">
     <div
       class="navbar-iconWrapper hamburger full-opacity-on-hover"
       data-cyId="navbar-menuButton"
@@ -21,7 +21,6 @@
         @click="logout"
       />
     </div>
-    <div v-if="menuOpen" class="navbar-menu-background-shadow" @click="editProfile" />
     <div v-if="menuOpen" class="navbar-menu" data-cyId="navbar-menu">
       <button
         class="nav-mobile-button"
@@ -51,12 +50,14 @@
       >
     </div>
   </nav>
+  <div v-if="menuOpen" class="navbar-menu-background-shadow" />
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import firebase from 'firebase/app';
 import { GTagEvent } from '@/gtag';
+import { clickOutside } from '@/utilities';
 
 export default defineComponent({
   props: {
@@ -84,6 +85,12 @@ export default defineComponent({
       this.menuOpen = false;
       this.$emit('toggleRequirementsMobile');
     },
+    closeMenuIfOpen() {
+      this.menuOpen = false;
+    },
+  },
+  directives: {
+    'click-outside': clickOutside,
   },
 });
 </script>
@@ -156,17 +163,6 @@ $mobile-navbar-height: 4.5rem;
     }
   }
 
-  .navbar-menu-background-shadow {
-    display: none;
-    position: fixed;
-    z-index: 2;
-    left: 0;
-    right: 0;
-    top: $mobile-navbar-height;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-  }
-
   .navbar-menu {
     position: fixed;
     z-index: 3;
@@ -206,6 +202,17 @@ $mobile-navbar-height: 4.5rem;
   cursor: default;
 }
 
+.navbar-menu-background-shadow {
+  display: none;
+  position: fixed;
+  z-index: 2;
+  left: 0;
+  right: 0;
+  top: $mobile-navbar-height;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
 @media only screen and (max-width: $medium-breakpoint) {
   .navbar {
     width: 100%;
@@ -216,6 +223,7 @@ $mobile-navbar-height: 4.5rem;
     display: flex;
     position: fixed;
     flex-direction: row;
+    z-index: 3;
 
     .nav-mobile-button {
       border: 0;
@@ -256,8 +264,7 @@ $mobile-navbar-height: 4.5rem;
     }
 
     .hamburger,
-    .requirements-bar,
-    .navbar-menu-background-shadow {
+    .requirements-bar {
       display: block;
     }
 
@@ -265,6 +272,10 @@ $mobile-navbar-height: 4.5rem;
       display: flex;
       flex-direction: column;
     }
+  }
+
+  .navbar-menu-background-shadow {
+    display: block;
   }
 
   .desktop {

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -257,7 +257,7 @@ export default defineComponent({
   /* The Modal (background) */
   &-onboarding {
     position: fixed; /* Stay in place */
-    z-index: 3; /* Sit on top */
+    z-index: 4; /* Sit on top */
     left: 0;
     top: 0;
     width: 100%; /* Full width */


### PR DESCRIPTION
### Summary <!-- Required -->

Have clicking outside the mobile navbar close the menu instead of opening the onboarding modal

https://user-images.githubusercontent.com/25535093/142451659-817b2605-1a49-4e59-8c36-ef09e7d940e3.mp4

### Test Plan <!-- Required -->

1. Open the mobile navbar and ensure clicking outside the menu closes it instead of opening Onboarding
2. Ensure clicking elsewhere on the navbar or on the CoursePlan logo does not close the menu
3. Check that modals that appear above the navbar on mobile (such as Onboarding and selectable requirements) still display
3. Confirm desktop breakpoints are unchanged
