### PR TITLE
Assign Course to Placeholder Modal (Front-End)

### DIFF
--- a/src/components/Course/Placeholder.vue
+++ b/src/components/Course/Placeholder.vue
@@ -47,18 +47,18 @@ export default defineComponent({
       this.isPlaceholderModalOpen = false;
     },
     assignCourse() {
-      // TODO write the code that assigns a course to a placeholder
+      // TODO @willespencer write the code that assigns a course to a placeholder
     },
     getRequirementID() {
-      // TODO get requirement ID from name and slot
+      // TODO @willespencer get requirement ID from name and slot
       return '0';
     },
     getRequirementDescription() {
-      // TODO get requirement description to show on add modal
-      return 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vestibulum eu ligula in feugiat. Mauris sed cursus enim, eu feugiat nibh. Vivamus nisi lorem, dictum non aliquet non, blandit non quam. Maecenas vestibulum, ligula et cursus porta, elit nisi facilisis nunc, et faucibus risus arcu a tellus.';
+      // TODO @willespencer get requirement description to show on add modal
+      return 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vestibulum eu ligula in feugiat. Mauris sed cursus enim, eu feugiat nibh.';
     },
     getRequirementLearnMore() {
-      // TODO get requirement learn more link to show on add modal
+      // TODO @willespencer get requirement learn more link to show on add modal
       return 'https://cornelldti.org';
     },
   },

--- a/src/components/Course/Placeholder.vue
+++ b/src/components/Course/Placeholder.vue
@@ -9,6 +9,7 @@
       :isPlaceholderModal="true"
       @add-course="assignCourse"
       @close-course-modal="closeModal"
+      @delete-placeholder="deletePlaceholder"
     />
     <div class="placeholder-color">
       <img src="@/assets/images/dots/sixDots.svg" alt="" />
