### PR TITLE
Use service account secret when provided

### DIFF
--- a/.github/workflows/track-users.yml
+++ b/.github/workflows/track-users.yml
@@ -17,3 +17,5 @@ jobs:
         run: npm ci
       - name: Run TrackUsers
         run: npm run track-users
+        env:
+          SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CORNELLDTI_COURSEPLAN_PROD }}

--- a/.github/workflows/track-users.yml
+++ b/.github/workflows/track-users.yml
@@ -18,4 +18,5 @@ jobs:
       - name: Run TrackUsers
         run: npm run track-users
         env:
+          PROD: true
           SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CORNELLDTI_COURSEPLAN_PROD }}

--- a/src/firebase-admin-config.ts
+++ b/src/firebase-admin-config.ts
@@ -4,9 +4,10 @@ import * as admin from 'firebase-admin';
 import { getTypedFirestoreDataConverter } from './firebase-config-common';
 
 const serviceAccountFilename = process.env.PROD ? 'serviceAccountProd.json' : 'serviceAccount.json';
-const serviceAccount =
+const serviceAccountUnparsed =
   process.env.SERVICE_ACCOUNT ??
-  JSON.parse(fs.readFileSync(path.join(__dirname, '..', serviceAccountFilename)).toString());
+  fs.readFileSync(path.join(__dirname, '..', serviceAccountFilename)).toString();
+const serviceAccount = JSON.parse(serviceAccountUnparsed);
 
 const databaseURL = process.env.PROD
   ? 'https://cornell-courseplan.firebaseio.com'

--- a/src/firebase-admin-config.ts
+++ b/src/firebase-admin-config.ts
@@ -14,7 +14,7 @@ const databaseURL = process.env.PROD
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL: databaseURL,
+  databaseURL,
 });
 
 const db = admin.firestore();

--- a/src/firebase-admin-config.ts
+++ b/src/firebase-admin-config.ts
@@ -4,12 +4,17 @@ import * as admin from 'firebase-admin';
 import { getTypedFirestoreDataConverter } from './firebase-config-common';
 
 const serviceAccountFilename = process.env.PROD ? 'serviceAccountProd.json' : 'serviceAccount.json';
-const serviceAccount = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '..', serviceAccountFilename)).toString()
-);
+const serviceAccount =
+  process.env.SERVICE_ACCOUNT ??
+  JSON.parse(fs.readFileSync(path.join(__dirname, '..', serviceAccountFilename)).toString());
+
+const databaseURL = process.env.PROD
+  ? 'https://cornell-courseplan.firebaseio.com'
+  : 'https://cornelldti-courseplan-dev.firebaseio.com';
+
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
+  databaseURL: databaseURL,
 });
 
 const db = admin.firestore();


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request ensures the service account is used when provided as an environmental variable (attempted fix at TrackUsers failing in #608). Furthermore, makes track-users as prod so the prod firestore url is used.

### Test Plan <!-- Required -->

1. Ensure running `npm run track-users` locally still uploads a Firestore doc to the dev instance (see [here](https://console.firebase.google.com/u/0/project/cornelldti-courseplan-dev/firestore/data/~2Ftrack-users~2F2021-11-30T18:18:11.184Z))
2. Re-run the TrackUsers action when merged to see if the error is resolved and a Firestore doc is added to the prod instance.
