### PR TITLE
[easy] Fix AG foreign language checker

### DIFF
--- a/src/requirements/data/colleges/ag.ts
+++ b/src/requirements/data/colleges/ag.ts
@@ -1,5 +1,9 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
-import { courseIsFWS, includesWithSingleRequirement } from '../checkers-common';
+import {
+  courseIsForeignLang,
+  courseIsFWS,
+  includesWithSingleRequirement,
+} from '../checkers-common';
 
 const calsCreditsRequirement: CollegeOrMajorRequirement = {
   name: 'CALS Credits',
@@ -584,7 +588,7 @@ const calsSocialSciencesAndHumanitiesRequiement: CollegeOrMajorRequirement = {
   checker: [
     (course: Course): boolean => course.catalogDistr?.includes('CA-') ?? false,
     (course: Course): boolean => course.catalogDistr?.includes('D-') ?? false,
-    (course: Course): boolean => course.catalogDistr?.includes('FL-') ?? false,
+    courseIsForeignLang,
     (course: Course): boolean => course.catalogDistr?.includes('HA-') ?? false,
     (course: Course): boolean => course.catalogDistr?.includes('KCM-') ?? false,
     (course: Course): boolean => course.catalogDistr?.includes('LA-') ?? false,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the FL checker in the AG college requirement 'Social Sciences and Humanities'.

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

#### TODO
There are a few other instances of empty lists for courses in the requirements json. This is pretty sus, so we should clean them up.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
The FL slot now can be fulfilled by foreign language courses. You can see this by expanding the `decorated-requirements.json` diff.

#### Before
![image](https://user-images.githubusercontent.com/34158284/147392692-ff4784c2-f76d-4c06-8ad8-5a4fd9b911fd.png)

#### After
![image](https://user-images.githubusercontent.com/34158284/147392686-ceb3b206-dc1c-426d-b3d0-afb3e20e7267.png)

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
In this PR, there is also a diff for `specializations`  under the EAS major. This is because the specializations and EAS PRs got merged to master around the same time (so the EAS PR didn't run `npm run req-gen` after pulling the specializations PR). This diff fixes that discrepancy.