### PR TITLE
Specialize requirements

### DIFF
--- a/src/requirements/README.md
+++ b/src/requirements/README.md
@@ -194,7 +194,7 @@ requirement is in it's own file.
 
 ### Final Computation for Frontend Vue Components
 
-- [`requirement-frontend-computation.ts`](./requirement-fronend-computation.ts) builds the
+- [`requirement-frontend-computation.ts`](./requirement-frontend-computation.ts) builds the
   requirement graph and fulfillment progress for each requirement.
 
 ## Contributing

--- a/src/requirements/data/index.ts
+++ b/src/requirements/data/index.ts
@@ -69,6 +69,8 @@ import spanishMinorRequirements from './minors/spanish';
 // import mengCSRequirements from './grad/meng-cs';
 import mpaRequirements from './grad/mpa';
 
+import Specializers from '../specialize';
+
 const json: RequirementsJson = {
   university: {
     UNI: {
@@ -175,6 +177,7 @@ const json: RequirementsJson = {
       name: 'Computer Science',
       schools: ['EN', 'AS1', 'AS2'],
       requirements: csRequirements,
+      specializations: [Specializers.EN.MATH2940],
     },
     DEA: {
       name: 'Design and Environmental Analysis',

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -1,5 +1,6 @@
 import { SPECIAL_COURSES } from './data/constants';
 import requirementJson from './typed-requirement-json';
+import * as Specialize from './specialize';
 
 /**
  * A collection of helper functions
@@ -86,6 +87,65 @@ export function requirementAllowDoubleCounting(
   return requirement.allowCourseDoubleCounting || false;
 }
 
+/**
+ * Get the requirements for a provided collection of majors/minors
+ *
+ * @param sourceType The type of the field of study, e.g. 'Major' or 'Minor'
+ * @param fields the names of the majors/minors
+ * @returns An array of requirements corresponding to every field of study in `fields`
+ */
+const fieldOfStudyReqs = (sourceType: 'Major' | 'Minor', fields: readonly string[]) => {
+  const jsonKey = sourceType.toLowerCase() as 'major' | 'minor';
+  const fieldRequirements = requirementJson[jsonKey];
+  return fields
+    .map(field => {
+      const fieldRequirement = fieldRequirements[field];
+      return fieldRequirement?.requirements.map(
+        it =>
+          (({
+            ...it,
+            id: `${sourceType}-${field}-${it.name}`,
+            sourceType,
+            sourceSpecificName: field,
+          } as const) ?? [])
+      );
+    })
+    .flat();
+};
+
+/**
+ * Get the majors corresponding to a list of major names
+ *
+ * @param majorNames the majors of the majors
+ * @returns An array of `Major<DecoratedCollegeOrMajorRequirement>` representing
+ * with the provided names. Names corresponding to no known major are ignored.
+ */
+const getMajors = (majorNames: readonly string[]) =>
+  majorNames.map(name => requirementJson.major[name]).filter(major => major !== undefined);
+
+/**
+ * Get the specialized requirements for a college given a list of majors
+ *
+ * @param collegeName the name of the college the user is enrolled in
+ * @param majorNames an array of the names of the majors the user is planning for
+ * @returns An array of college requirements specialized for the user based on
+ * their majors
+ */
+const specialized = (collegeName: string, majorNames: readonly string[]) => {
+  const majors = getMajors(majorNames);
+  const majorReqs = requirementJson.college[collegeName].requirements;
+  const spec = Specialize.specialized(majorReqs, majors);
+  return spec.map(
+    req =>
+      ({
+        ...req,
+        id: `College-${collegeName}-${req.name}`,
+        sourceType: 'College',
+        sourceSpecificName: collegeName,
+      } as const)
+  );
+};
+
 export function getUserRequirements({
   college,
   major: majors,
@@ -96,73 +156,36 @@ export function getUserRequirements({
   if (college && !(college in requirementJson.college))
     throw new Error(`College ${college} not found.`);
 
-  const universityReqs = requirementJson.university.UNI;
-  return [
-    // University requirements only added if college is defined, i.e. if the user has selected an undergraduate program.
-    ...(college
-      ? universityReqs.requirements.map(
-          it =>
-            ({
-              ...it,
-              id: `College-UNI-${it.name}`,
-              sourceType: 'College',
-              sourceSpecificName: college,
-            } as const)
-        )
-      : []),
-    ...(college
-      ? requirementJson.college[college].requirements.map(
-          it =>
-            ({
-              ...it,
-              id: `College-${college}-${it.name}`,
-              sourceType: 'College',
-              sourceSpecificName: college,
-            } as const)
-        )
-      : []),
-    ...majors
-      .map(major => {
-        const majorRequirement = requirementJson.major[major];
-        if (majorRequirement == null) return [];
-        return majorRequirement.requirements.map(
-          it =>
-            ({
-              ...it,
-              id: `Major-${major}-${it.name}`,
-              sourceType: 'Major',
-              sourceSpecificName: major,
-            } as const)
-        );
-      })
-      .flat(),
-    ...minors
-      .map(minor => {
-        const minorRequirement = requirementJson.minor[minor];
-        if (minorRequirement == null) return [];
-        return minorRequirement.requirements.map(
-          it =>
-            ({
-              ...it,
-              id: `Minor-${minor}-${it.name}`,
-              sourceType: 'Minor',
-              sourceSpecificName: minor,
-            } as const)
-        );
-      })
-      .flat(),
-    ...(grad
-      ? requirementJson.grad[grad].requirements.map(
-          it =>
-            ({
-              ...it,
-              id: `Grad-${grad}-${it.name}`,
-              sourceType: 'Grad',
-              sourceSpecificName: grad,
-            } as const)
-        )
-      : []),
-  ].map(requirement => ({
+  const rawUniReqs = requirementJson.university.UNI;
+  // University requirements only added if college is defined, i.e. if the user has selected an undergraduate program.
+  const uniReqs = college
+    ? rawUniReqs.requirements.map(
+        it =>
+          ({
+            ...it,
+            id: `College-UNI-${it.name}`,
+            sourceType: 'College',
+            sourceSpecificName: college,
+          } as const)
+      )
+    : [];
+  const collegeReqs = college ? specialized(college, majors) : [];
+  const majorReqs = fieldOfStudyReqs('Major', majors);
+  const minorReqs = fieldOfStudyReqs('Minor', minors);
+  const gradReqs = grad
+    ? requirementJson.grad[grad].requirements.map(
+        it =>
+          ({
+            ...it,
+            id: `Grad-${grad}-${it.name}`,
+            sourceType: 'Grad',
+            sourceSpecificName: grad,
+          } as const)
+      )
+    : [];
+  // flatten all requirements into single array
+  const allReqs = [uniReqs, collegeReqs, majorReqs, minorReqs, gradReqs].flat();
+  return allReqs.map(requirement => ({
     ...requirement,
     allowCourseDoubleCounting: requirementAllowDoubleCounting(requirement, majors) || undefined,
   }));

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -4,6 +4,8 @@ import {
   DecoratedRequirementsJson,
   RequirementChecker,
   Course,
+  MajorRequirements,
+  MutableMajorRequirements,
 } from './types';
 import sourceRequirements from './data';
 import { NO_EQUIVALENT_COURSES_COURSE_ID, SPECIAL_COURSES } from './data/constants';
@@ -97,13 +99,7 @@ const produceSatisfiableCoursesAttachedRequirementJson = (): DecoratedRequiremen
         readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
       };
     };
-    major: {
-      [key: string]: {
-        readonly name: string;
-        readonly schools: readonly string[];
-        readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
-      };
-    };
+    major: MutableMajorRequirements<DecoratedCollegeOrMajorRequirement>;
     minor: {
       [key: string]: {
         readonly name: string;
@@ -144,12 +140,19 @@ const produceSatisfiableCoursesAttachedRequirementJson = (): DecoratedRequiremen
     };
   });
   Object.entries(major).forEach(([majorName, majorRequirement]) => {
-    const { requirements, ...rest } = majorRequirement;
-    decoratedJson.major[majorName] = { ...rest, requirements: decorateRequirements(requirements) };
+    const { requirements, specializations, ...rest } = majorRequirement;
+    decoratedJson.major[majorName] = {
+      ...rest,
+      requirements: decorateRequirements(requirements),
+      specializations: decorateRequirements(specializations ?? []),
+    };
   });
   Object.entries(minor).forEach(([minorName, minorRequirement]) => {
     const { requirements, ...rest } = minorRequirement;
-    decoratedJson.minor[minorName] = { ...rest, requirements: decorateRequirements(requirements) };
+    decoratedJson.minor[minorName] = {
+      ...rest,
+      requirements: decorateRequirements(requirements),
+    };
   });
   Object.entries(grad).forEach(([gradName, gradRequirement]) => {
     const { requirements, ...rest } = gradRequirement;

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -4,7 +4,6 @@ import {
   DecoratedRequirementsJson,
   RequirementChecker,
   Course,
-  MajorRequirements,
   MutableMajorRequirements,
 } from './types';
 import sourceRequirements from './data';

--- a/src/requirements/specialize.ts
+++ b/src/requirements/specialize.ts
@@ -14,10 +14,10 @@ export function specialized<R extends RequirementCommon>(
   collegeReqs: readonly R[],
   majors: readonly Major<R>[]
 ) {
-  const specializations = majors.flatMap(({ specializations }) => specializations ?? []);
-  const excluded = new Set(specializations.map(({ name }) => name));
+  const allSpecializations = majors.flatMap(({ specializations }) => specializations ?? []);
+  const excluded = new Set(allSpecializations.map(({ name }) => name));
   const filteredReqs = collegeReqs.filter(({ name }) => !excluded.has(name));
-  return [...filteredReqs, ...specializations];
+  return [...filteredReqs, ...allSpecializations];
 }
 
 /**

--- a/src/requirements/specialize.ts
+++ b/src/requirements/specialize.ts
@@ -35,6 +35,6 @@ export default {
       fulfilledBy: 'courses',
       perSlotMinCount: [1, 1, 1],
       slotNames: ['MATH 1910', 'MATH 1920', 'MATH 2940'],
-    } as CollegeOrMajorRequirement
-  }
+    } as CollegeOrMajorRequirement,
+  },
 };

--- a/src/requirements/specialize.ts
+++ b/src/requirements/specialize.ts
@@ -1,0 +1,20 @@
+import { Major } from './types';
+
+/**
+ * Many majors often "specialize" the requirements of their respective college(s)
+ * `specialized(collegeReqs, majors)` is an array of `collegeReqs` having been
+ * specialized according to `majors`
+ *
+ * @param collegeReqs the base set of requirements for the college
+ * @param majors the set of majors to specialize `collegeReqs` for
+ * @returns An array of `collegeReqs` having been specialized for `majors`
+ */
+export function specialized<R extends RequirementCommon>(
+  collegeReqs: readonly R[],
+  majors: readonly Major<R>[]
+) {
+  const specializations = majors.flatMap(({ specializations }) => specializations ?? []);
+  const excluded = new Set(specializations.map(({ name }) => name));
+  const filteredReqs = collegeReqs.filter(({ name }) => !excluded.has(name));
+  return [...filteredReqs, ...specializations];
+}

--- a/src/requirements/specialize.ts
+++ b/src/requirements/specialize.ts
@@ -1,4 +1,5 @@
-import { Major } from './types';
+import { includesWithSubRequirements } from './data/checkers-common';
+import { CollegeOrMajorRequirement, Major } from './types';
 
 /**
  * Many majors often "specialize" the requirements of their respective college(s)
@@ -18,3 +19,22 @@ export function specialized<R extends RequirementCommon>(
   const filteredReqs = collegeReqs.filter(({ name }) => !excluded.has(name));
   return [...filteredReqs, ...specializations];
 }
+
+/**
+ * Here, we export an object containing common requirement specializations
+ * (e.g. requiring that MATH 2940 must be taken for engineering)
+ */
+export default {
+  EN: {
+    MATH2940: {
+      name: 'Mathematics',
+      description: 'MATH 1910, 1920, 2940, and a mathematics course chosen by the Major.',
+      source:
+        'https://www.engineering.cornell.edu/students/undergraduate-students/curriculum/undergraduate-requirements',
+      checker: includesWithSubRequirements(['MATH 1910'], ['MATH 1920'], ['MATH 2940']),
+      fulfilledBy: 'courses',
+      perSlotMinCount: [1, 1, 1],
+      slotNames: ['MATH 1910', 'MATH 1920', 'MATH 2940'],
+    } as CollegeOrMajorRequirement
+  }
+};

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -15,13 +15,19 @@ export type CollegeRequirements<R> = {
   };
 };
 
-export type MajorRequirements<R> = {
-  readonly [collegeCode: string]: {
-    readonly name: string;
-    readonly schools: readonly string[];
-    readonly requirements: readonly R[];
-  };
+export type Major<R> = Readonly<{
+  name: string;
+  schools: readonly string[];
+  requirements: readonly R[];
+  /** College requirements that have been "specialized" for this major */
+  specializations?: readonly R[];
+}>;
+
+export type MutableMajorRequirements<R> = {
+  [collegeCode: string]: Major<R>;
 };
+
+export type MajorRequirements<R> = Readonly<MutableMajorRequirements<R>>;
 
 type GenericRequirementsJson<R> = {
   readonly university: CollegeRequirements<R>;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements a framework for "specializing" college requirements for a specific major. For example, COE requires that MATH 1910, 1920, and one of 2930 or 2940 must be taken, whereas the CS major requires MATH 2940. This was accomplished by adding an optional `specializations` field to every major in `index.ts` which indicates how college requirements should be specialized for that major.

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] handle conflicting specializations for double majors. Right now, all specializations are added to the College requirements, which could result in a requirement appearing twice but specialized differently. It seems somewhat difficult to automatically resolve any conflicting specializations in the general case. However, hopefully this should be fairly infrequent, and also doesn't seem to be a significant issue anyways--both specializations would would have to be completed as desired.

### Test Plan <!-- Required -->
Below, we show specializing the COE Math requirement for CS:
<img width="1440" alt="Screen Shot 2021-11-30 at 5 29 46 PM" src="https://user-images.githubusercontent.com/73757337/144138537-ecf55aa3-a8ae-4db5-a4ba-2ec3e5eb7eef.png">
<!-- Provide screenshots or point out the additional unit tests -->

