### PR TITLE
Remove console error imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,6 @@
     <link rel="icon" href="favicon.ico" />
     <title>CoursePlan</title>
 
-    <!-- Load required Bootstrap and BootstrapVue CSS -->
-    <link
-      type="text/css"
-      rel="stylesheet"
-      href="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.css"
-    />
-
     <!-- Hotjar Tracking Code for www.courseplan.io -->
     <script>
       (function (h, o, t, j, a, r) {
@@ -40,9 +33,6 @@
       crossorigin="anonymous"
     ></script>
 
-    <!-- Load Vue followed by BootstrapVue -->
-    <script src="//unpkg.com/vue@latest/dist/vue.min.js"></script>
-    <script src="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.js"></script>
     <!-- Load Optimize for AB Testing -->
     <script src="https://www.googleoptimize.com/optimize.js?id=OPT-5JTC6CX"></script>
   </head>


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request removes the imports that are failing in the console on CoursePlan.io as a result of Vue being updated to `v3.2.30`. As noted in #496, a similar attempt to remove a broken import, we manage Bootstrap through NPM and thus do not need the import lines that are failing.

![image](https://user-images.githubusercontent.com/25535093/153115327-b96299bc-edbd-4380-a634-2d2d75efc073.png)

### Test Plan <!-- Required -->

Ensure that the errors do not appear in the console logs of the deploy link.

Additionally, confirm CP works and is styled as expected. Specifically - confirm styling on the landing page, onboarding modal, and mobile views look as expected

### Notes <!-- Optional -->

Do we want to push to prod after this is merged since the console errors are on the live site?

### Blockers <!-- Optional -->

This resolves the blocker on all current PRs with the Cypress tests failing because there were console errors.