### PR TITLE
Setup backend infra for CASE exams [WIP]

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -267,7 +267,7 @@ export default defineComponent({
         this.updateTransfer([], 'no');
       }
     },
-    updateTransfer(exams: readonly FirestoreAPIBExam[], tookSwim: 'yes' | 'no') {
+    updateTransfer(exams: readonly FirestoreTransferExam[], tookSwim: 'yes' | 'no') {
       const userExams = exams.filter(
         ({ subject, score }) => score !== 0 && subject !== placeholderText
       );

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -116,7 +116,7 @@ export default defineComponent({
     });
     exams.AP.push({ examType: 'AP', subject: placeholderText, score: 0 });
     exams.IB.push({ examType: 'IB', subject: placeholderText, score: 0 });
-    exams.CASE.push({ examType: 'CASE', subject: placeholderText});
+    exams.CASE.push({ examType: 'CASE', subject: placeholderText });
     const transferClasses: TransferClassWithOptionalCourse[] = [];
     transferClasses.push({ class: placeholderText, credits: 0 });
     return {
@@ -169,7 +169,11 @@ export default defineComponent({
       this.selectScore(score, i, 'IB');
     },
     addExam(examType: TransferExamType) {
-      const exam = { examType, subject: this.placeholderText, score: examType === 'CASE' ? undefined : 0 };
+      const exam = {
+        examType,
+        subject: this.placeholderText,
+        score: examType === 'CASE' ? undefined : 0,
+      };
       this.exams[examType].push(exam);
     },
     removeExam(examType: TransferExamType, index: number) {

--- a/src/requirements/__test__/exam-credit.test.ts
+++ b/src/requirements/__test__/exam-credit.test.ts
@@ -1,14 +1,11 @@
-import userDataToExamCourses, {
-  ExamsTaken,
-  examsTakenToExamCourses,
-} from '../requirement-exam-utils';
+import userDataToExamCourses, { examsTakenToExamCourses } from '../requirement-exam-utils';
 import { NO_FULFILLMENTS_COURSE_ID } from '../data/constants';
 
 /**
  * Tests for examsTakenToExamCourses
  */
 it('Exam is converted to correct course', () => {
-  const exams: ExamsTaken = [
+  const exams: FirestoreTransferExam[] = [
     {
       examType: 'AP',
       subject: 'Computer Science A',
@@ -26,7 +23,7 @@ it('Exam is converted to correct course', () => {
 });
 
 it('Exam score is too low', () => {
-  const exams: ExamsTaken = [
+  const exams: FirestoreTransferExam[] = [
     {
       examType: 'AP',
       subject: 'Computer Science A',
@@ -44,7 +41,7 @@ it('Exam score is too low', () => {
 });
 
 it('Two exams are converted to the correct courses', () => {
-  const exams: ExamsTaken = [
+  const exams: FirestoreTransferExam[] = [
     {
       examType: 'AP',
       subject: 'Computer Science A',
@@ -71,7 +68,7 @@ it('Exam is converted to correct course', () => {
     entranceYear: '2016',
     college: 'EN',
     major: [],
-    exam: [{ type: 'AP', score: 5, subject: 'Computer Science A' }],
+    exam: [{ examType: 'AP', score: 5, subject: 'Computer Science A' }],
     minor: [],
     tookSwim: 'no',
   };

--- a/src/requirements/data/exams/ExamCredit.ts
+++ b/src/requirements/data/exams/ExamCredit.ts
@@ -1,19 +1,30 @@
 import { FWS_COURSE_ID } from '../constants';
 
 /**
- * Describes how exams can be converted to a representation understood by CoursePlan.
- * If the user takes an exam, our algorithm determines the best fulfillment option for the user's score.
- * There can be multiple exam fulfillments (for different minimum scores) associated with a single exam.
+ * Describes how AP/IB/CASE exams can be converted to a representation understood by CoursePlan.
  */
-export type ExamFulfillment = {
+export type ExamFulfillmentBase = {
   readonly courseId: number;
   readonly courseEquivalents?: Record<string, number[]>;
-  readonly minimumScore: number;
   readonly credits: number;
   readonly majorsExcluded?: string[];
 };
-export type ExamFulfillments = Record<string, ExamFulfillment[]>;
-export type ExamData = Record<'AP' | 'IB', ExamFulfillments>;
+
+/**
+ * If the user takes an AP/IB exam, our algorithm determines the best fulfillment option for the user's score.
+ * There can be multiple exam fulfillments (for different minimum scores) associated with a single exam.
+ */
+export type ExamFulfillmentWithMinimumScore = ExamFulfillmentBase & {
+  readonly minimumScore: number;
+};
+
+export type ExamFulfillments<T = unknown> = Record<string, T>;
+
+export type ExamData = {
+  AP: ExamFulfillments<ExamFulfillmentWithMinimumScore[]>;
+  IB: ExamFulfillments<ExamFulfillmentWithMinimumScore[]>;
+  CASE: ExamFulfillments<ExamFulfillmentBase>;
+};
 
 // If the user's college is not in the keys of courseEquivalents, their college is generalized to OTHER_COLLEGES
 export const OTHER_COLLEGES = 'OTHER_COLLEGES';
@@ -270,7 +281,7 @@ const examData: ExamData = {
     ],
     Chemistry: [
       {
-        courseId: 202,
+        courseId: 201,
         courseEquivalents: {
           [OTHER_COLLEGES]: [351265], // CHEM 2070
           EN: [359187], // CHEM 2090
@@ -281,7 +292,7 @@ const examData: ExamData = {
     ],
     'Computer Science': [
       {
-        courseId: 203,
+        courseId: 202,
         courseEquivalents: {
           [OTHER_COLLEGES]: [358526], // CS 1110
         },
@@ -291,7 +302,7 @@ const examData: ExamData = {
     ],
     Economics: [
       {
-        courseId: 204,
+        courseId: 203,
         courseEquivalents: {
           [OTHER_COLLEGES]: [350025, 350038], // ECON 1110, ECON 1120
         },
@@ -301,7 +312,7 @@ const examData: ExamData = {
     ],
     'English Literature A': [
       {
-        courseId: 205,
+        courseId: 204,
         courseEquivalents: {
           [OTHER_COLLEGES]: [FWS_COURSE_ID], // FWS
         },
@@ -311,7 +322,7 @@ const examData: ExamData = {
     ],
     'English Language and Literature': [
       {
-        courseId: 206,
+        courseId: 205,
         courseEquivalents: {
           [OTHER_COLLEGES]: [FWS_COURSE_ID], // FWS
         },
@@ -321,7 +332,7 @@ const examData: ExamData = {
     ],
     Mathematics: [
       {
-        courseId: 207,
+        courseId: 206,
         courseEquivalents: {
           [OTHER_COLLEGES]: [352111, 352116], // MATH 1106, MATH 1110
         },
@@ -331,7 +342,7 @@ const examData: ExamData = {
     ],
     'Physical Science': [
       {
-        courseId: 208,
+        courseId: 207,
         courseEquivalents: {
           [OTHER_COLLEGES]: [351265, 355142], // CHEM 2070, PHYS 1101
         },
@@ -341,7 +352,7 @@ const examData: ExamData = {
     ],
     Physics: [
       {
-        courseId: 209,
+        courseId: 208,
         courseEquivalents: {
           [OTHER_COLLEGES]: [355142, 355197], // PHYS 1101, PHYS 2207
           EN: [355146], // PHYS 1112
@@ -350,6 +361,22 @@ const examData: ExamData = {
         credits: 4,
       },
     ],
+  },
+  CASE: {
+    'MATH 1910': {
+      courseId: 300,
+      courseEquivalents: {
+        EN: [352255],
+      },
+      credits: 4,
+    },
+    'PHYS 1112': {
+      courseId: 301,
+      courseEquivalents: {
+        EN: [355146],
+      },
+      credits: 4,
+    },
   },
 };
 

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -151,6 +151,16 @@ export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppO
     'gradPrograms' in data && data.gradPrograms.length !== 0
       ? data.gradPrograms[0].acronym
       : undefined,
-  exam: 'exam' in data ? [...data.exam] : [],
+  // TODO @bshen migration script from type to examType
+  exam:
+    'exam' in data
+      ? [
+          ...data.exam.map(e => ({
+            ...e,
+            type: e.examType || e.type,
+            examType: e.type || e.examType,
+          })),
+        ]
+      : [],
   tookSwim: 'tookSwim' in data ? data.tookSwim : 'no',
 });

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -41,19 +41,15 @@ type FirestoreSemester = {
 };
 
 type FirestoreCollegeOrMajorOrMinor = { readonly acronym: string };
-type FirestoreAPIBExam = {
-  readonly type: 'AP' | 'IB';
-  readonly score: number;
-  readonly subject: string;
-};
 
 /** Represents the name of an exam a student can take for transfer credit */
 type TransferExamType = 'AP' | 'IB' | 'CASE';
 
 type FirestoreTransferExam = {
   readonly examType: TransferExamType;
-  readonly score: number;
   readonly subject: string;
+  readonly score?: number;
+  readonly type?: TransferExamType; // TODO @bshen migrate away
 };
 
 type FirestoreCollegeMajorMinorOrGrad = { readonly acronym: string };
@@ -64,7 +60,7 @@ type FirestoreOnboardingUserData = {
   readonly majors: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly minors: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly gradPrograms: readonly FirestoreCollegeMajorMinorOrGrad[];
-  readonly exam: readonly FirestoreAPIBExam[];
+  readonly exam: readonly FirestoreTransferExam[];
   readonly tookSwim: 'yes' | 'no';
 };
 
@@ -182,7 +178,7 @@ type AppOnboardingData = {
   readonly major: readonly string[];
   readonly minor: readonly string[];
   readonly grad?: string;
-  readonly exam: readonly FirestoreAPIBExam[];
+  readonly exam: readonly FirestoreTransferExam[];
   readonly tookSwim: 'yes' | 'no';
 };
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is a continuation of #579. It sets up the backend infra to add CASE exams.

- [x] implemented X
- [x] fixed Y

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs: Same as with the semester `type` migration.

- [ ] migration script from `type` to `examType`
- [ ] push code update
- [ ] migration script to remove `type` from database

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes
I noticed a lot of ungraceful fails with improperly formatted Firestore data (especially when the schema is changed after a push to staging/prod). It may be a good future goal to fail gracefully.

We need more reliable CASE exam data.