### PR TITLE
Add entrance/grad seasons to onboarding

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -285,12 +285,6 @@ input {
     }
   }
 
-  &-yearSemWrapper {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-  }
-
   &-addRemoveWrapper {
     margin-top: 0.5rem;
     display: flex;

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -285,6 +285,12 @@ input {
     }
   }
 
+  &-yearSemWrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+  }
+
   &-addRemoveWrapper {
     margin-top: 0.5rem;
     display: flex;

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -144,7 +144,9 @@ export default defineComponent({
         this.name.firstName === '' ||
         this.name.lastName === '' ||
         this.onboarding.gradYear === '' ||
+        !this.onboarding.gradSem ||
         this.onboarding.entranceYear === '' ||
+        !this.onboarding.entranceSem ||
         (this.onboarding.college === '' && this.onboarding.grad === '')
       );
     },
@@ -185,11 +187,11 @@ export default defineComponent({
       if (this.name.lastName === '') {
         messages.push('a last name');
       }
-      if (this.onboarding.gradYear === '') {
-        messages.push('a graduation year');
+      if (this.onboarding.gradYear === '' || !this.onboarding.gradSem) {
+        messages.push('a graduation date');
       }
-      if (this.onboarding.entranceYear === '') {
-        messages.push('an entrance year');
+      if (this.onboarding.entranceYear === '' || !this.onboarding.entranceSem) {
+        messages.push('an entrance date');
       }
 
       // generate the string depending on how many error messages are selected

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -244,7 +244,9 @@ export default defineComponent({
     },
     updateBasic(
       gradYear: string,
+      gradSem: FirestoreSemesterSeason,
       entranceYear: string,
+      entranceSem: FirestoreSemesterSeason,
       college: string,
       major: readonly string[],
       minor: readonly string[],
@@ -255,7 +257,9 @@ export default defineComponent({
       this.onboarding = {
         ...this.onboarding,
         gradYear,
+        gradSem,
         entranceYear,
+        entranceSem,
         college,
         major,
         minor,

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -27,36 +27,70 @@
           >
           <input class="onboarding-input" v-model="lastName" @input="updateBasic()" />
         </div>
-        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-          <label class="onboarding-label"
-            ><span class="onboarding-subHeader--font"
-              >Entrance Year<span class="onboarding-required-star">*</span>
-            </span></label
-          >
-          <div class="onboarding-selectWrapper">
-            <onboarding-basic-single-dropdown
-              :availableChoices="semesters"
-              :choice="entranceYear"
-              :cannotBeRemoved="true"
-              :scrollBottomToElement="2020"
-              @on-select="selectEntranceYear"
-            />
+        <div class="onboarding-yearSemWrapper">
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+            <label class="onboarding-label"
+              ><span class="onboarding-subHeader--font"
+                >Entrance Season<span class="onboarding-required-star">*</span>
+              </span></label
+            >
+            <div class="onboarding-selectWrapper">
+              <onboarding-basic-single-dropdown
+                :availableChoices="seasons"
+                :choice="entranceSemChoice"
+                :cannotBeRemoved="true"
+                @on-select="selectEntranceSem"
+              />
+            </div>
+          </div>
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+            <label class="onboarding-label"
+              ><span class="onboarding-subHeader--font"
+                >Entrance Year<span class="onboarding-required-star">*</span>
+              </span></label
+            >
+            <div class="onboarding-selectWrapper">
+              <onboarding-basic-single-dropdown
+                :availableChoices="semesters"
+                :choice="entranceYear"
+                :cannotBeRemoved="true"
+                :scrollBottomToElement="2020"
+                @on-select="selectEntranceYear"
+              />
+            </div>
           </div>
         </div>
-        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-          <label class="onboarding-label"
-            ><span class="onboarding-subHeader--font"
-              >Graduation Year<span class="onboarding-required-star">*</span>
-            </span></label
-          >
-          <div class="onboarding-selectWrapper">
-            <onboarding-basic-single-dropdown
-              :availableChoices="semesters"
-              :choice="gradYear"
-              :cannotBeRemoved="true"
-              :scrollBottomToElement="2024"
-              @on-select="selectGraduationYear"
-            />
+        <div class="onboarding-yearSemWrapper">
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+            <label class="onboarding-label"
+              ><span class="onboarding-subHeader--font"
+                >Graduation Season<span class="onboarding-required-star">*</span>
+              </span></label
+            >
+            <div class="onboarding-selectWrapper">
+              <onboarding-basic-single-dropdown
+                :availableChoices="seasons"
+                :choice="gradSemChoice"
+                :cannotBeRemoved="true"
+                @on-select="selectGraduationSem"
+              />
+            </div>
+          </div>
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+            <label class="onboarding-label"
+              ><span class="onboarding-subHeader--font"
+                >Graduation Year<span class="onboarding-required-star">*</span>
+              </span></label
+            >
+            <div class="onboarding-selectWrapper">
+              <onboarding-basic-single-dropdown
+                :availableChoices="semesters"
+                :choice="gradYear"
+                :cannotBeRemoved="true"
+                :scrollBottomToElement="2024"
+                @on-select="selectGraduationYear"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -161,7 +195,9 @@ export default defineComponent({
   emits: {
     updateBasic(
       gradYear: string,
+      gradSem: FirestoreSemesterSeason,
       entranceYear: string,
+      entranceSem: FirestoreSemesterSeason,
       collegeAcronym: string,
       majorAcronyms: readonly string[],
       minorAcronyms: readonly string[],
@@ -170,7 +206,9 @@ export default defineComponent({
     ) {
       return (
         typeof gradYear === 'string' &&
+        typeof gradSem === 'string' &&
         typeof entranceYear === 'string' &&
+        typeof entranceSem === 'string' &&
         typeof collegeAcronym === 'string' &&
         Array.isArray(majorAcronyms) &&
         Array.isArray(minorAcronyms) &&
@@ -197,7 +235,9 @@ export default defineComponent({
       lastName: this.userName.lastName,
       placeholderText,
       gradYear: this.onboardingData.gradYear,
+      gradSem: this.onboardingData.gradSem,
       entranceYear: this.onboardingData.entranceYear,
+      entranceSem: this.onboardingData.entranceSem,
       collegeAcronym,
       majorAcronyms,
       minorAcronyms,
@@ -253,13 +293,29 @@ export default defineComponent({
       }
       return semsDict;
     },
+    seasons(): Readonly<Record<string, string>> {
+      return {
+        Fall: 'Fall',
+        Spring: 'Spring',
+        Summer: 'Summer',
+        Winter: 'Winter',
+      };
+    },
+    gradSemChoice(): string {
+      return this.gradSem ? (this.gradSem as string) : '';
+    },
+    entranceSemChoice(): string {
+      return this.gradSem ? (this.entranceSem as string) : '';
+    },
   },
   methods: {
     updateBasic() {
       this.$emit(
         'updateBasic',
         this.gradYear,
+        this.gradSem,
         this.entranceYear,
+        this.entranceSem,
         this.collegeAcronym,
         this.majorAcronyms.filter(it => it !== ''),
         this.minorAcronyms.filter(it => it !== ''),
@@ -294,6 +350,14 @@ export default defineComponent({
     },
     selectEntranceYear(year: string) {
       this.entranceYear = year;
+      this.updateBasic();
+    },
+    selectGraduationSem(season: string) {
+      this.gradSem = season as FirestoreSemesterSeason;
+      this.updateBasic();
+    },
+    selectEntranceSem(season: string) {
+      this.entranceSem = season as FirestoreSemesterSeason;
       this.updateBasic();
     },
     selectCollege(acronym: string) {

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -27,70 +27,69 @@
           >
           <input class="onboarding-input" v-model="lastName" @input="updateBasic()" />
         </div>
-        <div class="onboarding-yearSemWrapper">
-          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span class="onboarding-subHeader--font"
-                >Entrance Season<span class="onboarding-required-star">*</span>
-              </span></label
-            >
-            <div class="onboarding-selectWrapper">
-              <onboarding-basic-single-dropdown
-                :availableChoices="seasons"
-                :choice="entranceSemChoice"
-                :cannotBeRemoved="true"
-                @on-select="selectEntranceSem"
-              />
-            </div>
-          </div>
-          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span class="onboarding-subHeader--font"
-                >Entrance Year<span class="onboarding-required-star">*</span>
-              </span></label
-            >
-            <div class="onboarding-selectWrapper">
-              <onboarding-basic-single-dropdown
-                :availableChoices="semesters"
-                :choice="entranceYear"
-                :cannotBeRemoved="true"
-                :scrollBottomToElement="2020"
-                @on-select="selectEntranceYear"
-              />
-            </div>
+        <div
+          class="onboarding-inputWrapper onboarding-inputWrapper--name onboarding-inputWrapper--description"
+        >
+          <label class="onboarding-label"
+            ><span class="onboarding-subHeader--font"
+              >Entrance Season<span class="onboarding-required-star">*</span>
+            </span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="seasons"
+              :choice="entranceSemChoice"
+              :cannotBeRemoved="true"
+              @on-select="selectEntranceSem"
+            />
           </div>
         </div>
-        <div class="onboarding-yearSemWrapper">
-          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span class="onboarding-subHeader--font"
-                >Graduation Season<span class="onboarding-required-star">*</span>
-              </span></label
-            >
-            <div class="onboarding-selectWrapper">
-              <onboarding-basic-single-dropdown
-                :availableChoices="seasons"
-                :choice="gradSemChoice"
-                :cannotBeRemoved="true"
-                @on-select="selectGraduationSem"
-              />
-            </div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+          <label class="onboarding-label"
+            ><span class="onboarding-subHeader--font"
+              >Entrance Year<span class="onboarding-required-star">*</span>
+            </span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="semesters"
+              :choice="entranceYear"
+              :cannotBeRemoved="true"
+              :scrollBottomToElement="2020"
+              @on-select="selectEntranceYear"
+            />
           </div>
-          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span class="onboarding-subHeader--font"
-                >Graduation Year<span class="onboarding-required-star">*</span>
-              </span></label
-            >
-            <div class="onboarding-selectWrapper">
-              <onboarding-basic-single-dropdown
-                :availableChoices="semesters"
-                :choice="gradYear"
-                :cannotBeRemoved="true"
-                :scrollBottomToElement="2024"
-                @on-select="selectGraduationYear"
-              />
-            </div>
+        </div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--name"></div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+          <label class="onboarding-label"
+            ><span class="onboarding-subHeader--font"
+              >Graduation Season<span class="onboarding-required-star">*</span>
+            </span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="seasons"
+              :choice="gradSemChoice"
+              :cannotBeRemoved="true"
+              @on-select="selectGraduationSem"
+            />
+          </div>
+        </div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+          <label class="onboarding-label"
+            ><span class="onboarding-subHeader--font"
+              >Graduation Year<span class="onboarding-required-star">*</span>
+            </span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="semesters"
+              :choice="gradYear"
+              :cannotBeRemoved="true"
+              :scrollBottomToElement="2024"
+              @on-select="selectGraduationYear"
+            />
           </div>
         </div>
       </div>

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -36,12 +36,33 @@
               ><span> {{ userName.lastName }}</span></label
             >
           </div>
+          <div
+            class="onboarding-inputWrapper onboarding-inputWrapper--name onboarding-inputWrapper--description"
+          >
+            <label class="onboarding-label"
+              ><span>Entrance Season<span class="onboarding-required-star">*</span></span></label
+            >
+            <label class="onboarding-label--review"
+              ><span data-cyId="onboarding-entranceSeason">{{ entranceSemText }}</span></label
+            >
+          </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
             <label class="onboarding-label"
               ><span>Entrance Year<span class="onboarding-required-star">*</span></span></label
             >
             <label class="onboarding-label--review"
               ><span data-cyId="onboarding-entranceYear">{{ entranceYearText }}</span></label
+            >
+          </div>
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name"></div>
+          <div
+            class="onboarding-inputWrapper onboarding-inputWrapper--name onboarding-inputWrapper--noMargin"
+          >
+            <label class="onboarding-label"
+              ><span>Graduation Season<span class="onboarding-required-star">*</span></span></label
+            >
+            <label class="onboarding-label--review"
+              ><span data-cyId="onboarding-gradSeason">{{ gradSemText }}</span></label
             >
           </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
@@ -212,6 +233,12 @@ export default defineComponent({
       return this.onboardingData.entranceYear !== ''
         ? this.onboardingData.entranceYear
         : placeholderText;
+    },
+    gradSemText(): string {
+      return this.onboardingData.gradSem ?? placeholderText;
+    },
+    entranceSemText(): string {
+      return this.onboardingData.entranceSem ?? placeholderText;
     },
     totalCredits(): number {
       let count = 0;

--- a/src/global-firestore-data/onboarding-data.ts
+++ b/src/global-firestore-data/onboarding-data.ts
@@ -10,7 +10,9 @@ export const setAppOnboardingData = (
   setUsernameData(name);
   onboardingDataCollection.doc(store.state.currentFirebaseUser.email).set({
     gradYear: onboarding.gradYear,
+    gradSem: onboarding.gradSem,
     entranceYear: onboarding.entranceYear,
+    entranceSem: onboarding.entranceSem,
     colleges: onboarding.college ? [{ acronym: onboarding.college }] : [],
     majors: onboarding.major.map(acronym => ({ acronym })),
     minors: onboarding.minor.map(acronym => ({ acronym })),

--- a/src/requirements/__test__/exam-credit.test.ts
+++ b/src/requirements/__test__/exam-credit.test.ts
@@ -68,7 +68,9 @@ it('Two exams are converted to the correct courses', () => {
 it('Exam is converted to correct course', () => {
   const userData: AppOnboardingData = {
     gradYear: '2020',
+    gradSem: 'Spring',
     entranceYear: '2016',
+    entranceSem: 'Fall',
     college: 'EN',
     major: [],
     exam: [{ type: 'AP', score: 5, subject: 'Computer Science A' }],

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -142,8 +142,10 @@ export const firestoreSemesterCourseToBottomBarCourse = ({
 
 export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
   // TODO: take into account multiple colleges
-  gradYear: data.gradYear ? data.gradYear : '',
-  entranceYear: data.entranceYear ? data.entranceYear : '',
+  gradYear: data.gradYear ?? '',
+  gradSem: data.gradSem,
+  entranceYear: data.entranceYear ?? '',
+  entranceSem: data.entranceSem,
   college: data.colleges.length !== 0 ? data.colleges[0].acronym : undefined,
   major: data.majors.map(({ acronym }) => acronym),
   minor: data.minors.map(({ acronym }) => acronym),

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -59,7 +59,9 @@ type FirestoreTransferExam = {
 type FirestoreCollegeMajorMinorOrGrad = { readonly acronym: string };
 type FirestoreOnboardingUserData = {
   readonly gradYear: string;
+  readonly gradSem: FirestoreSemesterSeason;
   readonly entranceYear: string;
+  readonly entranceSem: FirestoreSemesterSeason;
   readonly colleges: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly majors: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly minors: readonly FirestoreCollegeMajorMinorOrGrad[];
@@ -175,9 +177,9 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
 // college and grad are optional fields: grad can be undefined if the user hasn't selected a grad program, and college can be undefined if the user has only selected a grad program.
 type AppOnboardingData = {
   readonly gradYear: string;
-  readonly gradSem?: FirestoreSemesterSeason;
+  readonly gradSem: FirestoreSemesterSeason;
   readonly entranceYear: string;
-  readonly entranceSem?: FirestoreSemesterSeason;
+  readonly entranceSem: FirestoreSemesterSeason;
   readonly college?: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request adds entrance and grad season inputs to the Onboarding modal. This solves the issue in #618 where students that enter in Spring 2020 would be given the post Fall 2020 A&S reqs since we don't check semester season, just year. This also now implements @vaishnavi17 's code in #529 to base starter semesters off of entrance and grad seasons instead of just years

- [x] implemented X
- [x] fixed Y

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] resolve bug 1
- [ ] implement Z

<!--- Note dependencies on other PRs if any. -->

Depends on #{number of PR}


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Blockers <!-- Optional -->

<!--- Note and itemize any blockers (especially for WIP PRs) here and on Notion -->

- A newly discovered dependency that hasn’t been addressed

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->

- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)
