### PR TITLE
Add AP/IB exam id tests

### DIFF
--- a/src/requirements/__test__/__snapshots__/exam-data-id.test.ts.snap
+++ b/src/requirements/__test__/__snapshots__/exam-data-id.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ID of the exams are unchanged. 1`] = `
+Array [
+  "AP Biology",
+  "AP Chemistry",
+  "AP Computer Science A",
+  "AP English Language and Composition",
+  "AP English Literature and Composition",
+  "AP French Language",
+  "AP French Literature",
+  "AP Italian Language",
+  "AP Italian Literature",
+  "AP Macroeconomics",
+  "AP Mathematics AB",
+  "AP Mathematics BC (Engineering)",
+  "AP Mathematics BC (Non-Engineering)",
+  "AP Microeconomics",
+  "AP Physics C-Electricity & Magnetism",
+  "AP Physics C-Mechanics",
+  "AP Physics I",
+  "AP Physics II",
+  "AP Psychology",
+  "AP Spanish Language",
+  "AP Spanish Literature",
+  "AP Statistics",
+  "IB Chemical and Physical Systems",
+  "IB Chemistry",
+  "IB Computer Science",
+  "IB Economics",
+  "IB English Language and Literature",
+  "IB English Literature A",
+  "IB Mathematics",
+  "IB Physical Science",
+  "IB Physics",
+]
+`;

--- a/src/requirements/__test__/exam-data-id.test.ts
+++ b/src/requirements/__test__/exam-data-id.test.ts
@@ -1,0 +1,27 @@
+import { examSubjects } from '../requirement-exam-utils';
+
+const examIds = [
+  ...examSubjects.AP.map(subject => `AP ${subject}`),
+  ...examSubjects.IB.map(subject => `IB ${subject}`),
+].sort((a, b) => a.localeCompare(b));
+
+it('ID of the exams are unchanged.', () => {
+  /**
+   * What should you do when this test fails:
+   * a. Unbreak the test. To update the snapshot, run `npm run test -- -u`.
+   * b. Write a migration script for any exam unique ids that changed.
+   */
+
+  expect(examIds).toMatchSnapshot();
+});
+
+it('No duplicate exam unique ID.', () => {
+  const set = new Set<string>();
+  examIds.forEach(id => {
+    if (set.has(id)) {
+      fail(`Detected duplicated exam unique ID: ${id}`);
+    } else {
+      set.add(id);
+    }
+  });
+});


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request tests that the exam unique IDs are unchanged and unique. Modeled from `requirement-data-id.test.ts`.
- The first test is necessary because we are using them in the database as identifiers representing exams taken, and there could be bugs if we change them without writing a migration script
- The second test is not strictly necessary, since `examData` uses the exam subjects as property names, but I kept it for redundancy.

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
👀 ci

I also tested locally that it caught changes to exam subjects.