@@ -33,6 +34,10 @@ export default defineComponent({
     placeholderObj: { type: Object as PropType<FirestoreSemesterPlaceholder>, required: true },
     compact: { type: Boolean, required: true },
     semesterIndex: { type: Number, required: false, default: 0 },
+  },
+  emits: {
+    'delete-placeholder': (placeholderObj: FirestoreSemesterPlaceholder) =>
+      typeof placeholderObj === 'object',
   },
   data() {
     return {
@@ -60,6 +65,9 @@ export default defineComponent({
     getRequirementLearnMore() {
       // TODO @willespencer get requirement learn more link to show on add modal
       return 'https://cornelldti.org';
+    },
+    deletePlaceholder() {
+      this.$emit('delete-placeholder', this.placeholderObj);
     },
   },
 });

--- a/src/components/Course/Placeholder.vue
+++ b/src/components/Course/Placeholder.vue
@@ -1,5 +1,15 @@
 <template>
   <div :class="{ 'placeholder--min': compact }" class="placeholder">
+    <new-self-check-or-placeholder-course-modal
+      v-if="isPlaceholderModalOpen"
+      :subReqName="placeholderObj.name"
+      :subReqDescription="getRequirementDescription()"
+      :subReqLearnMore="getRequirementLearnMore()"
+      :requirementId="getRequirementID()"
+      :isPlaceholderModal="true"
+      @add-course="assignCourse"
+      @close-course-modal="closeModal"
+    />
     <div class="placeholder-color">
       <img src="@/assets/images/dots/sixDots.svg" alt="" />
     </div>
@@ -15,17 +25,41 @@
 <script lang="ts">
 import { PropType, defineComponent } from 'vue';
 import CourseCaution from '@/components/Course/CourseCaution.vue';
+import NewSelfCheckOrPlaceholderCourseModal from '@/components/Modals/NewCourse/NewSelfCheckOrPlaceholderCourseModal.vue';
 
 export default defineComponent({
-  components: { CourseCaution },
+  components: { CourseCaution, NewSelfCheckOrPlaceholderCourseModal },
   props: {
     placeholderObj: { type: Object as PropType<FirestoreSemesterPlaceholder>, required: true },
     compact: { type: Boolean, required: true },
     semesterIndex: { type: Number, required: false, default: 0 },
   },
+  data() {
+    return {
+      isPlaceholderModalOpen: false,
+    };
+  },
   methods: {
     openModal() {
-      // TODO: open modal to assign a course to a placeholder
+      this.isPlaceholderModalOpen = true;
+    },
+    closeModal() {
+      this.isPlaceholderModalOpen = false;
+    },
+    assignCourse() {
+      // TODO write the code that assigns a course to a placeholder
+    },
+    getRequirementID() {
+      // TODO get requirement ID from name and slot
+      return '0';
+    },
+    getRequirementDescription() {
+      // TODO get requirement description to show on add modal
+      return 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vestibulum eu ligula in feugiat. Mauris sed cursus enim, eu feugiat nibh. Vivamus nisi lorem, dictum non aliquet non, blandit non quam. Maecenas vestibulum, ligula et cursus porta, elit nisi facilisis nunc, et faucibus risus arcu a tellus.';
+    },
+    getRequirementLearnMore() {
+      // TODO get requirement learn more link to show on add modal
+      return 'https://cornelldti.org';
     },
   },
 });

--- a/src/components/Modals/NewCourse/NewSelfCheckOrPlaceholderCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewSelfCheckOrPlaceholderCourseModal.vue
@@ -19,7 +19,7 @@
       @on-escape="closeCurrentModal"
       @on-select="setCourse"
     />
-    <div>
+    <div v-if="!isPlaceholderModal">
       <div class="newCourse-title">Add this class to the following semester</div>
       <div class="newCourse-semester-edit">
         <select-semester
@@ -29,6 +29,12 @@
           @updateSemProps="updateSemProps"
         />
       </div>
+    </div>
+    <div v-else class="newCourse-description">
+      {{ subReqDescription }}
+      <a class="newCourse=link" :href="subReqLearnMore" target="_blank">
+        <strong>Learn More</strong></a
+      >
     </div>
   </TeleportModal>
 </template>
@@ -45,7 +51,10 @@ export default defineComponent({
   components: { CourseSelector, TeleportModal, SelectSemester },
   props: {
     subReqName: { type: String, required: true },
+    subReqDescription: { type: String, default: '' },
+    subReqLearnMore: { type: String, default: '' },
     requirementId: { type: String, required: true },
+    isPlaceholderModal: { type: Boolean, default: false },
   },
   emits: {
     'close-course-modal': () => true,
@@ -68,7 +77,7 @@ export default defineComponent({
       return `Add Course to ${this.subReqName}`;
     },
     leftButtonText(): string {
-      return 'Cancel';
+      return this.isPlaceholderModal ? 'Remove' : 'Cancel';
     },
     rightButtonText(): string {
       return 'Add';
@@ -137,6 +146,9 @@ export default defineComponent({
     line-height: 17px;
     color: $lightPlaceholderGray;
     margin-bottom: 6px;
+  }
+  &-link {
+    color: $emGreen;
   }
 }
 

--- a/src/components/Modals/NewCourse/NewSelfCheckOrPlaceholderCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewSelfCheckOrPlaceholderCourseModal.vue
@@ -59,6 +59,7 @@ export default defineComponent({
   },
   emits: {
     'close-course-modal': () => true,
+    'delete-placeholder': () => true,
     'add-course': (
       selected: CornellCourseRosterCourse,
       season: FirestoreSemesterSeason,
@@ -111,7 +112,7 @@ export default defineComponent({
     },
     cancelOrRemove() {
       if (this.isPlaceholderModal) {
-        // TODO @willespencer remove placeholder from plan
+        this.$emit('delete-placeholder');
       }
       this.closeCurrentModal();
     },

--- a/src/components/Modals/NewCourse/NewSelfCheckOrPlaceholderCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewSelfCheckOrPlaceholderCourseModal.vue
@@ -3,10 +3,11 @@
     :title="modalTitle"
     content-class="content-course"
     :leftButtonText="leftButtonText"
+    :leftButtonWarningStyle="isPlaceholderModal"
     :rightButtonText="rightButtonText"
     :rightButtonIsDisabled="!canAddCourse"
     @modal-closed="closeCurrentModal"
-    @left-button-clicked="backOrCancel"
+    @left-button-clicked="cancelOrRemove"
     @right-button-clicked="addCourse"
   >
     <div class="newCourse-text">Search Course Roster</div>
@@ -32,7 +33,7 @@
     </div>
     <div v-else class="newCourse-description">
       {{ subReqDescription }}
-      <a class="newCourse=link" :href="subReqLearnMore" target="_blank">
+      <a class="newCourse-link" :href="subReqLearnMore" target="_blank">
         <strong>Learn More</strong></a
       >
     </div>
@@ -83,6 +84,9 @@ export default defineComponent({
       return 'Add';
     },
     canAddCourse(): boolean {
+      if (this.isPlaceholderModal) {
+        return this.selectedCourse != null;
+      }
       return this.selectedCourse != null && this.year > 0 && String(this.season) !== 'Select';
     },
     courseCanAppearInSearchResult(): (course: CornellCourseRosterCourse) => boolean {
@@ -105,7 +109,10 @@ export default defineComponent({
       this.$emit('add-course', this.selectedCourse, this.season, this.year);
       this.closeCurrentModal();
     },
-    backOrCancel() {
+    cancelOrRemove() {
+      if (this.isPlaceholderModal) {
+        // TODO @willespencer remove placeholder from plan
+      }
       this.closeCurrentModal();
     },
     updateSemProps(season: string, year: number) {
@@ -146,6 +153,10 @@ export default defineComponent({
     line-height: 17px;
     color: $lightPlaceholderGray;
     margin-bottom: 6px;
+  }
+  &-description {
+    margin: 0.375rem 0 1rem 0;
+    line-height: 14px;
   }
   &-link {
     color: $emGreen;

--- a/src/components/Modals/TeleportModal.vue
+++ b/src/components/Modals/TeleportModal.vue
@@ -22,8 +22,16 @@
           </button>
         </div>
         <slot class="modal-body"></slot>
-        <div v-if="!isSimpleModal" class="modal-buttonWrapper">
-          <button class="modal-button" @click="leftButtonClicked">
+        <div
+          v-if="!isSimpleModal"
+          class="modal-buttonWrapper"
+          :class="{ 'modal-buttonWrapper--warningStyle': leftButtonWarningStyle }"
+        >
+          <button
+            class="modal-button"
+            @click="leftButtonClicked"
+            :class="{ 'modal-button--warningStyle': leftButtonWarningStyle }"
+          >
             {{ leftButtonText }}
           </button>
           <button
@@ -55,6 +63,7 @@ export default defineComponent({
     title: { type: String, default: '' },
     contentClass: { type: String, required: true },
     leftButtonText: { type: String, default: '' },
+    leftButtonWarningStyle: { type: Boolean, default: false },
     rightButtonText: { type: String, default: '' },
     rightButtonImage: { type: String, default: '' },
     rightButtonAlt: { type: String, default: '' },
@@ -176,6 +185,10 @@ export default defineComponent({
     margin-top: 1rem;
     display: flex;
     justify-content: flex-end;
+
+    &--warningStyle {
+      justify-content: space-between;
+    }
   }
 
   &-button {
@@ -188,6 +201,11 @@ export default defineComponent({
     display: flex;
     justify-content: center;
     align-items: center;
+
+    &--warningStyle {
+      color: $error;
+      border: 1px solid $error;
+    }
 
     &--add {
       color: $white;

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="incompleteselfcheck">
-    <new-self-check-course-modal
+    <new-self-check-or-placeholder-course-modal
       v-if="isCourseModalOpen"
       :subReqName="subReqName"
       :requirementId="subReqId"
@@ -48,7 +48,7 @@ import {
   getRelatedRequirementIdsForCourseOptOut,
 } from '@/requirements/requirement-frontend-utils';
 
-import NewSelfCheckCourseModal from '@/components/Modals/NewCourse/NewSelfCheckCourseModal.vue';
+import NewSelfCheckOrPlaceholderCourseModal from '@/components/Modals/NewCourse/NewSelfCheckOrPlaceholderCourseModal.vue';
 
 type Data = {
   showDropdown: boolean;
@@ -57,7 +57,7 @@ type Data = {
 
 export default defineComponent({
   components: {
-    NewSelfCheckCourseModal,
+    NewSelfCheckOrPlaceholderCourseModal,
   },
   props: {
     subReqId: { type: String, required: true },

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -102,6 +102,7 @@
                 :compact="compact"
                 :semesterIndex="semesterIndex + 1"
                 :placeholderObj="element"
+                @delete-placeholder="deletePlaceholder"
               />
             </div>
           </template>
@@ -380,6 +381,10 @@ export default defineComponent({
       deleteCourseFromSemester(this.year, this.season, uniqueID, this.$gtag);
       // Update requirements menu
       this.openConfirmationModal(`Removed ${courseCode} from ${this.season} ${this.year}`);
+    },
+    deletePlaceholder(placeholderObj: FirestoreSemesterPlaceholder) {
+      deleteCourseFromSemester(this.year, this.season, placeholderObj.uniqueID, this.$gtag);
+      this.openConfirmationModal(`Removed ${placeholderObj.name} Placeholder`);
     },
     colorCourse(color: string, uniqueID: number, courseCode: string) {
       editSemester(


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request implements the front-end for the modal that opens to assign courses to placeholders to continue Templates development. Follow-up from #592.

- [x] Open modal when a placeholder is clicked
- [x] Refactor `NewSelfCheckCourseModal` to handle placeholder assigning as well
- [x] Implement removing placeholder button and styling (with confirmation)
- [x] Add temporary description/learn more values with TODOs  

![image](https://user-images.githubusercontent.com/25535093/151435913-84274633-b411-40a3-8793-d0bd3160e739.png)

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

Complete the requirements side of this modal in a later PR. This should be easier as real placeholder data is populated into a user's Firestore collection. Specifically...

- [ ] Filter out the courses that can be added in the new modal
- [ ] Assign selected course to requirement
- [ ] Replace placeholder in front-end with selected course (and show confirmation)
- [ ] Show corresponding description and learn more link from requirements sidebar

### Test Plan <!-- Required -->

Similarly to #592 - placeholder data has to be added to Firestore manually. Afterward...

1. Confirm clicking on a placeholder opens up a modal with the name of the placeholder as its title
2. Confirm the styling of the modal matches the designs
3. Confirm pressing remove on the modal deletes the placeholder from the plan, and refreshing it
4. Confirm courses are properly filtered in a self-check add modal and can be assigned to the requirements and semesters as before.

![image](https://user-images.githubusercontent.com/25535093/151438592-266176e7-26d4-4661-aa01-5b8ef4d4acf8.png)

### Notes <!-- Optional -->

@kkkehui could you take a look and let me know if this looks good? I think I closely followed the designs - but I did keep the placeholder text inside the input box the same as our other add modals for consistency and easier coding. Let me know what you think!

Additionally, This PR can be safely merged as long as the self check add modal remains unchanged, as real users cannot yet have placeholders!
