### PR TITLE
[easy] Fix HE credits double counting and DEA statistics requirement

### DIFF
--- a/src/requirements/data/colleges/he.ts
+++ b/src/requirements/data/colleges/he.ts
@@ -14,6 +14,7 @@ const humanEcologyRequirements: readonly CollegeOrMajorRequirement[] = [
     ],
     fulfilledBy: 'credits',
     perSlotMinCount: [43],
+    allowCourseDoubleCounting: true,
   },
   {
     name: '9 Credits In HE Outside Major',

--- a/src/requirements/data/majors/dea.ts
+++ b/src/requirements/data/majors/dea.ts
@@ -136,6 +136,7 @@ const deaRequirements: readonly CollegeOrMajorRequirement[] = [
     fulfilledBy: 'courses',
     perSlotMinCount: [1],
     slotNames: ['Course'],
+    disallowTransferCredit: true,
   },
   {
     name: 'Natural Science I',


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes some requirements data.

- [x] HE credits requirement should allow course double counting
- [x] DEA statistics requirement should not accept AP credit

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
See summary.
- ~nothing can be tested until #631 is merged~
- ~DEA statistics can not be tested with the graph until new ap/ib infra is merged, but it can be tested by looking at the requirements sidebar~*

*Note: This is because in the old infra, `disallowTransferCredit` is taken into consideration after the graph builder and in the frontend computation -- specifically, `computeFulfillmentStatistics()`. However, in the new infra, it is taken into consideration before the graph builder during the precomputation (requirements json generation) -- specifically, `decorateRequirementWithExams()`.