### PR TITLE
Avoid tracking users that have not finished onboarding

### DIFF
--- a/src/requirements/admin/track-users.ts
+++ b/src/requirements/admin/track-users.ts
@@ -98,7 +98,7 @@ async function trackUsers() {
   let onboardingData = {} as FirestoreTrackUsersOnboardingData;
 
   // set of all user emails that are in the usernameCollection (and thus finished onboarding)
-  let userEmails = new Set();
+  const userEmails = new Set();
 
   await usernameCollection.get().then(usernameQuerySnapshot => {
     let totalUsersCount = 0;


### PR DESCRIPTION
### Summary <!-- Required -->

Fixes bug in #604 that breaks TrackUsers - some users still do not have a `season` property in the database, so not using the `type` parameter is season is null breaks some of the code.

This is because, as found by @benjamin-shen, users that do not finish onboarding are not in the usernames collection, and thus the script that added `season` param for every existing `type` param on a semester for users in the username collection (#593) does not add `season` to those who have not finished onboarding. 

To resolve this, there is now a check to ensure a user has finished onboarding (and is in the username collection) before tracking their other dats. This is a positive change regardless of the bug, as we only want to track semester and onboarding data for users that have actually gotten past onboarding.

### Test Plan <!-- Required -->

Run TrackUsers locally to ensure it now works on dev without error, and that the number of users in the username collection matches the number of users counted in other collections (instead of being smaller like before)

![image](https://user-images.githubusercontent.com/25535093/144108778-a9eff7d8-fe3e-438e-82b5-3bd086a64c45.png)

### Notes <!-- Optional -->

I believe there needs to be a script run to add the `semester` field to users that have not finished onboarding, regardless of this PR fix. Otherwise,, after `type` is deleted from the codebase, if these users ever come back and finish onboarding, their semester view will be broken.