### PR TITLE
Add exam course ids and conditions to requirements json

### DIFF
--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -9,16 +9,6 @@ type RequirementCommon = {
   readonly allowCourseDoubleCounting?: true;
   /** If this is set to true, then AP/IB credits cannot be applied towards this requirement. */
   readonly disallowTransferCredit?: true;
-  /** Requirements may have conditions associated with certain course ids, eg. for AP/IB exams. */
-  readonly conditions?: Record<
-    [courseId: number],
-    {
-      /** If the user IS NOT in one of these colleges, the course id cannot fulfill the requirement. */
-      colleges: string[];
-      /** If the user IS in one of these majors, the course id cannot fulfill the requirement. */
-      majorsExcluded?: string[];
-    }
-  >;
 
   /**
    * If this field exists with string,
@@ -89,8 +79,22 @@ type RequirementFulfillmentInformation<T = Record<string, unknown>> =
     } & T)
   | ToggleableRequirementFulfillmentInformation<T>;
 
+/** Requirements may have conditions associated with certain course ids, eg. for AP/IB exams. */
+type RequirementCourseConditions = Record<
+  [courseId: number],
+  {
+    /** If the user IS NOT in one of these colleges, the course id cannot fulfill the requirement. */
+    readonly colleges: string[];
+    /** If the user IS in one of these majors, the course id cannot fulfill the requirement. */
+    readonly majorsExcluded?: string[];
+  }
+>;
+
 type DecoratedCollegeOrMajorRequirement = RequirementCommon &
-  RequirementFulfillmentInformation<{ readonly courses: readonly (readonly number[])[] }>;
+  RequirementFulfillmentInformation<{
+    readonly courses: readonly (readonly number[])[];
+    readonly conditions?: readonly RequirementCourseConditions;
+  }>;
 
 /**
  * CourseTaken is the data type used in requirement computation.

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -9,6 +9,16 @@ type RequirementCommon = {
   readonly allowCourseDoubleCounting?: true;
   /** If this is set to true, then AP/IB credits cannot be applied towards this requirement. */
   readonly disallowTransferCredit?: true;
+  /** Requirements may have conditions associated with certain course ids, eg. for AP/IB exams. */
+  readonly conditions?: Record<
+    [courseId: number],
+    {
+      /** If the user IS NOT in one of these colleges, the course id cannot fulfill the requirement. */
+      colleges: string[];
+      /** If the user IS in one of these majors, the course id cannot fulfill the requirement. */
+      majorsExcluded?: string[];
+    }
+  >;
 
   /**
    * If this field exists with string,

--- a/src/requirements/requirement-exam-mapping.ts
+++ b/src/requirements/requirement-exam-mapping.ts
@@ -5,10 +5,13 @@ import examData, {
 } from './data/exams/ExamCredit';
 import { colleges, College } from './data';
 
+// TODO @bshen try to refactor these types
 type ExamRequirementsCollegeConditions = Record<number, College[]>;
 type ExamRequirementsConditions = {
-  collegeConditions: ExamRequirementsCollegeConditions; // if the user IS NOT in one of these colleges, the course id cannot fulfill the requirement
-  majorsExcluded?: string[]; // if the user IS in one of these majors, the course id cannot fulfill the requirement
+  /** If the user IS NOT in one of these colleges, the course id cannot fulfill the requirement. */
+  collegeConditions: ExamRequirementsCollegeConditions;
+  /** If the user IS in one of these majors, the course id cannot fulfill the requirement. */
+  majorsExcluded?: string[];
 };
 
 /**
@@ -119,21 +122,19 @@ export const examRequirementsMapping: Record<
   };
 }, {});
 
-export const examToCourseMapping: Record<number, string[]> = Object.fromEntries(
+export const examToCourseMapping: Record<string, number[]> = Object.fromEntries(
   Object.entries(examRequirementsMapping).map(([id, conditions]) => [
     id,
-    Object.keys(conditions.collegeConditions),
+    Object.keys(conditions.collegeConditions).map(k => parseInt(k, 10)),
   ])
 );
 
-export const courseToExamMapping: Record<number, string[]> = Object.entries(
+export const courseToExamMapping: Record<string, number[]> = Object.entries(
   examToCourseMapping
-).reduce((mapping: Record<number, string[]>, [id, courses]) => {
-  courses
-    .map(c => parseInt(c, 10))
-    .forEach(course => {
-      if (!mapping[course]) mapping[course] = [];
-      mapping[course] = [...mapping[course], id];
-    });
+).reduce((mapping: Record<number, number[]>, [id, courses]) => {
+  courses.forEach(course => {
+    if (!mapping[course]) mapping[course] = [];
+    mapping[course] = [...mapping[course], parseInt(id, 10)];
+  });
   return mapping;
 }, {});

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -359,7 +359,7 @@ const generateDecoratedRequirementsJson = (): DecoratedRequirementsJson => {
     decoratedJson.major[majorName] = {
       ...rest,
       requirements: decorateRequirements(requirements),
-      specializations: decorateRequirements(specializations ?? []),
+      specializations: specializations && decorateRequirements(specializations),
     };
   });
   Object.entries(minor).forEach(([minorName, minorRequirement]) => {

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -283,29 +283,30 @@ const decorateRequirementWithExams = (
           };
     }
     case 'toggleable': {
-      const { fulfillmentOptions, conditions, description } = requirement;
-      const newConditions = { ...conditions };
-      const newFulfillmentOptions = Object.fromEntries(
-        Object.entries(fulfillmentOptions).map(([optionName, option]) => {
-          const { courses, ...rest } = option;
-          const examConditions = computeConditionsForExams(courses);
-          Object.keys(examConditions).forEach(e => {
-            if (e in newConditions) console.log(description);
-          });
-          Object.assign(newConditions, examConditions);
-          return [optionName, { ...rest, courses: courses.map(addCourseIdsForAssociatedExams) }];
-        })
-      );
-      return Object.keys(newConditions).length !== 0
-        ? {
-            ...requirement,
-            fulfillmentOptions: newFulfillmentOptions,
-            conditions: newConditions,
-          }
-        : {
-            ...requirement,
-            fulfillmentOptions: newFulfillmentOptions,
-          };
+      const { fulfillmentOptions } = requirement;
+      return {
+        ...requirement,
+        fulfillmentOptions: Object.fromEntries(
+          Object.entries(fulfillmentOptions).map(([optionName, option]) => {
+            const { courses, conditions, ...rest } = option;
+            const examConditions = computeConditionsForExams(courses);
+            const newConditions = {
+              ...conditions,
+              ...examConditions,
+            };
+            return [
+              optionName,
+              Object.keys(newConditions).length !== 0
+                ? {
+                    ...rest,
+                    courses: courses.map(addCourseIdsForAssociatedExams),
+                    conditions: newConditions,
+                  }
+                : { ...rest, courses: courses.map(addCourseIdsForAssociatedExams) },
+            ];
+          })
+        ),
+      };
     }
     default:
       throw new Error();

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -6,7 +6,7 @@ import {
   Course,
   MutableMajorRequirements,
 } from './types';
-import sourceRequirements, { College, colleges } from './data';
+import sourceRequirements, { colleges } from './data';
 import { NO_EQUIVALENT_COURSES_COURSE_ID, SPECIAL_COURSES } from './data/constants';
 import {
   examRequirementsMapping,
@@ -260,15 +260,13 @@ const sortRequirementCourses: RequirementDecorator = requirement => {
               ([
                 name,
                 { courses: additionalRequirementsCourses, ...additionalRequirementRest },
-              ]) => {
-                return [
-                  name,
-                  {
-                    ...additionalRequirementRest,
-                    courses: additionalRequirementsCourses.map(c => [...c].sort((a, b) => a - b)),
-                  },
-                ];
-              }
+              ]) => [
+                name,
+                {
+                  ...additionalRequirementRest,
+                  courses: additionalRequirementsCourses.map(c => [...c].sort((a, b) => a - b)),
+                },
+              ]
             )
           ),
       };
@@ -405,7 +403,6 @@ const generateDecoratedRequirementsJson = (): DecoratedRequirementsJson => {
 };
 
 const decoratedRequirements = generateDecoratedRequirementsJson();
-
 const decoratedRequirementsString = JSON.stringify(decoratedRequirements, undefined, 2);
 
 writeFileSync('src/requirements/decorated-requirements.json', decoratedRequirementsString);

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -153,7 +153,7 @@ const computeConditionsForExams = (courses: readonly (readonly number[])[]) => {
     });
     if (validColleges.size === colleges.length) return;
     conditions[exam] = {
-      colleges: [...validColleges],
+      colleges: [...validColleges].sort(),
       ...(majorsExcluded && { majorsExcluded }),
     };
   });

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -9,6 +9,7 @@ import {
 import sourceRequirements from './data';
 import { NO_EQUIVALENT_COURSES_COURSE_ID, SPECIAL_COURSES } from './data/constants';
 import { fullCoursesArray } from '../assets/courses/typed-full-courses';
+import universityRequirements from './data/university';
 
 /**
  * Special (synthetic) courses used for AP/IB fulfillment.
@@ -24,6 +25,37 @@ const specialCourses: Course[] = Object.entries(SPECIAL_COURSES)
     acadGroup: '',
   }))
   .filter(({ crseId }) => crseId !== NO_EQUIVALENT_COURSES_COURSE_ID);
+
+type MutableDecoratedJson = {
+  university: {
+    [key: string]: {
+      readonly name: string;
+      readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
+    };
+  };
+  college: {
+    [key: string]: {
+      readonly name: string;
+      readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
+    };
+  };
+  major: MutableMajorRequirements<DecoratedCollegeOrMajorRequirement>;
+  minor: {
+    [key: string]: {
+      readonly name: string;
+      readonly schools: readonly string[];
+      readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
+    };
+  };
+  grad: {
+    [key: string]: {
+      readonly name: string;
+      // Unsure if grad programs can be offered by multiple schools, but allows flexibility.
+      readonly schools: readonly string[];
+      readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
+    };
+  };
+};
 
 const getEligibleCoursesFromRequirementCheckers = (
   checkers: readonly RequirementChecker[]
@@ -83,38 +115,8 @@ const decorateRequirementWithCourses = (
   }
 };
 
-const produceSatisfiableCoursesAttachedRequirementJson = (): DecoratedRequirementsJson => {
+const requirementsJsonWithSatisfiableCourses = (): MutableDecoratedJson => {
   const { university, college, major, minor, grad } = sourceRequirements;
-  type MutableDecoratedJson = {
-    university: {
-      [key: string]: {
-        readonly name: string;
-        readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
-      };
-    };
-    college: {
-      [key: string]: {
-        readonly name: string;
-        readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
-      };
-    };
-    major: MutableMajorRequirements<DecoratedCollegeOrMajorRequirement>;
-    minor: {
-      [key: string]: {
-        readonly name: string;
-        readonly schools: readonly string[];
-        readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
-      };
-    };
-    grad: {
-      [key: string]: {
-        readonly name: string;
-        // Unsure if grad programs can be offered by multiple schools, but allows flexibility.
-        readonly schools: readonly string[];
-        readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
-      };
-    };
-  };
   const decoratedJson: MutableDecoratedJson = {
     university: {},
     college: {},
@@ -122,40 +124,43 @@ const produceSatisfiableCoursesAttachedRequirementJson = (): DecoratedRequiremen
     minor: {},
     grad: {},
   };
-  const decorateRequirements = (requirements: readonly CollegeOrMajorRequirement[]) =>
+  const decorateRequirementsWithCourses = (requirements: readonly CollegeOrMajorRequirement[]) =>
     requirements.map(decorateRequirementWithCourses);
   Object.entries(university).forEach(([universityName, universityRequirement]) => {
     const { requirements, ...rest } = universityRequirement;
     decoratedJson.university[universityName] = {
       ...rest,
-      requirements: decorateRequirements(requirements),
+      requirements: decorateRequirementsWithCourses(requirements),
     };
   });
   Object.entries(college).forEach(([collegeName, collegeRequirement]) => {
     const { requirements, ...rest } = collegeRequirement;
     decoratedJson.college[collegeName] = {
       ...rest,
-      requirements: decorateRequirements(requirements),
+      requirements: decorateRequirementsWithCourses(requirements),
     };
   });
   Object.entries(major).forEach(([majorName, majorRequirement]) => {
     const { requirements, specializations, ...rest } = majorRequirement;
     decoratedJson.major[majorName] = {
       ...rest,
-      requirements: decorateRequirements(requirements),
-      specializations: decorateRequirements(specializations ?? []),
+      requirements: decorateRequirementsWithCourses(requirements),
+      specializations: decorateRequirementsWithCourses(specializations ?? []),
     };
   });
   Object.entries(minor).forEach(([minorName, minorRequirement]) => {
     const { requirements, ...rest } = minorRequirement;
     decoratedJson.minor[minorName] = {
       ...rest,
-      requirements: decorateRequirements(requirements),
+      requirements: decorateRequirementsWithCourses(requirements),
     };
   });
   Object.entries(grad).forEach(([gradName, gradRequirement]) => {
     const { requirements, ...rest } = gradRequirement;
-    decoratedJson.grad[gradName] = { ...rest, requirements: decorateRequirements(requirements) };
+    decoratedJson.grad[gradName] = {
+      ...rest,
+      requirements: decorateRequirementsWithCourses(requirements),
+    };
   });
 
   // Check no duplicate requirement identifier
@@ -183,10 +188,88 @@ const produceSatisfiableCoursesAttachedRequirementJson = (): DecoratedRequiremen
   return decoratedJson;
 };
 
-const decoratedRequirementString = JSON.stringify(
-  produceSatisfiableCoursesAttachedRequirementJson(),
-  undefined,
-  2
+const decorateRequirementWithExams = (
+  requirement: DecoratedCollegeOrMajorRequirement
+): DecoratedCollegeOrMajorRequirement => {
+  switch (requirement.fulfilledBy) {
+    case 'self-check':
+      return requirement;
+    case 'courses':
+    case 'credits': {
+      const { courses, ...rest } = requirement;
+      return {
+        ...rest,
+        courses: courses.concat([[10000000]]),
+      };
+    }
+    case 'toggleable': {
+      const { fulfillmentOptions } = requirement;
+      return {
+        ...requirement,
+        fulfillmentOptions: Object.fromEntries(
+          Object.entries(fulfillmentOptions).map(([optionName, option]) => {
+            const { courses, ...rest } = option;
+            return [optionName, { ...rest, courses: courses.concat([[20000000]]) }];
+          })
+        ),
+      };
+    }
+    default:
+      throw new Error();
+  }
+};
+
+const requirementsJsonWithSatisfiableExams = (
+  decoratedJson: MutableDecoratedJson
+): DecoratedRequirementsJson => {
+  const decorateRequirementsWithExams = (
+    requirements: readonly DecoratedCollegeOrMajorRequirement[]
+  ) => requirements.map(decorateRequirementWithExams);
+  const { university, college, major, minor, grad } = decoratedJson;
+  Object.entries(university).forEach(([universityName, universityRequirement]) => {
+    const { requirements, ...rest } = universityRequirement;
+    decoratedJson.university[universityName] = {
+      ...rest,
+      requirements: decorateRequirementsWithExams(requirements),
+    };
+  });
+  Object.entries(college).forEach(([collegeName, collegeRequirement]) => {
+    const { requirements, ...rest } = collegeRequirement;
+    decoratedJson.college[collegeName] = {
+      ...rest,
+      requirements: decorateRequirementsWithExams(requirements),
+    };
+  });
+  Object.entries(major).forEach(([majorName, majorRequirement]) => {
+    const { requirements, specializations, ...rest } = majorRequirement;
+    decoratedJson.major[majorName] = {
+      ...rest,
+      requirements: decorateRequirementsWithExams(requirements),
+      specializations: decorateRequirementsWithExams(specializations ?? []),
+    };
+  });
+  Object.entries(minor).forEach(([minorName, minorRequirement]) => {
+    const { requirements, ...rest } = minorRequirement;
+    decoratedJson.minor[minorName] = {
+      ...rest,
+      requirements: decorateRequirementsWithExams(requirements),
+    };
+  });
+  Object.entries(grad).forEach(([gradName, gradRequirement]) => {
+    const { requirements, ...rest } = gradRequirement;
+    decoratedJson.grad[gradName] = {
+      ...rest,
+      requirements: decorateRequirementsWithExams(requirements),
+    };
+  });
+
+  return decoratedJson;
+};
+
+const decoratedRequirements = requirementsJsonWithSatisfiableExams(
+  requirementsJsonWithSatisfiableCourses()
 );
 
-writeFileSync('src/requirements/decorated-requirements.json', decoratedRequirementString);
+const decoratedRequirementsString = JSON.stringify(decoratedRequirements, undefined, 2);
+
+writeFileSync('src/requirements/decorated-requirements.json', decoratedRequirementsString);


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is step 3 in the AP/IB Infra Update #576. It builds off the pseudocode described in #606.

- [x] added exam course ids and conditions to requirements json
- [x] generalized decorator logic in `requirement-json-generator`
- [x] conditionally add the `specializations` property (to remove `"specializations": []` in the json) @zachary0kent 

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
No frontend changes 😿. Check `decorated-requirements.json` to see that the added exam course ids and conditions look reasonable.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
We might want to consider using [json-stable-stringify](https://www.npmjs.com/package/json-stable-stringify) in the future if the json is not always 100% stable. We can also specify a particular key order with the package.
