### PR TITLE
Add check-req-json workflow job

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -44,7 +44,9 @@ jobs:
           node-version: '16'
           cache: 'npm'
       - name: NPM Install
-        run: npm install && npm run req-gen
+        run: npm install
+      - name: Run req-gen
+        run: npm run req-gen
       - name: Check that the requirements json has no changes
         run: exit $(git status --porcelain | wc -l)
   frontend-tests:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -34,6 +34,19 @@ jobs:
         run: npm install && cd functions && npm install
       - name: Check that package-lock.json has no changes
         run: exit $(git status --porcelain | wc -l)
+  check-req-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'npm'
+      - name: NPM Install
+        run: npm install && npm run req-gen
+      - name: Check that the requirements json has no changes
+        run: exit $(git status --porcelain | wc -l)
   frontend-tests:
     runs-on: ubuntu-latest
     concurrency: cypress-tests


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds the check-req-json workflow job, modeled off of check-lockfile. Rationale:
- There is a discrepancy on master right now 🤦 
- I sometimes forget to run `npm run req-gen` after small changes on my branch 😶
- If I pull from master I don't want to think about whether or not I need to run `npm run req-gen`

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
👀 ci
d202b96 fails but 620c611 passes

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
This doesn't solve the discrepancy from the following scenario:
1. dev A branches off of master to add requirements data
2. dev B pushes requirements json logic change to master
3. dev A makes a pr (github doesn't catch this!)

This is a small enough occurrence and won't break staging, so it's not a big deal. But it can be avoided by being aware of other PRs and merging manually when adding data (in which cases this workflow job should catch the diff).
