### PR TITLE
[easy] Add NPM clean install to failing TrackUsers GitHub Action

### DIFF
--- a/.github/workflows/track-users.yml
+++ b/.github/workflows/track-users.yml
@@ -13,5 +13,7 @@ jobs:
         with:
           node-version: '16'
           cache: 'npm'
+      - name: NPM Clean Install
+        run: npm ci
       - name: Run TrackUsers
         run: npm run track-users


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request adds an NPM clean install step to the TrackUsers GitHub Action to stop it from failing daily (as `ts-node` needs to be installed to run the new script).

![image](https://user-images.githubusercontent.com/25535093/143907451-a7a71bae-d03e-4355-9a47-074a7e4437ea.png)

### Test Plan <!-- Required -->

Confirm the action passes when it runs as scheduled tonight.