### PR TITLE
[easy] Add prod service account secret to failing TrackUsers action

### DIFF
--- a/.github/workflows/track-users.yml
+++ b/.github/workflows/track-users.yml
@@ -17,3 +17,5 @@ jobs:
         run: npm ci
       - name: Run TrackUsers
         run: npm run track-users
+        env:
+          SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CORNELLDTI_COURSEPLAN_PROD }}


### PR DESCRIPTION
### Summary <!-- Required -->

Add the production service account secret to the `env` for the track-users action to prevent it from failing (like in #605)

### Test Plan <!-- Required -->

Re-run the job to confirm it now passes and adds a document to the prod Firestore.

### Notes <!-- Optional -->

The prod serviceAccount now has a secret stored in GitHub with name `FIREBASE_SERVICE_ACCOUNT_CORNELLDTI_COURSEPLAN_PROD` - thanks @SamChou19815 !