### PR TITLE
Added the template file for the ECE major

### DIFF
--- a/src/requirements/__test__/__snapshots__/requirement-data-id.test.ts.snap
+++ b/src/requirements/__test__/__snapshots__/requirement-data-id.test.ts.snap
@@ -154,7 +154,7 @@ Array [
   "Major-DEA-Natural Science II",
   "Major-DEA-Research Methods Course",
   "Major-DEA-Statistics",
-  "Major-ECE-Advanced Programming/Computer Engineering ",
+  "Major-ECE-Advanced Programming/Computer Engineering",
   "Major-ECE-Core Courses",
   "Major-ECE-Culminating Design Experience (CDE)",
   "Major-ECE-Engineering Distribution",

--- a/src/requirements/data/majors/ece.ts
+++ b/src/requirements/data/majors/ece.ts
@@ -55,7 +55,7 @@ const eceRequirements: readonly CollegeOrMajorRequirement[] = [
     slotNames: ['ECE 3030 or ECE 3150', 'ECE 3100 or ECE 3250', 'ECE 3140'],
   },
   {
-    name: 'Advanced Programming/Computer Engineering ',
+    name: 'Advanced Programming/Computer Engineering',
     description:
       'At least three credits of computer programming at a level above that of CS 1110/1112/1114/1115 and CS 1130/1132/1133/1142, or an advanced computer engineering course at a level above ECE 3140. ' +
       'Current courses that meet this requirement are CS 2110, ENGRD 3200, AEP 4380, ECE 2400, ECE 4740, ECE 4750, or ECE 4760. Other courses may be allowed by an ECE petition.',

--- a/src/requirements/data/templates/ece.ts
+++ b/src/requirements/data/templates/ece.ts
@@ -28,16 +28,28 @@ const eceTemplate: Template = [
   },
   {
     reqGroup: 'EN',
-    name: 'Advanced Programming/Computer Engineering',
-    placeholderSemesters: [3],
+    name: 'Intro to Engineering',
+    placeholderSemesters: [1],
   },
   {
     reqGroup: 'EN',
+    name: 'Computing from engineering',
+    placeholderSemesters: [2],
+  },
+  /*
+  {
+    reqGroup: 'ECE',
+    name: 'Advanced Programming/Computer Engineering',
+    placeholderSemesters: [3],
+  },
+  */
+  {
+    reqGroup: 'ECE',
     name: 'ENGRD 2300',
     placeholderSemesters: [3],
   },
   {
-    reqGroup: 'EN',
+    reqGroup: 'ECE',
     name: 'Core Courses',
     placeholderSemesters: [3, 4],
   },
@@ -52,34 +64,34 @@ const eceTemplate: Template = [
     placeholderSemesters: [3, 4, 5, 6, 7, 8],
   },
   {
-    reqGroup: 'EN',
+    reqGroup: 'ECE',
     name: 'Outside ECE Technical Electives',
     placeholderSemesters: [5, 6, 7],
   },
   {
-    reqGroup: 'EN',
+    reqGroup: 'ECE',
     name: 'Culminating Design Experience (CDE)',
     placeholderSemesters: [7],
   },
   {
     reqGroup: 'EN',
     name: 'Advisor Approved Electives',
-    placeholderSemesters: [3, 4],
+    placeholderSemesters: [5, 6],
   },
   {
-    reqGroup: 'EN',
+    reqGroup: 'ECE',
     name: 'Foundation Courses',
     placeholderSemesters: [5, 6],
   },
   {
-    reqGroup: 'EN',
+    reqGroup: 'ECE',
     name: 'Upper-Level ECE Electives',
-    placeholderSemesters: [6],
+    placeholderSemesters: [6, 7, 8],
   },
   {
-    reqGroup: 'EN',
+    reqGroup: 'ECE',
     name: 'Upper-Level ECE Electives: 4000 level',
-    placeholderSemesters: [7, 8],
+    placeholderSemesters: [8],
   },
 ];
 

--- a/src/requirements/data/templates/ece.ts
+++ b/src/requirements/data/templates/ece.ts
@@ -14,7 +14,12 @@ const eceTemplate: Template = [
   {
     reqGroup: 'EN',
     name: 'Physics',
-    placeholderSemesters: [2, 3, 4],
+    placeholderSemesters: [2, 3],
+  },
+  {
+    reqGroup: 'ECE',
+    name: 'Physics 2214/2218',
+    placeholderSemesters: [4],
   },
   {
     reqGroup: 'EN',
@@ -33,7 +38,7 @@ const eceTemplate: Template = [
   },
   {
     reqGroup: 'EN',
-    name: 'Computing from engineering',
+    name: 'Computing',
     placeholderSemesters: [2],
   },
   /*

--- a/src/requirements/data/templates/ece.ts
+++ b/src/requirements/data/templates/ece.ts
@@ -1,0 +1,86 @@
+import { Template } from '@/requirements/types';
+
+const eceTemplate: Template = [
+  {
+    reqGroup: 'UNI',
+    name: 'Physical Education',
+    placeholderSemesters: [1, 2],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Mathematics',
+    placeholderSemesters: [1, 2, 3, 4],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Physics',
+    placeholderSemesters: [2, 3, 4],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Chemistry',
+    placeholderSemesters: [1],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'First-Year Writing Seminars',
+    placeholderSemesters: [1, 2],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Advanced Programming/Computer Engineering',
+    placeholderSemesters: [3],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'ENGRD 2300',
+    placeholderSemesters: [3],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Core Courses',
+    placeholderSemesters: [3, 4],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Engineering Distribution',
+    placeholderSemesters: [4],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Liberal Studies: 6 courses',
+    placeholderSemesters: [3, 4, 5, 6, 7, 8],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Outside ECE Technical Electives',
+    placeholderSemesters: [5, 6, 7],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Culminating Design Experience (CDE)',
+    placeholderSemesters: [7],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Advisor Approved Electives',
+    placeholderSemesters: [3, 4],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Foundation Courses',
+    placeholderSemesters: [5, 6],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Upper-Level ECE Electives',
+    placeholderSemesters: [6],
+  },
+  {
+    reqGroup: 'EN',
+    name: 'Upper-Level ECE Electives: 4000 level',
+    placeholderSemesters: [7, 8],
+  },
+];
+
+export default eceTemplate;


### PR DESCRIPTION
### Summary 

This pull request adds the template data for the ECE major, closely following the implementation of the CS major template.

- [x] fixed a very small and (so far) insignificant typo in the ECE major file - an extra space in the description that would have resulted in a bug when running the script that constructs the actual templates on the front end, as said script would involve exactly matching between descriptions in a major file and names in the corresponding template file.

Remaining TODOs:

- [ ] add further templates for other majors.

### Test Plan 

Compare the data file with the ECE FA2021 template to ensure all requirements are correctly matched to where placeholders should be.

<img width="1405" alt="Screen Shot 2021-11-18 at 13 31 40" src="https://user-images.githubusercontent.com/20724086/142477815-415a2cc9-4fc0-4bac-8527-858deef20235.png">