### PR TITLE
Add entrance/grad seasons to onboarding

### DIFF
--- a/cypress/integration/hidden-features.spec.ts
+++ b/cypress/integration/hidden-features.spec.ts
@@ -35,8 +35,8 @@ it('Onboard a new user with all required fields', () => {
   cy.get('[data-cyId=onboarding]').clickOutside();
   cy.get('[data-cyId=onboarding]').should('be.visible');
 
-  // set Graduation year to 2018
-  cy.get('[data-cyId=onboarding-dropdown]').eq(0).click();
+  // set Entrance semester to 2018 (default Fall)
+  cy.get('[data-cyId=onboarding-dropdown]').eq(1).click();
   cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
     cy.wrap($el)
       .invoke('text')
@@ -49,8 +49,21 @@ it('Onboard a new user with all required fields', () => {
   cy.get('[data-cyId=onboarding-nextButton]').should('be.disabled');
   cy.get('[data-cyId=onboarding-error]').scrollIntoView().should('be.visible');
 
-  // set Graduation year to 2022
-  cy.get('[data-cyId=onboarding-dropdown]').eq(1).click();
+  // set Graduation semester to Summer 2022
+  cy.get('[data-cyId=onboarding-dropdown]').eq(2).click();
+  cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
+    cy.wrap($el)
+      .invoke('text')
+      .then(text => {
+        if (text.includes('Summer')) {
+          cy.wrap($el).click();
+        }
+      });
+  });
+  cy.get('[data-cyId=onboarding-nextButton]').should('be.disabled');
+  cy.get('[data-cyId=onboarding-error]').scrollIntoView().should('be.visible');
+
+  cy.get('[data-cyId=onboarding-dropdown]').eq(3).click();
   cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
     cy.wrap($el)
       .invoke('text')
@@ -64,7 +77,7 @@ it('Onboard a new user with all required fields', () => {
   cy.get('[data-cyId=onboarding-error]').scrollIntoView().should('be.visible');
 
   // set to Engineering college
-  cy.get('[data-cyId=onboarding-dropdown]').eq(2).click();
+  cy.get('[data-cyId=onboarding-dropdown]').eq(4).click();
   cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
     cy.wrap($el)
       .invoke('text')
@@ -80,9 +93,11 @@ it('Onboard a new user with all required fields', () => {
   cy.get('[data-cyId=onboarding-error]').should('not.exist');
   cy.get('[data-cyId=onboarding-nextButton]').click();
 
-  // confirm 2018, 2022, and engineering are selected on the review screen
+  // confirm Fall 2018, Summer 2022, and engineering are selected on the review screen
   cy.get('[data-cyId=onboarding-entranceYear]').contains('2018');
+  cy.get('[data-cyId=onboarding-entranceSeason]').contains('Fall');
   cy.get('[data-cyId=onboarding-gradYear]').contains('2022');
+  cy.get('[data-cyId=onboarding-gradSeason]').contains('Summer');
   cy.get('[data-cyId=onboarding-college]').contains('Engineering');
   cy.get('[data-cyId=onboarding-finishButton]').click();
 });

--- a/cypress/integration/test.spec.ts
+++ b/cypress/integration/test.spec.ts
@@ -90,12 +90,12 @@ it('Edit a semester (Fall of oldest year -> Spring of second oldest year)', () =
     .contains(`Spring ${startYear + 1}`);
 });
 
-// Test that you can change entrance year, grad year, colleges and majors. A later requirements test is dependent on these choices
+// Test that you can change entrance semester, grad semester, colleges and majors. A later requirements test is dependent on these choices
 it('Switch to engineering college and cs major in class of 2022', () => {
   cy.get('[data-cyId=editProfile]').click();
 
-  // set Graduation year to 2018
-  cy.get('[data-cyId=onboarding-dropdown]').eq(0).click();
+  // set Entrance semester to 2018
+  cy.get('[data-cyId=onboarding-dropdown]').eq(1).click();
   cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
     cy.wrap($el)
       .invoke('text')
@@ -106,8 +106,19 @@ it('Switch to engineering college and cs major in class of 2022', () => {
       });
   });
 
-  // set Graduation year to 2022
-  cy.get('[data-cyId=onboarding-dropdown]').eq(1).click();
+  // set Graduation semester to Summer 2022
+  cy.get('[data-cyId=onboarding-dropdown]').eq(2).click();
+  cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
+    cy.wrap($el)
+      .invoke('text')
+      .then(text => {
+        if (text.includes('Summer')) {
+          cy.wrap($el).click();
+        }
+      });
+  });
+
+  cy.get('[data-cyId=onboarding-dropdown]').eq(3).click();
   cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
     cy.wrap($el)
       .invoke('text')
@@ -119,7 +130,7 @@ it('Switch to engineering college and cs major in class of 2022', () => {
   });
 
   // set to Engineering college
-  cy.get('[data-cyId=onboarding-dropdown]').eq(2).click();
+  cy.get('[data-cyId=onboarding-dropdown]').eq(4).click();
   cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
     cy.wrap($el)
       .invoke('text')
@@ -131,7 +142,7 @@ it('Switch to engineering college and cs major in class of 2022', () => {
   });
 
   // set to CS major
-  cy.get('[data-cyId=onboarding-dropdown]').eq(3).click();
+  cy.get('[data-cyId=onboarding-dropdown]').eq(5).click();
   cy.get('[data-cyId=onboarding-dropdownItem]').each($el => {
     cy.wrap($el)
       .invoke('text')
@@ -146,9 +157,11 @@ it('Switch to engineering college and cs major in class of 2022', () => {
   cy.get('[data-cyId=onboarding-nextButton]').click();
   cy.get('[data-cyId=onboarding-nextButton]').click();
 
-  // confirm 2018, 2022, engineering, and computer science are selected on the review screen
+  // confirm Fall 2018, Summer 2022, engineering, and computer science are selected on the review screen
   cy.get('[data-cyId=onboarding-entranceYear]').contains('2018');
+  cy.get('[data-cyId=onboarding-entranceSeason]').contains('Fall');
   cy.get('[data-cyId=onboarding-gradYear]').contains('2022');
+  cy.get('[data-cyId=onboarding-gradSeason]').contains('Summer');
   cy.get('[data-cyId=onboarding-college]').contains('Engineering');
   cy.get('[data-cyId=onboarding-major]').contains('Computer Science');
   cy.get('[data-cyId=onboarding-finishButton]').click();

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -285,12 +285,6 @@ input {
     }
   }
 
-  &-yearSemWrapper {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-  }
-
   &-addRemoveWrapper {
     margin-top: 0.5rem;
     display: flex;

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -605,3 +605,9 @@ select option[disabled]:first-child {
   text-decoration-line: underline;
   color: $yuxuanBlue;
 }
+
+.season-emoji {
+  padding-left: 0px;
+  padding-right: 10px;
+  height: 14px;
+}

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -285,6 +285,12 @@ input {
     }
   }
 
+  &-yearSemWrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+  }
+
   &-addRemoveWrapper {
     margin-top: 0.5rem;
     display: flex;

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -188,11 +188,11 @@ export default defineComponent({
       if (this.name.lastName === '') {
         messages.push('a last name');
       }
-      if (this.onboarding.gradYear === '' || !this.onboarding.gradSem) {
-        messages.push('a graduation date');
-      }
       if (this.onboarding.entranceYear === '' || !this.onboarding.entranceSem) {
         messages.push('an entrance date');
+      }
+      if (this.onboarding.gradYear === '' || !this.onboarding.gradSem) {
+        messages.push('a graduation date');
       }
 
       // generate the string depending on how many error messages are selected

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -144,7 +144,9 @@ export default defineComponent({
         this.name.firstName === '' ||
         this.name.lastName === '' ||
         this.onboarding.gradYear === '' ||
+        !this.onboarding.gradSem ||
         this.onboarding.entranceYear === '' ||
+        !this.onboarding.entranceSem ||
         (this.onboarding.college === '' && this.onboarding.grad === '')
       );
     },
@@ -185,11 +187,11 @@ export default defineComponent({
       if (this.name.lastName === '') {
         messages.push('a last name');
       }
-      if (this.onboarding.gradYear === '') {
-        messages.push('a graduation year');
+      if (this.onboarding.gradYear === '' || !this.onboarding.gradSem) {
+        messages.push('a graduation date');
       }
-      if (this.onboarding.entranceYear === '') {
-        messages.push('an entrance year');
+      if (this.onboarding.entranceYear === '' || !this.onboarding.entranceSem) {
+        messages.push('an entrance date');
       }
 
       // generate the string depending on how many error messages are selected

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -40,6 +40,7 @@
             v-if="currentPage == 1"
             :userName="name"
             :onboardingData="onboarding"
+            :isEditingProfile="isEditingProfile"
             @updateBasic="updateBasic"
           />
           <onboarding-transfer

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -243,7 +243,9 @@ export default defineComponent({
     },
     updateBasic(
       gradYear: string,
+      gradSem: FirestoreSemesterSeason,
       entranceYear: string,
+      entranceSem: FirestoreSemesterSeason,
       college: string,
       major: readonly string[],
       minor: readonly string[],
@@ -254,7 +256,9 @@ export default defineComponent({
       this.onboarding = {
         ...this.onboarding,
         gradYear,
+        gradSem,
         entranceYear,
+        entranceSem,
         college,
         major,
         minor,

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -189,10 +189,10 @@ export default defineComponent({
         messages.push('a last name');
       }
       if (this.onboarding.entranceYear === '' || !this.onboarding.entranceSem) {
-        messages.push('an entrance date');
+        messages.push('an entrance semester');
       }
       if (this.onboarding.gradYear === '' || !this.onboarding.gradSem) {
-        messages.push('a graduation date');
+        messages.push('a graduation semester');
       }
 
       // generate the string depending on how many error messages are selected

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -302,10 +302,10 @@ export default defineComponent({
       };
     },
     gradSemChoice(): string {
-      return this.gradSem ? (this.gradSem as string) : '';
+      return this.gradSem as string;
     },
     entranceSemChoice(): string {
-      return this.gradSem ? (this.entranceSem as string) : '';
+      return this.entranceSem as string;
     },
   },
   methods: {

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -194,6 +194,7 @@ export default defineComponent({
   props: {
     userName: { type: Object as PropType<FirestoreUserName>, required: true },
     onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
+    isEditingProfile: { type: Boolean, required: true },
   },
   emits: {
     updateBasic(
@@ -225,15 +226,24 @@ export default defineComponent({
     const minorAcronyms = [...this.onboardingData.minor];
     if (majorAcronyms.length === 0) majorAcronyms.push('');
     if (minorAcronyms.length === 0) minorAcronyms.push('');
+
+    // if sem has not been previously filled out, choice is automatically is "Fall"/"Spring" for new users, old users have no data
+    let { gradSem } = this.onboardingData;
+    let { entranceSem } = this.onboardingData;
+    if (!this.isEditingProfile) {
+      gradSem = gradSem !== '' ? gradSem : 'Spring';
+      entranceSem = entranceSem !== '' ? entranceSem : 'Fall';
+    }
+
     return {
       firstName: this.userName.firstName,
       middleName: this.userName.middleName,
       lastName: this.userName.lastName,
       placeholderText,
       gradYear: this.onboardingData.gradYear,
-      gradSem: this.onboardingData.gradSem,
+      gradSem,
       entranceYear: this.onboardingData.entranceYear,
-      entranceSem: this.onboardingData.entranceSem,
+      entranceSem,
       collegeAcronym: this.onboardingData.college ? this.onboardingData.college : '',
       majorAcronyms,
       minorAcronyms,

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -27,36 +27,70 @@
           >
           <input class="onboarding-input" v-model="lastName" @input="updateBasic()" />
         </div>
-        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-          <label class="onboarding-label"
-            ><span class="onboarding-subHeader--font"
-              >Entrance Year<span class="onboarding-required-star">*</span>
-            </span></label
-          >
-          <div class="onboarding-selectWrapper">
-            <onboarding-basic-single-dropdown
-              :availableChoices="semesters"
-              :choice="entranceYear"
-              :cannotBeRemoved="true"
-              :scrollBottomToElement="2020"
-              @on-select="selectEntranceYear"
-            />
+        <div class="onboarding-yearSemWrapper">
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+            <label class="onboarding-label"
+              ><span class="onboarding-subHeader--font"
+                >Entrance Season<span class="onboarding-required-star">*</span>
+              </span></label
+            >
+            <div class="onboarding-selectWrapper">
+              <onboarding-basic-single-dropdown
+                :availableChoices="seasons"
+                :choice="entranceSemChoice"
+                :cannotBeRemoved="true"
+                @on-select="selectEntranceSem"
+              />
+            </div>
+          </div>
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+            <label class="onboarding-label"
+              ><span class="onboarding-subHeader--font"
+                >Entrance Year<span class="onboarding-required-star">*</span>
+              </span></label
+            >
+            <div class="onboarding-selectWrapper">
+              <onboarding-basic-single-dropdown
+                :availableChoices="semesters"
+                :choice="entranceYear"
+                :cannotBeRemoved="true"
+                :scrollBottomToElement="2020"
+                @on-select="selectEntranceYear"
+              />
+            </div>
           </div>
         </div>
-        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-          <label class="onboarding-label"
-            ><span class="onboarding-subHeader--font"
-              >Graduation Year<span class="onboarding-required-star">*</span>
-            </span></label
-          >
-          <div class="onboarding-selectWrapper">
-            <onboarding-basic-single-dropdown
-              :availableChoices="semesters"
-              :choice="gradYear"
-              :cannotBeRemoved="true"
-              :scrollBottomToElement="2024"
-              @on-select="selectGraduationYear"
-            />
+        <div class="onboarding-yearSemWrapper">
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+            <label class="onboarding-label"
+              ><span class="onboarding-subHeader--font"
+                >Graduation Season<span class="onboarding-required-star">*</span>
+              </span></label
+            >
+            <div class="onboarding-selectWrapper">
+              <onboarding-basic-single-dropdown
+                :availableChoices="seasons"
+                :choice="gradSemChoice"
+                :cannotBeRemoved="true"
+                @on-select="selectGraduationSem"
+              />
+            </div>
+          </div>
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+            <label class="onboarding-label"
+              ><span class="onboarding-subHeader--font"
+                >Graduation Year<span class="onboarding-required-star">*</span>
+              </span></label
+            >
+            <div class="onboarding-selectWrapper">
+              <onboarding-basic-single-dropdown
+                :availableChoices="semesters"
+                :choice="gradYear"
+                :cannotBeRemoved="true"
+                :scrollBottomToElement="2024"
+                @on-select="selectGraduationYear"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -158,7 +192,9 @@ export default defineComponent({
   emits: {
     updateBasic(
       gradYear: string,
+      gradSem: FirestoreSemesterSeason,
       entranceYear: string,
+      entranceSem: FirestoreSemesterSeason,
       collegeAcronym: string,
       majorAcronyms: readonly string[],
       minorAcronyms: readonly string[],
@@ -167,7 +203,9 @@ export default defineComponent({
     ) {
       return (
         typeof gradYear === 'string' &&
+        typeof gradSem === 'string' &&
         typeof entranceYear === 'string' &&
+        typeof entranceSem === 'string' &&
         typeof collegeAcronym === 'string' &&
         Array.isArray(majorAcronyms) &&
         Array.isArray(minorAcronyms) &&
@@ -187,7 +225,9 @@ export default defineComponent({
       lastName: this.userName.lastName,
       placeholderText,
       gradYear: this.onboardingData.gradYear,
+      gradSem: this.onboardingData.gradSem,
       entranceYear: this.onboardingData.entranceYear,
+      entranceSem: this.onboardingData.entranceSem,
       collegeAcronym: this.onboardingData.college ? this.onboardingData.college : '',
       majorAcronyms,
       minorAcronyms,
@@ -239,13 +279,29 @@ export default defineComponent({
       }
       return semsDict;
     },
+    seasons(): Readonly<Record<string, string>> {
+      return {
+        Fall: 'Fall',
+        Spring: 'Spring',
+        Summer: 'Summer',
+        Winter: 'Winter',
+      };
+    },
+    gradSemChoice(): string {
+      return this.gradSem ? (this.gradSem as string) : '';
+    },
+    entranceSemChoice(): string {
+      return this.gradSem ? (this.entranceSem as string) : '';
+    },
   },
   methods: {
     updateBasic() {
       this.$emit(
         'updateBasic',
         this.gradYear,
+        this.gradSem,
         this.entranceYear,
+        this.entranceSem,
         this.collegeAcronym,
         this.majorAcronyms.filter(it => it !== ''),
         this.minorAcronyms.filter(it => it !== ''),
@@ -276,6 +332,14 @@ export default defineComponent({
     },
     selectEntranceYear(year: string) {
       this.entranceYear = year;
+      this.updateBasic();
+    },
+    selectGraduationSem(season: string) {
+      this.gradSem = season as FirestoreSemesterSeason;
+      this.updateBasic();
+    },
+    selectEntranceSem(season: string) {
+      this.entranceSem = season as FirestoreSemesterSeason;
       this.updateBasic();
     },
     selectCollege(acronym: string) {

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -27,70 +27,69 @@
           >
           <input class="onboarding-input" v-model="lastName" @input="updateBasic()" />
         </div>
-        <div class="onboarding-yearSemWrapper">
-          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span class="onboarding-subHeader--font"
-                >Entrance Season<span class="onboarding-required-star">*</span>
-              </span></label
-            >
-            <div class="onboarding-selectWrapper">
-              <onboarding-basic-single-dropdown
-                :availableChoices="seasons"
-                :choice="entranceSemChoice"
-                :cannotBeRemoved="true"
-                @on-select="selectEntranceSem"
-              />
-            </div>
-          </div>
-          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span class="onboarding-subHeader--font"
-                >Entrance Year<span class="onboarding-required-star">*</span>
-              </span></label
-            >
-            <div class="onboarding-selectWrapper">
-              <onboarding-basic-single-dropdown
-                :availableChoices="semesters"
-                :choice="entranceYear"
-                :cannotBeRemoved="true"
-                :scrollBottomToElement="2020"
-                @on-select="selectEntranceYear"
-              />
-            </div>
+        <div
+          class="onboarding-inputWrapper onboarding-inputWrapper--name onboarding-inputWrapper--description"
+        >
+          <label class="onboarding-label"
+            ><span class="onboarding-subHeader--font"
+              >Entrance Season<span class="onboarding-required-star">*</span>
+            </span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="seasons"
+              :choice="entranceSemChoice"
+              :cannotBeRemoved="true"
+              @on-select="selectEntranceSem"
+            />
           </div>
         </div>
-        <div class="onboarding-yearSemWrapper">
-          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span class="onboarding-subHeader--font"
-                >Graduation Season<span class="onboarding-required-star">*</span>
-              </span></label
-            >
-            <div class="onboarding-selectWrapper">
-              <onboarding-basic-single-dropdown
-                :availableChoices="seasons"
-                :choice="gradSemChoice"
-                :cannotBeRemoved="true"
-                @on-select="selectGraduationSem"
-              />
-            </div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+          <label class="onboarding-label"
+            ><span class="onboarding-subHeader--font"
+              >Entrance Year<span class="onboarding-required-star">*</span>
+            </span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="semesters"
+              :choice="entranceYear"
+              :cannotBeRemoved="true"
+              :scrollBottomToElement="2020"
+              @on-select="selectEntranceYear"
+            />
           </div>
-          <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span class="onboarding-subHeader--font"
-                >Graduation Year<span class="onboarding-required-star">*</span>
-              </span></label
-            >
-            <div class="onboarding-selectWrapper">
-              <onboarding-basic-single-dropdown
-                :availableChoices="semesters"
-                :choice="gradYear"
-                :cannotBeRemoved="true"
-                :scrollBottomToElement="2024"
-                @on-select="selectGraduationYear"
-              />
-            </div>
+        </div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--name"></div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+          <label class="onboarding-label"
+            ><span class="onboarding-subHeader--font"
+              >Graduation Season<span class="onboarding-required-star">*</span>
+            </span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="seasons"
+              :choice="gradSemChoice"
+              :cannotBeRemoved="true"
+              @on-select="selectGraduationSem"
+            />
+          </div>
+        </div>
+        <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
+          <label class="onboarding-label"
+            ><span class="onboarding-subHeader--font"
+              >Graduation Year<span class="onboarding-required-star">*</span>
+            </span></label
+          >
+          <div class="onboarding-selectWrapper">
+            <onboarding-basic-single-dropdown
+              :availableChoices="semesters"
+              :choice="gradYear"
+              :cannotBeRemoved="true"
+              :scrollBottomToElement="2024"
+              @on-select="selectGraduationYear"
+            />
           </div>
         </div>
       </div>

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -38,6 +38,7 @@
           <div class="onboarding-selectWrapper">
             <onboarding-basic-single-dropdown
               :availableChoices="seasons"
+              :correspondingImages="seasonImgs"
               :choice="entranceSemChoice"
               :cannotBeRemoved="true"
               @on-select="selectEntranceSem"
@@ -70,6 +71,7 @@
           <div class="onboarding-selectWrapper">
             <onboarding-basic-single-dropdown
               :availableChoices="seasons"
+              :correspondingImages="seasonImgs"
               :choice="gradSemChoice"
               :cannotBeRemoved="true"
               @on-select="selectGraduationSem"
@@ -180,6 +182,11 @@ import { clickOutside, getCurrentYear, yearRange } from '@/utilities';
 import OnboardingBasicMultiDropdown from './OnboardingBasicMultiDropdown.vue';
 import OnboardingBasicSingleDropdown from './OnboardingBasicSingleDropdown.vue';
 
+import fall from '@/assets/images/fallEmoji.svg';
+import spring from '@/assets/images/springEmoji.svg';
+import winter from '@/assets/images/winterEmoji.svg';
+import summer from '@/assets/images/summerEmoji.svg';
+
 const placeholderText = 'Select one';
 
 export default defineComponent({
@@ -284,6 +291,14 @@ export default defineComponent({
         Spring: 'Spring',
         Summer: 'Summer',
         Winter: 'Winter',
+      };
+    },
+    seasonImgs(): Readonly<Record<FirestoreSemesterSeason, string>> {
+      return {
+        Fall: fall,
+        Spring: spring,
+        Summer: summer,
+        Winter: winter,
       };
     },
     gradSemChoice(): string {

--- a/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasicSingleDropdown.vue
@@ -33,6 +33,12 @@
           @click="onSelect([key, fullName])"
           data-cyId="onboarding-dropdownItem"
         >
+          <img
+            v-if="correspondingImages"
+            class="season-emoji"
+            :src="correspondingImages[fullName]"
+            alt=""
+          />
           {{ fullName }}
         </div>
       </div>
@@ -58,6 +64,10 @@ export default defineComponent({
     choice: { type: String, required: true },
     cannotBeRemoved: { type: Boolean, required: true },
     scrollBottomToElement: { type: Number, default: 0 },
+    correspondingImages: {
+      type: Object as PropType<Readonly<Record<string, string>>>,
+      default: null,
+    },
   },
   mounted() {
     this.curQuery = this.availableChoices[this.choice];

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -36,12 +36,33 @@
               ><span> {{ userName.lastName }}</span></label
             >
           </div>
+          <div
+            class="onboarding-inputWrapper onboarding-inputWrapper--name onboarding-inputWrapper--description"
+          >
+            <label class="onboarding-label"
+              ><span>Entrance Season<span class="onboarding-required-star">*</span></span></label
+            >
+            <label class="onboarding-label--review"
+              ><span data-cyId="onboarding-entranceSeason">{{ entranceSemText }}</span></label
+            >
+          </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
             <label class="onboarding-label"
               ><span>Entrance Year<span class="onboarding-required-star">*</span></span></label
             >
             <label class="onboarding-label--review"
               ><span data-cyId="onboarding-entranceYear">{{ entranceYearText }}</span></label
+            >
+          </div>
+          <div class="onboarding-inputWrapper onboarding-inputWrapper--name"></div>
+          <div
+            class="onboarding-inputWrapper onboarding-inputWrapper--name onboarding-inputWrapper--noMargin"
+          >
+            <label class="onboarding-label"
+              ><span>Graduation Season<span class="onboarding-required-star">*</span></span></label
+            >
+            <label class="onboarding-label--review"
+              ><span data-cyId="onboarding-gradSeason">{{ gradSemText }}</span></label
             >
           </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
@@ -212,6 +233,12 @@ export default defineComponent({
       return this.onboardingData.entranceYear !== ''
         ? this.onboardingData.entranceYear
         : placeholderText;
+    },
+    gradSemText(): string {
+      return this.onboardingData.gradSem ?? placeholderText;
+    },
+    entranceSemText(): string {
+      return this.onboardingData.entranceSem ?? placeholderText;
     },
     totalCredits(): number {
       let count = 0;

--- a/src/global-firestore-data/onboarding-data.ts
+++ b/src/global-firestore-data/onboarding-data.ts
@@ -10,9 +10,9 @@ export const setAppOnboardingData = (
   setUsernameData(name);
   onboardingDataCollection.doc(store.state.currentFirebaseUser.email).set({
     gradYear: onboarding.gradYear,
-    gradSem: onboarding.gradSem,
+    gradSem: onboarding.gradSem ?? '',
     entranceYear: onboarding.entranceYear,
-    entranceSem: onboarding.entranceSem,
+    entranceSem: onboarding.entranceSem ?? '',
     colleges: onboarding.college ? [{ acronym: onboarding.college }] : [],
     majors: onboarding.major.map(acronym => ({ acronym })),
     minors: onboarding.minor.map(acronym => ({ acronym })),

--- a/src/global-firestore-data/onboarding-data.ts
+++ b/src/global-firestore-data/onboarding-data.ts
@@ -10,7 +10,9 @@ export const setAppOnboardingData = (
   setUsernameData(name);
   onboardingDataCollection.doc(store.state.currentFirebaseUser.email).set({
     gradYear: onboarding.gradYear,
+    gradSem: onboarding.gradSem,
     entranceYear: onboarding.entranceYear,
+    entranceSem: onboarding.entranceSem,
     colleges: onboarding.college ? [{ acronym: onboarding.college }] : [],
     majors: onboarding.major.map(acronym => ({ acronym })),
     minors: onboarding.minor.map(acronym => ({ acronym })),

--- a/src/global-firestore-data/onboarding-data.ts
+++ b/src/global-firestore-data/onboarding-data.ts
@@ -10,9 +10,9 @@ export const setAppOnboardingData = (
   setUsernameData(name);
   onboardingDataCollection.doc(store.state.currentFirebaseUser.email).set({
     gradYear: onboarding.gradYear,
-    gradSem: onboarding.gradSem ?? '',
+    gradSem: onboarding.gradSem,
     entranceYear: onboarding.entranceYear,
-    entranceSem: onboarding.entranceSem ?? '',
+    entranceSem: onboarding.entranceSem,
     colleges: onboarding.college ? [{ acronym: onboarding.college }] : [],
     majors: onboarding.major.map(acronym => ({ acronym })),
     minors: onboarding.minor.map(acronym => ({ acronym })),

--- a/src/requirements/__test__/exam-credit.test.ts
+++ b/src/requirements/__test__/exam-credit.test.ts
@@ -68,7 +68,9 @@ it('Two exams are converted to the correct courses', () => {
 it('Exam is converted to correct course', () => {
   const userData: AppOnboardingData = {
     gradYear: '2020',
+    gradSem: 'Spring',
     entranceYear: '2016',
+    entranceSem: 'Fall',
     college: 'EN',
     major: [],
     exam: [{ type: 'AP', score: 5, subject: 'Computer Science A' }],

--- a/src/store.ts
+++ b/src/store.ts
@@ -61,7 +61,9 @@ const store: TypedVuexStore = new TypedVuexStore({
     userName: { firstName: '', middleName: '', lastName: '' },
     onboardingData: {
       gradYear: '',
+      gradSem: '',
       entranceYear: '',
+      entranceSem: '',
       college: '',
       major: [],
       minor: [],

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -140,12 +140,13 @@ export const firestoreSemesterCourseToBottomBarCourse = ({
   workload: 0,
 });
 
+// set entranceSem to fall and gradSem to spring by default locally, saved to Firestore when Onboarding finished
 export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
   // TODO: take into account multiple colleges
   gradYear: data.gradYear ?? '',
-  gradSem: data.gradSem,
+  gradSem: data.gradSem ?? 'Spring',
   entranceYear: data.entranceYear ?? '',
-  entranceSem: data.entranceSem,
+  entranceSem: data.entranceSem ?? 'Fall',
   college: data.colleges.length !== 0 ? data.colleges[0].acronym : undefined,
   major: data.majors.map(({ acronym }) => acronym),
   minor: data.minors.map(({ acronym }) => acronym),

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -142,8 +142,10 @@ export const firestoreSemesterCourseToBottomBarCourse = ({
 
 export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
   // TODO: take into account multiple colleges
-  gradYear: data.gradYear ? data.gradYear : '',
-  entranceYear: data.entranceYear ? data.entranceYear : '',
+  gradYear: data.gradYear ?? '',
+  gradSem: data.gradSem,
+  entranceYear: data.entranceYear ?? '',
+  entranceSem: data.entranceSem,
   college: data.colleges.length !== 0 ? data.colleges[0].acronym : undefined,
   major: data.majors.map(({ acronym }) => acronym),
   minor: data.minors.map(({ acronym }) => acronym),

--- a/src/user-data-converter.ts
+++ b/src/user-data-converter.ts
@@ -144,9 +144,9 @@ export const firestoreSemesterCourseToBottomBarCourse = ({
 export const createAppOnboardingData = (data: FirestoreOnboardingUserData): AppOnboardingData => ({
   // TODO: take into account multiple colleges
   gradYear: data.gradYear ?? '',
-  gradSem: data.gradSem ?? 'Spring',
+  gradSem: data.gradSem ?? '',
   entranceYear: data.entranceYear ?? '',
-  entranceSem: data.entranceSem ?? 'Fall',
+  entranceSem: data.entranceSem ?? '',
   college: data.colleges.length !== 0 ? data.colleges[0].acronym : undefined,
   major: data.majors.map(({ acronym }) => acronym),
   minor: data.minors.map(({ acronym }) => acronym),

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -59,9 +59,9 @@ type FirestoreTransferExam = {
 type FirestoreCollegeMajorMinorOrGrad = { readonly acronym: string };
 type FirestoreOnboardingUserData = {
   readonly gradYear: string;
-  readonly gradSem: FirestoreSemesterSeason | '';
+  readonly gradSem: FirestoreSemesterSeason;
   readonly entranceYear: string;
-  readonly entranceSem: FirestoreSemesterSeason | '';
+  readonly entranceSem: FirestoreSemesterSeason;
   readonly colleges: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly majors: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly minors: readonly FirestoreCollegeMajorMinorOrGrad[];
@@ -175,12 +175,11 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
 }
 
 // college and grad are optional fields: grad can be undefined if the user hasn't selected a grad program, and college can be undefined if the user has only selected a grad program.
-// gradSem and entranceSem can be undefined until user data is loaded in
 type AppOnboardingData = {
   readonly gradYear: string;
-  readonly gradSem: FirestoreSemesterSeason | '';
+  readonly gradSem: FirestoreSemesterSeason;
   readonly entranceYear: string;
-  readonly entranceSem: FirestoreSemesterSeason | '';
+  readonly entranceSem: FirestoreSemesterSeason;
   readonly college?: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -59,7 +59,9 @@ type FirestoreTransferExam = {
 type FirestoreCollegeMajorMinorOrGrad = { readonly acronym: string };
 type FirestoreOnboardingUserData = {
   readonly gradYear: string;
+  readonly gradSem: FirestoreSemesterSeason;
   readonly entranceYear: string;
+  readonly entranceSem: FirestoreSemesterSeason;
   readonly colleges: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly majors: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly minors: readonly FirestoreCollegeMajorMinorOrGrad[];
@@ -175,9 +177,9 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
 // college and grad are optional fields: grad can be undefined if the user hasn't selected a grad program, and college can be undefined if the user has only selected a grad program.
 type AppOnboardingData = {
   readonly gradYear: string;
-  readonly gradSem?: FirestoreSemesterSeason;
+  readonly gradSem: FirestoreSemesterSeason;
   readonly entranceYear: string;
-  readonly entranceSem?: FirestoreSemesterSeason;
+  readonly entranceSem: FirestoreSemesterSeason;
   readonly college?: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -59,9 +59,9 @@ type FirestoreTransferExam = {
 type FirestoreCollegeMajorMinorOrGrad = { readonly acronym: string };
 type FirestoreOnboardingUserData = {
   readonly gradYear: string;
-  readonly gradSem: FirestoreSemesterSeason;
+  readonly gradSem: FirestoreSemesterSeason | '';
   readonly entranceYear: string;
-  readonly entranceSem: FirestoreSemesterSeason;
+  readonly entranceSem: FirestoreSemesterSeason | '';
   readonly colleges: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly majors: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly minors: readonly FirestoreCollegeMajorMinorOrGrad[];
@@ -177,9 +177,9 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
 // college and grad are optional fields: grad can be undefined if the user hasn't selected a grad program, and college can be undefined if the user has only selected a grad program.
 type AppOnboardingData = {
   readonly gradYear: string;
-  readonly gradSem: FirestoreSemesterSeason;
+  readonly gradSem: FirestoreSemesterSeason | '';
   readonly entranceYear: string;
-  readonly entranceSem: FirestoreSemesterSeason;
+  readonly entranceSem: FirestoreSemesterSeason | '';
   readonly college?: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -59,9 +59,9 @@ type FirestoreTransferExam = {
 type FirestoreCollegeMajorMinorOrGrad = { readonly acronym: string };
 type FirestoreOnboardingUserData = {
   readonly gradYear: string;
-  readonly gradSem: FirestoreSemesterSeason;
+  readonly gradSem: FirestoreSemesterSeason | '';
   readonly entranceYear: string;
-  readonly entranceSem: FirestoreSemesterSeason;
+  readonly entranceSem: FirestoreSemesterSeason | '';
   readonly colleges: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly majors: readonly FirestoreCollegeMajorMinorOrGrad[];
   readonly minors: readonly FirestoreCollegeMajorMinorOrGrad[];
@@ -175,11 +175,12 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
 }
 
 // college and grad are optional fields: grad can be undefined if the user hasn't selected a grad program, and college can be undefined if the user has only selected a grad program.
+// gradSem and entranceSem can be undefined until user data is loaded in
 type AppOnboardingData = {
   readonly gradYear: string;
-  readonly gradSem: FirestoreSemesterSeason;
+  readonly gradSem: FirestoreSemesterSeason | '';
   readonly entranceYear: string;
-  readonly entranceSem: FirestoreSemesterSeason;
+  readonly entranceSem: FirestoreSemesterSeason | '';
   readonly college?: string;
   readonly major: readonly string[];
   readonly minor: readonly string[];


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request adds entrance and grad season inputs to the Onboarding modal. For new users, they default to Fall & Spring, and for existing users, they will not be able to re-submit onboarding until they are filled out.

This solves the issue in #618 where students that enter in Spring 2020 would be given the post Fall 2020 A&S reqs since we don't check semester season, just year. This also now implements @vaishnavi17 's code in #529 to base starter semesters off of entrance and grad seasons instead of just years

- [x] Added season dropdowns in onboarding with emojis. Initial choice is dependent on if user is new, see above.
- [x] Updated the review page to show the dropdown info
- [x] Updated error check code to block users from submitting unless seasons selected
- [x] Update Cypress tests to select semester seasons

### Test Plan <!-- Required -->

1. Test that for existing users, opening onboarding has 'Select one' placeholder text in the new dropdowns, and cannot be submitted until both are filled out. 
![image](https://user-images.githubusercontent.com/25535093/154336739-45ca9aca-c3a2-4287-bcc2-4e163d9b9b6b.png)

2. Test editing the fields and re-opening modal has season selections saved, and review page is accurate
![image](https://user-images.githubusercontent.com/25535093/154336973-cee7efab-7d5d-47ed-b1f8-c01de705b4e1.png)

3. Delete `user-onboarding-data` document for myself and confirm the the new flow, and Fall and Spring respectively selected by default
![image](https://user-images.githubusercontent.com/25535093/154336801-3a4684c5-2397-477a-ac79-dc7d39991b89.png)

4. Confirm #529 works - specifically that a user's starter semesters populate based on their starting and graduating season now (delete `user-onboarding-data` and `user-semesters)
 
![image](https://user-images.githubusercontent.com/25535093/154337932-14b6b17a-1b0b-4b09-bb6c-05fb3e5e5fe1.png)
(when selecting Spring 2018 and Fall 2022 as entrance/grad)

### Notes <!-- Optional -->

#618 can be modified after this is merged to use a user's entrance semester!

Some future suggestions based on this PR to make items for (are any of these a priority?)
1. Update TrackUsers analytics to change grad/entrance year counters to grad/entrance sem counters to we know how many spring admits etc. there are
2. Update Vaish's code to handle entrance or grad semesters besides Fall and Winter - selecting Spring or Winter does not populate the correct semesters