### PR TITLE
Revert "Add Spring 2022 Contributors to README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,6 @@ Then access http://localhost:8080/
 
 ## Contributors
 
-### SP22
-
-- **Will Spencer** - Developer
-- **Ben Shen** - Developer
-- **Noah Schiff** - Developer
-- **Yuxuan Chen** - Designer
-- **Robin Ahn** - Designer
-- **Kehui Guo** - Designer
-- **Miranda Yu** - PMM
-- **Jessica Feng** - TPM
-- **Michael Farkouh** - Co-PM
-- **Ein Chang** - Co-PM
-
 ### FA21
 
 - **Will Spencer** - Developer


### PR DESCRIPTION
### Summary <!-- Required -->
Reverts cornell-dti/course-plan#650 temporarily to get rid of the merge conflict on #649. 

Usually merge conflicts can better be resolved by merging the base branch into the target branch, but in this case we do not want to merge `beta-release` into `master` as it would push some of the commits on `beta-release` to `master` that should not be, such as #634 (because it was squashed instead of merged). I believe after #649 is merged (and not squashed) and the readme changes are re-added, there will no longer be a merge conflict in the next release as there will not be git confusion between squash and merge commits

### Test Plan <!-- Required -->
👀 