### PR TITLE
[easy] Fix enforce release workflow job

### DIFF
--- a/.github/workflows/ci-policies.yml
+++ b/.github/workflows/ci-policies.yml
@@ -11,7 +11,7 @@ jobs:
           echo "Your head ref is ${{ github.head_ref }}."
           echo "Your base ref is ${{ github.base_ref }}."
       - name: Fail if try to push release from non-master branch
-        if: github.base_ref == 'beta-release' && github.head_ref != 'master'
+        if: github.base_ref != 'beta-release' && github.head_ref == 'master'
         run: |
           echo "Head ref must be master for release. Everything should go through staging first!"
           exit 1

--- a/.github/workflows/ci-policies.yml
+++ b/.github/workflows/ci-policies.yml
@@ -11,7 +11,7 @@ jobs:
           echo "Your head ref is ${{ github.head_ref }}."
           echo "Your base ref is ${{ github.base_ref }}."
       - name: Fail if try to push release from non-master branch
-        if: github.base_ref != 'beta-release' && github.head_ref == 'master'
+        if: github.base_ref == 'beta-release' && github.head_ref != 'master'
         run: |
           echo "Head ref must be master for release. Everything should go through staging first!"
           exit 1


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the `enforce-release-workflow` job in the `ci-policies` workflow. Before, it was failing on PRs from `master` to any non-`beta-release` branch. Rather, it should fail on PRs from non-`master` branches to `beta-release`.

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
before: [ci passed](https://github.com/cornell-dti/course-plan/runs/4337584044?check_suite_focus=true) (should fail)
![image](https://user-images.githubusercontent.com/34158284/143635520-083a9495-5f46-4a29-b0f4-364d4fc31e4b.png)
![image](https://user-images.githubusercontent.com/34158284/143636563-e015eea0-77b1-41a9-af28-8061dff9af87.png)

after: [ci failed](https://github.com/cornell-dti/course-plan/runs/4337552051?check_suite_focus=true) (should fail)
![image](https://user-images.githubusercontent.com/34158284/143638099-6c6afc7e-ebe0-4256-9187-6b0e7283d303.png)
![image](https://user-images.githubusercontent.com/34158284/143632229-0095701c-1483-4275-88ff-66c85e26f602.png)

### Notes
(not related to this PR)

I discovered a bug with Github where if you make a PR `A=>B` and then a new PR `A=>C`, the workflow instance for the second PR overwrites the workflow instance for the first PR. Then, when you delete the second PR and rerun the workflow instance for the first PR, the PR-specific env variables (like base ref and head ref) don't update properly. Editing the PR didn't fix the issue, but closing and reopening the PR (which created new workflow instances) fixed it.