### PR TITLE
Fix AP English FWS requirement

### DIFF
--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -94,6 +94,7 @@ export default defineComponent({
       } = getRelatedUnfulfilledRequirements(
         selectedCourse,
         store.state.groupedRequirementFulfillmentReport,
+        store.state.onboardingData,
         store.state.toggleableRequirementChoices,
         store.state.overriddenFulfillmentChoices
       );

--- a/src/components/Modals/NewCourse/NewSelfCheckCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewSelfCheckCourseModal.vue
@@ -80,6 +80,7 @@ export default defineComponent({
       return getFilter(
         store.state.userRequirementsMap,
         store.state.toggleableRequirementChoices,
+        store.state.onboardingData,
         this.requirementId
       );
     },

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -85,6 +85,7 @@ export default defineComponent({
             !canFulfillChecker(
               store.state.userRequirementsMap,
               store.state.toggleableRequirementChoices,
+              store.state.onboardingData,
               this.subReqId,
               course.crseId
             )
@@ -150,7 +151,8 @@ export default defineComponent({
         optOut: getAllEligibleRelatedRequirementIds(
           this.selfCheckCourses[option].crseId,
           store.state.groupedRequirementFulfillmentReport,
-          store.state.toggleableRequirementChoices
+          store.state.toggleableRequirementChoices,
+          store.state.onboardingData
         ),
       }));
     },
@@ -173,7 +175,8 @@ export default defineComponent({
           optOut: getAllEligibleRelatedRequirementIds(
             newCourse.crseId,
             store.state.groupedRequirementFulfillmentReport,
-            store.state.toggleableRequirementChoices
+            store.state.toggleableRequirementChoices,
+            store.state.onboardingData
           ),
         }),
         this.$gtag

--- a/src/components/Requirements/RequirementFulfillmentSlots.vue
+++ b/src/components/Requirements/RequirementFulfillmentSlots.vue
@@ -99,7 +99,8 @@ export default defineComponent({
         this.requirementFulfillment.requirement,
         {
           [this.requirementFulfillment.requirement.id]: this.toggleableRequirementChoice,
-        }
+        },
+        store.state.onboardingData
       );
       if (requirementFulfillmentSpec === null) return [];
       /**

--- a/src/components/Requirements/RequirementSelfCheckSlots.vue
+++ b/src/components/Requirements/RequirementSelfCheckSlots.vue
@@ -50,7 +50,8 @@ export default defineComponent({
         this.requirementFulfillment.requirement,
         {
           [this.requirementFulfillment.requirement.id]: this.toggleableRequirementChoice,
-        }
+        },
+        store.state.onboardingData
       );
       if (requirementFulfillmentSpec !== null) {
         if (requirementFulfillmentSpec.fulfilledBy === 'credits') {

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -283,7 +283,8 @@ export default defineComponent({
             const optOut = getAllEligibleRelatedRequirementIds(
               crseId,
               store.state.groupedRequirementFulfillmentReport,
-              store.state.toggleableRequirementChoices
+              store.state.toggleableRequirementChoices,
+              store.state.onboardingData
             ).filter(it => it !== requirementID);
             choices[uniqueID] = { ...choice, optOut };
           });

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -81,7 +81,7 @@ type RequirementFulfillmentInformation<T = Record<string, unknown>> =
 
 /** Requirements may have conditions associated with certain course ids, eg. for AP/IB exams. */
 type RequirementCourseConditions = Record<
-  [courseId: number],
+  number,
   {
     /** If the user IS NOT in one of these colleges, the course id cannot fulfill the requirement. */
     readonly colleges: string[];
@@ -93,7 +93,7 @@ type RequirementCourseConditions = Record<
 type DecoratedCollegeOrMajorRequirement = RequirementCommon &
   RequirementFulfillmentInformation<{
     readonly courses: readonly (readonly number[])[];
-    readonly conditions?: readonly RequirementCourseConditions;
+    readonly conditions?: Readonly<RequirementCourseConditions>;
   }>;
 
 /**

--- a/src/requirements/__test__/requirement-frontend-utils.test.ts
+++ b/src/requirements/__test__/requirement-frontend-utils.test.ts
@@ -6,8 +6,17 @@ const mockRequirementCommon = {
   id: 'MOCK_ID',
   source: '',
   sourceType: 'College',
-  sourceSpecificName: 'Engineering',
+  sourceSpecificName: 'EN',
 } as const;
+
+const mockOnboardingData: AppOnboardingData = {
+  gradYear: '',
+  entranceYear: '',
+  major: [],
+  minor: [],
+  exam: [],
+  tookSwim: 'no',
+};
 
 const getMockCourseTaken = (courseId: number, credits = 0): CourseTaken => ({
   courseId,
@@ -30,7 +39,7 @@ it('computeFulfillmentCoursesAndStatistics self-check test', () => {
 
   // A simple test on self-check.
   expect(
-    computeFulfillmentCoursesAndStatistics(mockRequirement, [], {}, {})
+    computeFulfillmentCoursesAndStatistics(mockRequirement, [], mockOnboardingData, {}, {})
   ).toEqual<StatisticsResultType>({
     courses: [],
     fulfilledBy: 'self-check',
@@ -52,6 +61,7 @@ it('computeFulfillmentCoursesAndStatistics credit test', () => {
     computeFulfillmentCoursesAndStatistics(
       mockRequirement,
       [getMockCourseTaken(1234, 4), getMockCourseTaken(5678, 4)],
+      mockOnboardingData,
       {},
       {}
     )
@@ -67,6 +77,7 @@ it('computeFulfillmentCoursesAndStatistics credit test', () => {
     computeFulfillmentCoursesAndStatistics(
       mockRequirement,
       [getMockCourseTaken(1234, 4), getMockCourseTaken(5678, 4), getMockCourseTaken(9101112, 4)],
+      mockOnboardingData,
       {},
       {}
     )
@@ -99,6 +110,7 @@ it('computeFulfillmentCoursesAndStatistics course (without minNumberOfSlots) tes
     computeFulfillmentCoursesAndStatistics(
       mockRequirement,
       [getMockCourseTaken(1), getMockCourseTaken(2), getMockCourseTaken(3), getMockCourseTaken(4)],
+      mockOnboardingData,
       {},
       {}
     )
@@ -118,6 +130,7 @@ it('computeFulfillmentCoursesAndStatistics course (without minNumberOfSlots) tes
     computeFulfillmentCoursesAndStatistics(
       mockRequirement,
       [getMockCourseTaken(1), getMockCourseTaken(2), getMockCourseTaken(4), getMockCourseTaken(3)],
+      mockOnboardingData,
       {},
       {}
     )
@@ -182,6 +195,7 @@ it('computeFulfillmentCoursesAndStatistics course (with additional requirements)
         getMockCourseTaken(3, 3),
         getMockCourseTaken(4, 4),
       ],
+      mockOnboardingData,
       {},
       {}
     )
@@ -238,6 +252,7 @@ it('computeFulfillmentCoursesAndStatistics course (with minNumberOfSlots) test',
     computeFulfillmentCoursesAndStatistics(
       mockRequirement,
       [getMockCourseTaken(1), getMockCourseTaken(2), getMockCourseTaken(3)],
+      mockOnboardingData,
       {},
       {}
     )
@@ -275,7 +290,13 @@ it('computeFulfillmentCoursesAndStatistics toggleable requirement test', () => {
   // The first one has no choice so it defaults to the first option.
   // The second one chooses option A, and the third one chooses option B.
   expect(
-    computeFulfillmentCoursesAndStatistics(mockRequirement, [getMockCourseTaken(1)], {}, {})
+    computeFulfillmentCoursesAndStatistics(
+      mockRequirement,
+      [getMockCourseTaken(1)],
+      mockOnboardingData,
+      {},
+      {}
+    )
   ).toEqual<StatisticsResultType>({
     courses: [[getMockCourseTaken(1)]],
     fulfilledBy: 'courses',
@@ -286,6 +307,7 @@ it('computeFulfillmentCoursesAndStatistics toggleable requirement test', () => {
     computeFulfillmentCoursesAndStatistics(
       mockRequirement,
       [getMockCourseTaken(1)],
+      mockOnboardingData,
       {
         MOCK_ID: 'A',
       },
@@ -301,6 +323,7 @@ it('computeFulfillmentCoursesAndStatistics toggleable requirement test', () => {
     computeFulfillmentCoursesAndStatistics(
       mockRequirement,
       [getMockCourseTaken(1)],
+      mockOnboardingData,
       {
         MOCK_ID: 'B',
       },

--- a/src/requirements/data/colleges/en.ts
+++ b/src/requirements/data/colleges/en.ts
@@ -6,6 +6,7 @@ import {
   ifCodeMatch,
   courseIsForeignLang,
 } from '../checkers-common';
+import { LIBERAL_STUDIES_COURSE_ID } from '../constants';
 
 const engineeringLiberalArtsDistributions: readonly string[] = [
   'CA',
@@ -138,7 +139,9 @@ const engineeringRequirements: readonly CollegeOrMajorRequirement[] = [
           (course: Course): boolean =>
             engineeringLiberalArtsDistributions.some(
               distribution => course.catalogDistr?.includes(distribution) ?? false
-            ) || courseIsForeignLang(course),
+            ) ||
+            courseIsForeignLang(course) ||
+            course.crseId === LIBERAL_STUDIES_COURSE_ID,
         ],
         fulfilledBy: 'credits',
         perSlotMinCount: [18],

--- a/src/requirements/data/constants.ts
+++ b/src/requirements/data/constants.ts
@@ -1,8 +1,11 @@
 /** Exam course ID for special course that satisfies no requirements (not even total credits). */
 export const NO_FULFILLMENTS_COURSE_ID = 10;
 
+/** Equivalent course ID for special course that satisfies EN Liberal Studies requirement. */
+export const LIBERAL_STUDIES_COURSE_ID = 11;
+
 /** Equivalent course ID for special course that satisfies FWS requirement. */
-export const FWS_COURSE_ID = 11;
+export const FWS_COURSE_ID = 12;
 
 /** Equivalent course ID for special course that satisfies swim test requirement. */
 export const SWIM_TEST_COURSE_ID = 13;
@@ -16,6 +19,7 @@ export const SWIM_TEST_CODE = 'Swim Test';
 /** List of special course IDs */
 export const SPECIAL_COURSES = {
   NO_FULFILLMENTS: NO_FULFILLMENTS_COURSE_ID,
+  LIBERAL_STUDIES: LIBERAL_STUDIES_COURSE_ID,
   FWS: FWS_COURSE_ID,
   SWIM_TEST: SWIM_TEST_COURSE_ID,
 };

--- a/src/requirements/data/exams/ExamCredit.ts
+++ b/src/requirements/data/exams/ExamCredit.ts
@@ -1,4 +1,4 @@
-import { FWS_COURSE_ID } from '../constants';
+import { FWS_COURSE_ID, LIBERAL_STUDIES_COURSE_ID } from '../constants';
 
 /**
  * Describes how exams can be converted to a representation understood by CoursePlan.
@@ -78,25 +78,41 @@ const examData: ExamData = {
       {
         courseId: 107,
         courseEquivalents: {
-          [OTHER_COLLEGES]: [FWS_COURSE_ID], // FWS
+          EN: [LIBERAL_STUDIES_COURSE_ID], // Liberal Studies
         },
         minimumScore: 4,
         credits: 3,
       },
-    ],
-    'English Language and Composition': [
       {
         courseId: 108,
         courseEquivalents: {
           [OTHER_COLLEGES]: [FWS_COURSE_ID], // FWS
         },
+        minimumScore: 5,
+        credits: 3,
+      },
+    ],
+    'English Language and Composition': [
+      {
+        courseId: 109,
+        courseEquivalents: {
+          EN: [LIBERAL_STUDIES_COURSE_ID], // Liberal Studies
+        },
         minimumScore: 4,
+        credits: 3,
+      },
+      {
+        courseId: 110,
+        courseEquivalents: {
+          [OTHER_COLLEGES]: [FWS_COURSE_ID], // FWS
+        },
+        minimumScore: 5,
         credits: 3,
       },
     ],
     'French Language': [
       {
-        courseId: 109,
+        courseId: 111,
         courseEquivalents: {
           [OTHER_COLLEGES]: [353172], // FREN 2090
         },
@@ -104,12 +120,12 @@ const examData: ExamData = {
         credits: 3,
       },
     ],
-    'French Literature': [{ courseId: 110, minimumScore: 4, credits: 3 }],
-    'Italian Language': [{ courseId: 111, minimumScore: 4, credits: 3 }],
-    'Italian Literature': [{ courseId: 112, minimumScore: 4, credits: 3 }],
+    'French Literature': [{ courseId: 112, minimumScore: 4, credits: 3 }],
+    'Italian Language': [{ courseId: 113, minimumScore: 4, credits: 3 }],
+    'Italian Literature': [{ courseId: 114, minimumScore: 4, credits: 3 }],
     'Mathematics BC (Non-Engineering)': [
       {
-        courseId: 113,
+        courseId: 115,
         courseEquivalents: {
           [OTHER_COLLEGES]: [352116, 352120], // MATH 1110, MATH 1120
           EN: [],
@@ -120,7 +136,7 @@ const examData: ExamData = {
     ],
     'Mathematics BC (Engineering)': [
       {
-        courseId: 114,
+        courseId: 116,
         courseEquivalents: {
           [OTHER_COLLEGES]: [],
           EN: [352255], // MATH 1910
@@ -131,7 +147,7 @@ const examData: ExamData = {
     ],
     'Mathematics AB': [
       {
-        courseId: 115,
+        courseId: 117,
         courseEquivalents: {
           [OTHER_COLLEGES]: [352116], // MATH 1110
         },
@@ -141,7 +157,7 @@ const examData: ExamData = {
     ],
     'Physics I': [
       {
-        courseId: 116,
+        courseId: 118,
         courseEquivalents: {
           [OTHER_COLLEGES]: [355142], // PHYS 1101
         },
@@ -151,7 +167,7 @@ const examData: ExamData = {
     ],
     'Physics II': [
       {
-        courseId: 117,
+        courseId: 119,
         courseEquivalents: {
           [OTHER_COLLEGES]: [355143], // PHYS 1102
         },
@@ -161,7 +177,7 @@ const examData: ExamData = {
     ],
     'Physics C-Mechanics': [
       {
-        courseId: 118,
+        courseId: 120,
         courseEquivalents: {
           [OTHER_COLLEGES]: [355197], // PHYS 2207
           EN: [355146], // PHYS 1112
@@ -172,7 +188,7 @@ const examData: ExamData = {
     ],
     'Physics C-Electricity & Magnetism': [
       {
-        courseId: 119,
+        courseId: 121,
         courseEquivalents: {
           [OTHER_COLLEGES]: [355207], // PHYS 2213
         },
@@ -182,7 +198,7 @@ const examData: ExamData = {
     ],
     Psychology: [
       {
-        courseId: 120,
+        courseId: 122,
         courseEquivalents: {
           [OTHER_COLLEGES]: [351438], // PSYCH 1101
         },
@@ -192,21 +208,21 @@ const examData: ExamData = {
     ],
     'Spanish Language': [
       {
-        courseId: 120,
+        courseId: 123,
         minimumScore: 4,
         credits: 3,
       },
     ],
     'Spanish Literature': [
       {
-        courseId: 120,
+        courseId: 124,
         minimumScore: 4,
         credits: 3,
       },
     ],
     Statistics: [
       {
-        courseId: 121,
+        courseId: 125,
         courseEquivalents: {
           [OTHER_COLLEGES]: [
             350500, // AEM 2100
@@ -232,7 +248,7 @@ const examData: ExamData = {
         majorsExcluded: ['Biological Sciences'],
       },
       {
-        courseId: 122,
+        courseId: 126,
         courseEquivalents: {
           [OTHER_COLLEGES]: [
             350500, // AEM 2100

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -236,12 +236,14 @@ export default function computeGroupedRequirementFulfillmentReports(
     const dangerousRequirementFulfillmentStatistics = computeFulfillmentCoursesAndStatistics(
       requirement,
       dangerousRequirementFulfillmentGraph.getConnectedCoursesFromRequirement(requirement.id),
+      onboardingData,
       toggleableRequirementChoices,
       overriddenFulfillmentChoices
     );
     const safeRequirementFulfillmentStatistics = computeFulfillmentCoursesAndStatistics(
       requirement,
       safeRequirementFulfillmentGraph.getConnectedCoursesFromRequirement(requirement.id),
+      onboardingData,
       toggleableRequirementChoices,
       overriddenFulfillmentChoices
     );

--- a/src/requirements/requirement-graph-builder-from-user-data.ts
+++ b/src/requirements/requirement-graph-builder-from-user-data.ts
@@ -75,7 +75,11 @@ export default function buildRequirementFulfillmentGraphFromUserData(
       if (spec == null || spec.hasRequirementCheckerWarning) {
         return [];
       }
-      return spec.eligibleCourses.flat();
+      let courses = spec.eligibleCourses.flat();
+      Object.entries(spec.additionalRequirements || {}).forEach(([_, additionalSpec]) => {
+        courses.push(...additionalSpec.eligibleCourses.flat());
+      });
+      return courses;
     },
   };
   const dangerousRequirementFulfillmentGraph = buildRequirementFulfillmentGraph(

--- a/src/requirements/requirement-graph-builder-from-user-data.ts
+++ b/src/requirements/requirement-graph-builder-from-user-data.ts
@@ -1,4 +1,7 @@
-import { getUserRequirements } from './requirement-frontend-utils';
+import {
+  getMatchedRequirementFulfillmentSpecification,
+  getUserRequirements,
+} from './requirement-frontend-utils';
 import RequirementFulfillmentGraph from './requirement-graph';
 import {
   BuildRequirementFulfillmentGraphParameters,
@@ -64,24 +67,15 @@ export default function buildRequirementFulfillmentGraphFromUserData(
       const requirement = userRequirementsMap[requirementID];
       // When a requirement has checker warning, we do not add those edges in phase 1.
       // All edges will be explictly opt-in only from stage 3.
-      if (requirement.checkerWarning != null) return [];
-      let eligibleCoursesList: readonly (readonly number[])[];
-      switch (requirement.fulfilledBy) {
-        case 'self-check':
-          return [];
-        case 'courses':
-        case 'credits':
-          eligibleCoursesList = requirement.courses;
-          break;
-        case 'toggleable':
-          eligibleCoursesList = Object.values(requirement.fulfillmentOptions).flatMap(
-            it => it.courses
-          );
-          break;
-        default:
-          throw new Error();
+      const spec = getMatchedRequirementFulfillmentSpecification(
+        requirement,
+        toggleableRequirementChoices,
+        onboardingData
+      );
+      if (spec == null || spec.hasRequirementCheckerWarning) {
+        return [];
       }
-      return eligibleCoursesList.flat();
+      return spec.eligibleCourses.flat();
     },
   };
   const dangerousRequirementFulfillmentGraph = buildRequirementFulfillmentGraph(


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes some AP English issues. @willespencer 

- [x] changed AP English minimum score to 5 to fulfill FWS checker
- [x] added liberal studies special course for an AP English score for minimum 4
- [x] fixed bug with courses not being able to fulfill additional requirements when building graph

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] (r,C) constraint violation for AP English & FWS

<!--- Note dependencies on other PRs if any. -->

Depends on #639 because of the spec refactor in `requirement-graph-builder-from-user-data`. It can be merged after release #634.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

AP English score 5 should count towards FWS and Liberal Studies (credits)
  - this causes a constraint violation. not sure if it should, @einc ?

AP English score 4 should count for Liberal Studies (credits) and not FWS
![image](https://user-images.githubusercontent.com/34158284/149708977-299376c1-272d-4d58-918a-93ead93970f7.png)