### PR TITLE
Setup infrastructure for two-graph-based progress computation

### DIFF
--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -36,12 +36,13 @@ type CourseCautions = {
 
 const getCourseCautions = (course: FirestoreSemesterCourse): CourseCautions => {
   const {
-    requirementFulfillmentGraph,
+    safeRequirementFulfillmentGraph,
     derivedCoursesData: { duplicatedCourseCodeSet, courseToSemesterMap },
   } = store.state;
   const noMatchedRequirement =
-    requirementFulfillmentGraph.getConnectedRequirementsFromCourse({ uniqueId: course.uniqueID })
-      .length === 0;
+    safeRequirementFulfillmentGraph.getConnectedRequirementsFromCourse({
+      uniqueId: course.uniqueID,
+    }).length === 0;
   const semesterOfUserCourse = courseToSemesterMap[course.uniqueID];
   const typicallyOfferedWarning =
     semesterOfUserCourse != null &&

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -92,7 +92,7 @@ export default defineComponent({
             return;
           }
 
-          const currentlyMatchedRequirements = store.state.requirementFulfillmentGraph.getConnectedRequirementsFromCourse(
+          const currentlyMatchedRequirements = store.state.safeRequirementFulfillmentGraph.getConnectedRequirementsFromCourse(
             { uniqueId: course.uniqueID }
           );
           if (currentlyMatchedRequirements.includes(this.subReqId)) {
@@ -102,7 +102,7 @@ export default defineComponent({
 
           const currentRequirementAllowDoubleCounting =
             store.state.userRequirementsMap[this.subReqCourseId]?.allowCourseDoubleCounting;
-          const allOtherRequirementsAllowDoubleCounting = store.state.requirementFulfillmentGraph
+          const allOtherRequirementsAllowDoubleCounting = store.state.safeRequirementFulfillmentGraph
             .getConnectedRequirementsFromCourse({ uniqueId: course.uniqueID })
             .every(reqID => store.state.userRequirementsMap[reqID]?.allowCourseDoubleCounting);
           if (!currentRequirementAllowDoubleCounting && !allOtherRequirementsAllowDoubleCounting) {

--- a/src/components/Requirements/IncompleteSubReqCourse.vue
+++ b/src/components/Requirements/IncompleteSubReqCourse.vue
@@ -71,7 +71,7 @@ export default defineComponent({
   computed: {
     addCourseLabel(): string {
       let label = 'Add Course';
-      if (this.subReq.fulfilledBy === 'courses') {
+      if (this.subReq.fulfillment.fulfilledBy === 'courses') {
         label = `Add ${this.slotName}`;
       }
       return label;

--- a/src/components/Requirements/RequirementDebugger.vue
+++ b/src/components/Requirements/RequirementDebugger.vue
@@ -1,27 +1,38 @@
 <template>
-  <svg class="debugger-svg" :width="900" :height="itemSize * 48 + 36">
-    <g
-      v-for="(requirement, index) in requirementGraphForDisplay.requirements"
-      :key="index"
-      @click="setOnlyNodeToKeepEdge(requirement)"
-    >
-      <rect :x="0" :y="index * 48 + 16" :width="300" :height="32" class="requirement-box"></rect>
-      <text :x="8" :y="index * 48 + 36" :font-size="16">{{ requirement }}</text>
-    </g>
-    <g
-      v-for="(course, index) in requirementGraphForDisplay.courses"
-      :key="index"
-      @click="setOnlyNodeToKeepEdge(course.uniqueId)"
-    >
-      <rect :x="600" :y="index * 48 + 16" :width="300" :height="32" class="course-box"></rect>
-      <text :x="608" :y="index * 48 + 36" :font-size="16" fill="white">{{ course.code }}</text>
-    </g>
-    <path v-for="(line, index) in lines" :key="index" :d="line" stroke="black" />
-  </svg>
+  <div>
+    <div class="graph-toggler">
+      <label class="graph-toggler-choice">
+        <input type="radio" value="dangerous" v-model="graphType" /> Dangerous Graph
+      </label>
+      <label class="graph-toggler-choice">
+        <input type="radio" value="safe" v-model="graphType" /> Safe Graph
+      </label>
+    </div>
+    <svg class="debugger-svg" :width="900" :height="itemSize * 48 + 36">
+      <g
+        v-for="(requirement, index) in requirementGraphForDisplay.requirements"
+        :key="index"
+        @click="setOnlyNodeToKeepEdge(requirement)"
+      >
+        <rect :x="0" :y="index * 48 + 16" :width="300" :height="32" class="requirement-box"></rect>
+        <text :x="8" :y="index * 48 + 36" :font-size="16">{{ requirement }}</text>
+      </g>
+      <g
+        v-for="(course, index) in requirementGraphForDisplay.courses"
+        :key="index"
+        @click="setOnlyNodeToKeepEdge(course.uniqueId)"
+      >
+        <rect :x="600" :y="index * 48 + 16" :width="300" :height="32" class="course-box"></rect>
+        <text :x="608" :y="index * 48 + 36" :font-size="16" fill="white">{{ course.code }}</text>
+      </g>
+      <path v-for="(line, index) in lines" :key="index" :d="line" stroke="black" />
+    </svg>
+  </div>
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue';
 import store from '@/store';
+import RequirementFulfillmentGraph from '@/requirements/requirement-graph';
 
 type RequirementGraphForDisplay = {
   requirements: readonly string[];
@@ -30,9 +41,9 @@ type RequirementGraphForDisplay = {
 };
 
 function computeRequirementGraphForDisplay(
+  graph: RequirementFulfillmentGraph<string, CourseTaken>,
   onlyNodeToKeepEdge: string | number | null
 ): RequirementGraphForDisplay {
-  const graph = store.state.requirementFulfillmentGraph;
   const requirements = graph.getAllRequirements();
   const courses = graph.getAllCourses();
   const requirementToIndexMap = new Map(requirements.map((it, index) => [it, index]));
@@ -54,11 +65,11 @@ function computeRequirementGraphForDisplay(
   return { requirements, courses, edges };
 }
 
-type Data = { onlyNodeToKeepEdge: string | number | null };
+type Data = { onlyNodeToKeepEdge: string | number | null; graphType: 'safe' | 'dangerous' };
 
 export default defineComponent({
   data(): Data {
-    return { onlyNodeToKeepEdge: null };
+    return { onlyNodeToKeepEdge: null, graphType: 'dangerous' };
   },
   methods: {
     setOnlyNodeToKeepEdge(clickedNode: string | number) {
@@ -70,8 +81,13 @@ export default defineComponent({
     },
   },
   computed: {
+    graph(): RequirementFulfillmentGraph<string, CourseTaken> {
+      return this.graphType === 'safe'
+        ? store.state.safeRequirementFulfillmentGraph
+        : store.state.dangerousRequirementFulfillmentGraph;
+    },
     requirementGraphForDisplay(): RequirementGraphForDisplay {
-      return computeRequirementGraphForDisplay(this.onlyNodeToKeepEdge);
+      return computeRequirementGraphForDisplay(this.graph, this.onlyNodeToKeepEdge);
     },
     itemSize(): number {
       return Math.max(
@@ -91,6 +107,18 @@ export default defineComponent({
 </script>
 <style scoped lang="scss">
 @import '@/assets/scss/_variables.scss';
+
+.graph-toggler {
+  display: flex;
+  margin: 1em;
+  flex-direction: row;
+  justify-content: center;
+  width: 100%;
+}
+
+.graph-toggler-choice {
+  margin: 0 1em;
+}
 
 .debugger-svg {
   overflow: visible;

--- a/src/components/Requirements/RequirementDescription.vue
+++ b/src/components/Requirements/RequirementDescription.vue
@@ -57,24 +57,28 @@ export default defineComponent({
       return this.requirementFulfillment.requirement;
     },
     nestedRequirements(): readonly string[] | null {
-      if (this.requirementFulfillment.additionalRequirements) {
-        return Object.keys(this.requirementFulfillment.additionalRequirements);
+      if (this.requirementFulfillment.fulfillment.additionalRequirements) {
+        return Object.keys(this.requirementFulfillment.fulfillment.additionalRequirements);
       }
       return null;
     },
     progressString(): string {
-      const currentVisibleNestedRequirementStatistics = (this.requirementFulfillment
+      const currentVisibleNestedRequirementStatistics = (this.requirementFulfillment.fulfillment
         .additionalRequirements || {})[this.choice];
       if (currentVisibleNestedRequirementStatistics != null) {
         const {
-          minCountFulfilled,
+          safeMinCountFulfilled,
           minCountRequired,
           fulfilledBy,
         } = currentVisibleNestedRequirementStatistics;
-        return `${minCountFulfilled}/${minCountRequired} ${fulfilledBy}`;
+        return `${safeMinCountFulfilled}/${minCountRequired} ${fulfilledBy}`;
       }
-      const { minCountFulfilled, minCountRequired, fulfilledBy } = this.requirementFulfillment;
-      return `${minCountFulfilled}/${minCountRequired} ${fulfilledBy}`;
+      const {
+        safeMinCountFulfilled,
+        minCountRequired,
+        fulfilledBy,
+      } = this.requirementFulfillment.fulfillment;
+      return `${safeMinCountFulfilled}/${minCountRequired} ${fulfilledBy}`;
     },
   },
 });

--- a/src/components/Requirements/RequirementDisplayToggle.vue
+++ b/src/components/Requirements/RequirementDisplayToggle.vue
@@ -42,23 +42,21 @@ export default defineComponent({
     requirementFulfillmentProgress(): string {
       const {
         requirement,
-        minCountFulfilled,
-        minCountRequired,
-        additionalRequirements,
+        fulfillment: { safeMinCountFulfilled, minCountRequired, additionalRequirements },
       } = this.requirementFulfillment;
       if (requirement.fulfilledBy === 'self-check') return 'self check';
       if (additionalRequirements == null) {
-        return `${minCountFulfilled}/${minCountRequired} ${this.requirementFulfillment.fulfilledBy}`;
+        return `${safeMinCountFulfilled}/${minCountRequired} ${this.requirementFulfillment.fulfillment.fulfilledBy}`;
       }
       const additionalRequirementsList = Object.values(additionalRequirements);
       // Compute progress string x/y requirements fulfilled.
       // We also need to include the main requirement into consideration.
-      let totalFulfilledRequirements = minCountFulfilled >= minCountRequired ? 1 : 0;
+      let totalFulfilledRequirements = safeMinCountFulfilled >= minCountRequired ? 1 : 0;
       const totalRequirementsCount = 1 + additionalRequirementsList.length;
       for (let i = 0; i < additionalRequirementsList.length; i += 1) {
         const additionalRequirementProgress = additionalRequirementsList[i];
         if (
-          additionalRequirementProgress.minCountFulfilled >=
+          additionalRequirementProgress.safeMinCountFulfilled >=
           additionalRequirementProgress.minCountRequired
         ) {
           totalFulfilledRequirements += 1;

--- a/src/components/Requirements/RequirementFulfillmentSlots.vue
+++ b/src/components/Requirements/RequirementFulfillmentSlots.vue
@@ -118,10 +118,10 @@ export default defineComponent({
        * the nested requirement inside compound requirement the user chooses to display.
        */
       const matchedCourses = (
-        (this.requirementFulfillment.additionalRequirements || {})[
+        (this.requirementFulfillment.fulfillment.additionalRequirements || {})[
           this.compoundRequirementChoice
-        ] || this.requirementFulfillment
-      ).courses;
+        ] || this.requirementFulfillment.fulfillment
+      ).dangerousCourses;
 
       const allTakenCourseIds: ReadonlySet<number> = new Set(
         matchedCourses.flat().map(course => course.courseId)

--- a/src/components/Requirements/RequirementGroup.vue
+++ b/src/components/Requirements/RequirementGroup.vue
@@ -148,12 +148,12 @@ export default defineComponent({
       const ongoing: RequirementFulfillment[] = [];
       const completed: RequirementFulfillment[] = [];
       this.req.reqs.forEach(req => {
-        if (req.minCountFulfilled < req.minCountRequired) {
+        if (req.fulfillment.safeMinCountFulfilled < req.fulfillment.minCountRequired) {
           ongoing.push(req);
         } else if (
-          req.additionalRequirements != null &&
-          Object.values(req.additionalRequirements).some(
-            it => it.minCountFulfilled < it.minCountRequired
+          req.fulfillment.additionalRequirements != null &&
+          Object.values(req.fulfillment.additionalRequirements).some(
+            it => it.safeMinCountFulfilled < it.minCountRequired
           )
         ) {
           ongoing.push(req);

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -217,7 +217,7 @@ export default defineComponent({
     requirementFulfilled(): number {
       let fulfilled = 0;
       this.req.reqs.forEach(req => {
-        [req.fulfillment, ...Object.values(req.fulfillment.additionalRequirements || {})].forEach(
+        [req.fulfillment, ...Object.values(req.fulfillment.additionalRequirements ?? {})].forEach(
           reqOrNestedReq => {
             if (reqOrNestedReq.safeMinCountFulfilled >= reqOrNestedReq.minCountRequired)
               fulfilled += 1;
@@ -231,7 +231,7 @@ export default defineComponent({
       let totalRequired = 0;
       this.req.reqs.forEach(req => {
         if (req.fulfillment.fulfilledBy === 'self-check') return;
-        totalRequired += 1 + Object.values(req.fulfillment.additionalRequirements || {}).length;
+        totalRequired += 1 + Object.values(req.fulfillment.additionalRequirements ?? {}).length;
       });
       return totalRequired;
     },
@@ -239,7 +239,7 @@ export default defineComponent({
     totalRequirementProgress(): number {
       let fulfilled = 0;
       this.req.reqs.forEach(req => {
-        [req.fulfillment, ...Object.values(req.fulfillment.additionalRequirements || {})].forEach(
+        [req.fulfillment, ...Object.values(req.fulfillment.additionalRequirements ?? {})].forEach(
           reqOrNestedReq => {
             if (reqOrNestedReq.safeMinCountFulfilled >= reqOrNestedReq.minCountRequired) {
               fulfilled += 1;

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -217,9 +217,12 @@ export default defineComponent({
     requirementFulfilled(): number {
       let fulfilled = 0;
       this.req.reqs.forEach(req => {
-        [req, ...Object.values(req.additionalRequirements || {})].forEach(reqOrNestedReq => {
-          if (reqOrNestedReq.minCountFulfilled >= reqOrNestedReq.minCountRequired) fulfilled += 1;
-        });
+        [req.fulfillment, ...Object.values(req.fulfillment.additionalRequirements || {})].forEach(
+          reqOrNestedReq => {
+            if (reqOrNestedReq.safeMinCountFulfilled >= reqOrNestedReq.minCountRequired)
+              fulfilled += 1;
+          }
+        );
       });
       return fulfilled;
     },
@@ -227,8 +230,8 @@ export default defineComponent({
     requirementTotalRequired(): number {
       let totalRequired = 0;
       this.req.reqs.forEach(req => {
-        if (req.fulfilledBy === 'self-check') return;
-        totalRequired += 1 + Object.values(req.additionalRequirements || {}).length;
+        if (req.fulfillment.fulfilledBy === 'self-check') return;
+        totalRequired += 1 + Object.values(req.fulfillment.additionalRequirements || {}).length;
       });
       return totalRequired;
     },
@@ -236,10 +239,15 @@ export default defineComponent({
     totalRequirementProgress(): number {
       let fulfilled = 0;
       this.req.reqs.forEach(req => {
-        [req, ...Object.values(req.additionalRequirements || {})].forEach(reqOrNestedReq => {
-          if (reqOrNestedReq.minCountFulfilled >= reqOrNestedReq.minCountRequired) fulfilled += 1;
-          else fulfilled += reqOrNestedReq.minCountFulfilled / reqOrNestedReq.minCountRequired;
-        });
+        [req.fulfillment, ...Object.values(req.fulfillment.additionalRequirements || {})].forEach(
+          reqOrNestedReq => {
+            if (reqOrNestedReq.safeMinCountFulfilled >= reqOrNestedReq.minCountRequired) {
+              fulfilled += 1;
+            } else {
+              fulfilled += reqOrNestedReq.safeMinCountFulfilled / reqOrNestedReq.minCountRequired;
+            }
+          }
+        );
       });
       return fulfilled;
     },

--- a/src/components/Requirements/RequirementSelfCheckSlots.vue
+++ b/src/components/Requirements/RequirementSelfCheckSlots.vue
@@ -7,8 +7,8 @@
       <incomplete-self-check
         :subReqId="requirementFulfillment.requirement.id"
         :subReqName="requirementFulfillment.requirement.name"
-        :subReqFulfillment="requirementFulfillment.fulfilledBy"
-        :subReqCourseId="requirementFulfillment.minCountFulfilled"
+        :subReqFulfillment="requirementFulfillment.fulfillment.fulfilledBy"
+        :subReqCourseId="requirementFulfillment.fulfillment.safeMinCountFulfilled"
       />
     </div>
   </div>
@@ -39,7 +39,7 @@ export default defineComponent({
     fulfilledSelfCheckCourses(): readonly CourseTaken[] {
       // selectedCourses are courses that fulfill the requirement based on user-choice
       // they are taken from requirement graph
-      const selectedCourses = store.state.requirementFulfillmentGraph.getConnectedCoursesFromRequirement(
+      const selectedCourses = store.state.dangerousRequirementFulfillmentGraph.getConnectedCoursesFromRequirement(
         this.requirementFulfillment.requirement.id
       );
 
@@ -54,18 +54,20 @@ export default defineComponent({
       );
       if (requirementFulfillmentSpec !== null) {
         if (requirementFulfillmentSpec.fulfilledBy === 'credits') {
-          this.requirementFulfillment.courses[0].forEach(completedCourse =>
+          this.requirementFulfillment.fulfillment.dangerousCourses[0].forEach(completedCourse =>
             fulfillableCourses.push(completedCourse)
           );
         } else {
-          this.requirementFulfillment.courses.forEach((requirementFulfillmentCourseSlot, i) => {
-            const slotMinCount = requirementFulfillmentSpec.perSlotMinCount[i];
-            for (let j = 0; j < slotMinCount; j += 1) {
-              if (j < requirementFulfillmentCourseSlot.length) {
-                fulfillableCourses.push(requirementFulfillmentCourseSlot[j]);
+          this.requirementFulfillment.fulfillment.dangerousCourses.forEach(
+            (requirementFulfillmentCourseSlot, i) => {
+              const slotMinCount = requirementFulfillmentSpec.perSlotMinCount[i];
+              for (let j = 0; j < slotMinCount; j += 1) {
+                if (j < requirementFulfillmentCourseSlot.length) {
+                  fulfillableCourses.push(requirementFulfillmentCourseSlot[j]);
+                }
               }
             }
-          });
+          );
         }
       }
       // fulfillableCourses are then filtered to be AP/IB/transfer courses only

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -124,11 +124,27 @@ type RequirementFulfillmentStatisticsWithCoursesWithAdditionalRequirements = Req
     readonly [name: string]: RequirementFulfillmentStatisticsWithCourses;
   };
 };
+type MixedRequirementFulfillmentStatistics = {
+  readonly fulfilledBy: 'courses' | 'credits' | 'self-check';
+  readonly safeCourses: readonly (readonly CourseTaken[])[];
+  readonly dangerousCourses: readonly (readonly CourseTaken[])[];
+  readonly safeMinCountFulfilled: number;
+  readonly dangerousMinCountFulfilled: number;
+  readonly safeMinCountFulfilled: number;
+  readonly dangerousMinCountFulfilled: number;
+  readonly minCountRequired: number;
+};
+type MixedRequirementFulfillmentStatisticsWithAdditionalRequirements = MixedRequirementFulfillmentStatistics & {
+  readonly additionalRequirements?: {
+    readonly [name: string]: MixedRequirementFulfillmentStatistics;
+  };
+};
 
 type RequirementFulfillment = {
   /** The original requirement object. */
   readonly requirement: RequirementWithIDSourceType;
-} & RequirementFulfillmentStatisticsWithCoursesWithAdditionalRequirements;
+  readonly fulfillment: MixedRequirementFulfillmentStatisticsWithAdditionalRequirements;
+};
 
 type GroupedRequirementFulfillmentReport = {
   readonly groupName: 'College' | 'Major' | 'Minor' | 'Grad';

--- a/src/requirements/__test__/requirement-graph-builder.test.ts
+++ b/src/requirements/__test__/requirement-graph-builder.test.ts
@@ -1,4 +1,8 @@
-import buildRequirementFulfillmentGraph from '../requirement-graph-builder';
+import RequirementFulfillmentGraph from '../requirement-graph';
+import {
+  buildRequirementFulfillmentGraph,
+  removeIllegalEdgesFromRequirementFulfillmentGraph,
+} from '../requirement-graph-builder';
 
 const CS3410 = { uniqueId: 3410, courseId: 1 };
 const CS3420 = { uniqueId: 3420, courseId: 2 };
@@ -131,4 +135,28 @@ it('buildRequirementFulfillmentGraph phase 3 test 3', () => {
   expect(graph.getConnectedCoursesFromRequirement('CS3410/CS3420')).toEqual([CS3410]);
   expect(graph.getConnectedCoursesFromRequirement('Probability')).toEqual([MATH4710]);
   expect(graph.getConnectedCoursesFromRequirement('Elective')).toEqual([CS3420]);
+});
+
+it('removeIllegalEdgesFromRequirementFulfillmentGraph tests', () => {
+  const graph = new RequirementFulfillmentGraph<string, { uniqueId: number; courseId: 0 }>();
+  graph.addEdge('R1', { uniqueId: 1, courseId: 0 });
+  graph.addEdge('R2', { uniqueId: 1, courseId: 0 });
+  graph.addEdge('R3', { uniqueId: 1, courseId: 0 });
+  graph.addEdge('R1', { uniqueId: 2, courseId: 0 });
+  graph.addEdge('R2', { uniqueId: 2, courseId: 0 });
+  graph.addEdge('R1', { uniqueId: 2, courseId: 0 });
+  graph.addEdge('R1', { uniqueId: 3, courseId: 0 });
+  graph.addEdge('R4', { uniqueId: 3, courseId: 0 });
+  expect(
+    Array.from(
+      removeIllegalEdgesFromRequirementFulfillmentGraph(graph, r => r === 'R1' || r === 'R4')
+    )
+  ).toEqual([1]);
+
+  // Illegal double counting edges R2-1, R3-1 removed
+  expect(graph.getConnectedRequirementsFromCourse({ uniqueId: 1 })).toEqual(['R1']);
+  // Nothing removed
+  expect(graph.getConnectedRequirementsFromCourse({ uniqueId: 2 })).toEqual(['R1', 'R2']);
+  // Nothing removed
+  expect(graph.getConnectedRequirementsFromCourse({ uniqueId: 3 })).toEqual(['R1', 'R4']);
 });

--- a/src/requirements/admin/requirement-graph-admin-utils.ts
+++ b/src/requirements/admin/requirement-graph-admin-utils.ts
@@ -64,7 +64,7 @@ export default async function getUserRequirementDataOnAdmin(
 
   const {
     userRequirements,
-    requirementFulfillmentGraph,
+    dangerousRequirementFulfillmentGraph: requirementFulfillmentGraph,
   } = buildRequirementFulfillmentGraphFromUserData(
     courses,
     onboardingData,

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -8,11 +8,6 @@ import {
 import RequirementFulfillmentGraph from './requirement-graph';
 import buildRequirementFulfillmentGraphFromUserData from './requirement-graph-builder-from-user-data';
 
-type FulfillmentStatistics = {
-  readonly requirement: RequirementWithIDSourceType;
-  readonly courses: readonly (readonly CourseTaken[])[];
-} & RequirementFulfillmentStatistics;
-
 /**
  * Used for total academic credit requirements for all colleges except EN and AR
  * @param course course object with useful information retrived from Cornell courses API.
@@ -27,7 +22,7 @@ const courseIsAllEligible = (course: CourseTaken): boolean => {
 const getTotalCreditsFulfillmentStatistics = (
   college: string,
   courses: readonly CourseTaken[]
-): FulfillmentStatistics | null => {
+): RequirementFulfillment | null => {
   const requirementCommon = {
     sourceType: 'College',
     sourceSpecificName: college,
@@ -118,10 +113,14 @@ const getTotalCreditsFulfillmentStatistics = (
 
   return {
     requirement,
-    courses: [[]],
-    fulfilledBy: 'credits',
-    minCountFulfilled,
-    minCountRequired,
+    fulfillment: {
+      fulfilledBy: 'credits',
+      safeCourses: [[]],
+      dangerousCourses: [[]],
+      safeMinCountFulfilled: minCountFulfilled,
+      dangerousMinCountFulfilled: minCountFulfilled,
+      minCountRequired,
+    },
   };
 };
 
@@ -129,7 +128,7 @@ const getSwimTestFulfillmentStatistics = (
   college: string,
   courses: readonly CourseTaken[],
   tookSwimTest: boolean
-): FulfillmentStatistics => {
+): RequirementFulfillment => {
   const requirement: RequirementWithIDSourceType = {
     id: 'College-UNI-SwimTest',
     sourceType: 'College',
@@ -153,12 +152,17 @@ const getSwimTestFulfillmentStatistics = (
       credits: 0,
     });
   }
+  const minCountFulfilled = swimClasses.length > 0 ? 1 : 0;
   return {
     requirement,
-    courses: [swimClasses],
-    fulfilledBy: 'courses',
-    minCountFulfilled: swimClasses.length > 0 ? 1 : 0,
-    minCountRequired: 1,
+    fulfillment: {
+      fulfilledBy: 'courses',
+      safeCourses: [swimClasses],
+      dangerousCourses: [swimClasses],
+      safeMinCountFulfilled: minCountFulfilled,
+      dangerousMinCountFulfilled: minCountFulfilled,
+      minCountRequired: 1,
+    },
   };
 };
 
@@ -176,6 +180,51 @@ export function getCourseCodesArray(
   return courses;
 }
 
+function mergeRequirementFulfillmentStatisticsWithAdditionalRequirements(
+  dangerous: RequirementFulfillmentStatisticsWithCoursesWithAdditionalRequirements,
+  safe: RequirementFulfillmentStatisticsWithCoursesWithAdditionalRequirements
+): MixedRequirementFulfillmentStatisticsWithAdditionalRequirements {
+  function mergeRequirementFulfillmentStatistics(
+    {
+      fulfilledBy,
+      minCountFulfilled: dangerousMinCountFulfilled,
+      minCountRequired,
+      courses: dangerousCourses,
+    }: RequirementFulfillmentStatisticsWithCourses,
+    {
+      minCountFulfilled: safeMinCountFulfilled,
+      courses: safeCourses,
+    }: RequirementFulfillmentStatisticsWithCourses
+  ): MixedRequirementFulfillmentStatistics {
+    return {
+      fulfilledBy,
+      safeCourses,
+      dangerousCourses,
+      safeMinCountFulfilled,
+      dangerousMinCountFulfilled,
+      minCountRequired,
+    };
+  }
+
+  const base = mergeRequirementFulfillmentStatistics(dangerous, safe);
+  if (dangerous.additionalRequirements == null) return base;
+  const safeAdditionalRequirements = safe.additionalRequirements || {};
+  return {
+    ...base,
+    additionalRequirements: Object.fromEntries(
+      Object.entries(
+        dangerous.additionalRequirements
+      ).map(([key, dangerousAdditionalRequirement]) => [
+        key,
+        mergeRequirementFulfillmentStatistics(
+          dangerousAdditionalRequirement,
+          safeAdditionalRequirements[key]
+        ),
+      ])
+    ),
+  };
+}
+
 /** Compute everything needed for displaying requirement on the frontend. */
 export default function computeGroupedRequirementFulfillmentReports(
   semesters: readonly FirestoreSemester[],
@@ -184,7 +233,9 @@ export default function computeGroupedRequirementFulfillmentReports(
   overriddenFulfillmentChoices: FirestoreOverriddenFulfillmentChoices
 ): {
   readonly userRequirementsMap: Readonly<Record<string, RequirementWithIDSourceType>>;
-  readonly requirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
+  readonly dangerousRequirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
+  readonly safeRequirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
+  readonly doubleCountedCourseUniqueIDSet: ReadonlySet<string | number>;
   readonly groupedRequirementFulfillmentReport: readonly GroupedRequirementFulfillmentReport[];
 } {
   const coursesTaken = getCourseCodesArray(semesters, onboardingData);
@@ -192,7 +243,9 @@ export default function computeGroupedRequirementFulfillmentReports(
 
   const {
     userRequirements,
-    requirementFulfillmentGraph,
+    dangerousRequirementFulfillmentGraph,
+    safeRequirementFulfillmentGraph,
+    doubleCountedCourseUniqueIDSet,
   } = buildRequirementFulfillmentGraphFromUserData(
     coursesTaken,
     onboardingData,
@@ -200,7 +253,7 @@ export default function computeGroupedRequirementFulfillmentReports(
     overriddenFulfillmentChoices
   );
 
-  const collegeFulfillmentStatistics: FulfillmentStatistics[] = [];
+  const collegeFulfillmentStatistics: RequirementFulfillment[] = [];
   const totalCreditsFulfillmentStatistics = college
     ? getTotalCreditsFulfillmentStatistics(college, coursesTaken)
     : null;
@@ -211,19 +264,27 @@ export default function computeGroupedRequirementFulfillmentReports(
     collegeFulfillmentStatistics.push(
       getSwimTestFulfillmentStatistics(college, coursesTaken, onboardingData.tookSwim === 'yes')
     );
-  const majorFulfillmentStatisticsMap = new Map<string, FulfillmentStatistics[]>();
-  const minorFulfillmentStatisticsMap = new Map<string, FulfillmentStatistics[]>();
-  const gradFulfillmentStatisticsMap = new Map<string, FulfillmentStatistics[]>();
+  const majorFulfillmentStatisticsMap = new Map<string, RequirementFulfillment[]>();
+  const minorFulfillmentStatisticsMap = new Map<string, RequirementFulfillment[]>();
+  const gradFulfillmentStatisticsMap = new Map<string, RequirementFulfillment[]>();
   userRequirements.forEach(requirement => {
-    const courses = requirementFulfillmentGraph.getConnectedCoursesFromRequirement(requirement.id);
-    const fulfillmentStatistics = {
-      id: requirement.id,
+    const dangerousRequirementFulfillmentStatistics = computeFulfillmentCoursesAndStatistics(
       requirement,
-      ...computeFulfillmentCoursesAndStatistics(
-        requirement,
-        courses,
-        toggleableRequirementChoices,
-        overriddenFulfillmentChoices
+      dangerousRequirementFulfillmentGraph.getConnectedCoursesFromRequirement(requirement.id),
+      toggleableRequirementChoices,
+      overriddenFulfillmentChoices
+    );
+    const safeRequirementFulfillmentStatistics = computeFulfillmentCoursesAndStatistics(
+      requirement,
+      safeRequirementFulfillmentGraph.getConnectedCoursesFromRequirement(requirement.id),
+      toggleableRequirementChoices,
+      overriddenFulfillmentChoices
+    );
+    const fulfillmentStatistics: RequirementFulfillment = {
+      requirement,
+      fulfillment: mergeRequirementFulfillmentStatisticsWithAdditionalRequirements(
+        dangerousRequirementFulfillmentStatistics,
+        safeRequirementFulfillmentStatistics
       ),
     };
 
@@ -294,7 +355,9 @@ export default function computeGroupedRequirementFulfillmentReports(
 
   return {
     userRequirementsMap: Object.fromEntries(userRequirements.map(it => [it.id, it])),
-    requirementFulfillmentGraph,
+    dangerousRequirementFulfillmentGraph,
+    safeRequirementFulfillmentGraph,
+    doubleCountedCourseUniqueIDSet,
     groupedRequirementFulfillmentReport,
   };
 }

--- a/src/requirements/requirement-graph.ts
+++ b/src/requirements/requirement-graph.ts
@@ -93,4 +93,15 @@ export default class RequirementFulfillmentGraph<
     if (requirementSet == null) return [];
     return Array.from(requirementSet);
   }
+
+  public copy(): RequirementFulfillmentGraph<Requirement, Course> {
+    const newCopy = new RequirementFulfillmentGraph<Requirement, Course>();
+    this.requirementToCoursesMap.forEach((courseIdToCourseMap, key) => {
+      newCopy.requirementToCoursesMap.set(key, new Map(courseIdToCourseMap.entries()));
+    });
+    this.courseToRequirementsMap.forEach((requirementSet, key) => {
+      newCopy.courseToRequirementsMap.set(key, new Set(requirementSet));
+    });
+    return newCopy;
+  }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -50,7 +50,9 @@ export type VuexStoreState = {
   toggleableRequirementChoices: AppToggleableRequirementChoices;
   overriddenFulfillmentChoices: FirestoreOverriddenFulfillmentChoices;
   userRequirementsMap: Readonly<Record<string, RequirementWithIDSourceType>>;
-  requirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
+  dangerousRequirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
+  safeRequirementFulfillmentGraph: RequirementFulfillmentGraph<string, CourseTaken>;
+  doubleCountedCourseUniqueIDSet: ReadonlySet<string | number>;
   groupedRequirementFulfillmentReport: readonly GroupedRequirementFulfillmentReport[];
   subjectColors: Readonly<Record<string, string>>;
   uniqueIncrementer: number;
@@ -94,7 +96,10 @@ const store: TypedVuexStore = new TypedVuexStore({
     userRequirementsMap: {},
     // It won't be null once the app loads.
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    requirementFulfillmentGraph: null!,
+    dangerousRequirementFulfillmentGraph: null!,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    safeRequirementFulfillmentGraph: null!,
+    doubleCountedCourseUniqueIDSet: new Set(),
     groupedRequirementFulfillmentReport: [],
     subjectColors: {},
     uniqueIncrementer: 0,
@@ -143,12 +148,16 @@ const store: TypedVuexStore = new TypedVuexStore({
       data: Pick<
         VuexStoreState,
         | 'userRequirementsMap'
-        | 'requirementFulfillmentGraph'
+        | 'dangerousRequirementFulfillmentGraph'
+        | 'safeRequirementFulfillmentGraph'
+        | 'doubleCountedCourseUniqueIDSet'
         | 'groupedRequirementFulfillmentReport'
       >
     ) {
       state.userRequirementsMap = data.userRequirementsMap;
-      state.requirementFulfillmentGraph = data.requirementFulfillmentGraph;
+      state.dangerousRequirementFulfillmentGraph = data.dangerousRequirementFulfillmentGraph;
+      state.safeRequirementFulfillmentGraph = data.safeRequirementFulfillmentGraph;
+      state.doubleCountedCourseUniqueIDSet = data.doubleCountedCourseUniqueIDSet;
       state.groupedRequirementFulfillmentReport = data.groupedRequirementFulfillmentReport;
     },
     setSubjectColors(state: VuexStoreState, colors: Readonly<Record<string, string>>) {


### PR DESCRIPTION
## Summary

### Design

#### Background

There are concerns over the current too liberal approach of computing requirement as proposed in the original plan above. In the previous proposal, we keep all edges by default even if there is double-counting and let user opt-out of those edges later.

As a response to that, we have explored ideas that the edges are not added by default. Instead, the user has to explicitly do opt-in for courses that might introduce double counting. This proposal indeed ensures that we are conservative about progress computation, but it also makes certain things hard to explain to users:

- why user has to make choices
- how to find potential constraint violation because an edge is added
- how to inform user about making choices without exposing all the graph internals

#### Amendament Solution

It turns out that we can try to find the best of both worlds by computing two graphs. The first graph is the graph we will compute according to the original proposal above. It will keep all edges, and user choices to remove double counting will be represented as opt-out. (Phase 3 computation). Then based on the graph, we remove all the edges that are associated with constraint violation, which results in a graph that only contain safe edges (Phase 4 computation).

Both graphs will be useful. Phase 3 graph helps us to compute constraint violations that can be used as source of suggestions and warnings for users, and phase 4 graph provides a source for progress computation that is conservative and safe.

#### Example

Consider the following example before we account for user choices. By default, all edges are kept, even if there are constraint violations (i.e. double counting).

<img width="479" alt="Screen Shot 2021-11-02 at 21 47 33" src="https://user-images.githubusercontent.com/4290500/140000569-e90c641c-0465-4cdf-883a-6188b7ff22eb.png">

Then we start to take account of user choices. In this case, the user opts-out the edge `CS5414 --- MEng_CS_15_Credits`. Now we get a graph that on the left of the following figure.

<img width="1255" alt="Screen Shot 2021-11-02 at 21 47 42" src="https://user-images.githubusercontent.com/4290500/140000571-e52d000b-740b-4a98-b2b2-4da948d6b11d.png">

This graph still has constraint violations (edges marked in red), so we remove all the edges that are associated with constraint violations and obtain the graph on the right. The graph on the right will then by the source of truth for computing fulfillment progress.

### Implementation

This PR cherry picks the changes from #599 that involves updating the core requirement algorithm to use two graphs. The first graph applies user choices as before, and the second removes all edges that involve illegal double counting. 

Intuitively, the first graph is optimistic but dangerous: if we use the first graph to compute progress, we will overcount. However, it is still useful since it gives user guidance on what their current courses can fulfill in the most optimistic settings. The second graph is conservative and safe. It allows us to compute the real progress. The diff of the progress will be considered as uncertain progress, as shown in the proposed design in #599:

<img width="1577" alt="uncertain-progress" src="https://user-images.githubusercontent.com/4290500/142474259-9d449a16-6c55-4d1a-ab69-66ac17c4ff42.png">

The core update of the algorithm is rather small, just a single added function `removeIllegalEdgesFromRequirementFulfillmentGraph` that generates the second graph from the first graph. However, it forces the following downstream changes:

- Since we now have two graphs, we must also compute progress for both graph. Changes in `src/requirements/requirement-frontend-computation.ts` are handling that. It's actually the largest diff in this PR.
- In a lot of Vue components that query the graph or render some progress info, they now need to decide whether to use the safe/dangerous graph/progress. In this PR, most of them use the safe graph, but some uses the dangerous graph. I will explain the dangerous graph usage in inline comments. In this PR, it matters less, since it doesn't introduce mechanism to let user introduce possible double counting yet. However, it will matter more in the future.

Apart from the requirement debugger, there shouldn't be any UI, functionality, and behavior changes. Requirement debugger should always show that safe graph is the same as dangerous graph.

## Test Plan

Added unit tests on `removeIllegalEdgesFromRequirementFulfillmentGraph`.

Updated requirement graph debugger to include both safe and dangerous graph:

<img width="1624" alt="Screen Shot 2021-12-05 at 11 49 04 AM" src="https://user-images.githubusercontent.com/4290500/144755850-1b550a65-a693-4689-a1c8-a51464ff2584.png">