### PR TITLE
Add Warning Icon to Courses in Compact View

### DIFF
--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -15,7 +15,11 @@
         <div class="course-top">
           <div class="course-left">
             <div class="course-code" data-cyId="courseCode">{{ courseObj.code }}</div>
-            <course-caution v-if="!isReqCourse && compact" :course="courseObj" :isCompactView="true"/>
+            <course-caution
+              v-if="!isReqCourse && compact"
+              :course="courseObj"
+              :isCompactView="true"
+            />
           </div>
           <button v-if="!isReqCourse" class="course-dotRow" @click="openMenu">
             <img src="@/assets/images/dots/threeDots.svg" alt="open menu for course card" />
@@ -25,7 +29,7 @@
         <div v-if="!compact" class="course-info">
           <span class="course-credits">{{ creditString }}</span>
           <span v-if="semesterString" class="course-semesters">{{ semesterString }}</span>
-          <course-caution v-if="!isReqCourse" :course="courseObj" :isCompactView="false"/>
+          <course-caution v-if="!isReqCourse" :course="courseObj" :isCompactView="false" />
         </div>
       </div>
     </div>
@@ -224,9 +228,9 @@ export default defineComponent({
     align-items: center;
   }
 
-  &-left{
-        display: flex;
-        align-items: center;
+  &-left {
+    display: flex;
+    align-items: center;
   }
 
   &-top {

--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -13,7 +13,10 @@
     <div class="course-content" @click="courseOnClick()">
       <div class="course-main">
         <div class="course-top">
-          <div class="course-code" data-cyId="courseCode">{{ courseObj.code }}</div>
+          <div class="course-left">
+            <div class="course-code" data-cyId="courseCode">{{ courseObj.code }}</div>
+            <course-caution v-if="!isReqCourse && compact" :course="courseObj" :isCompactView="true"/>
+          </div>
           <button v-if="!isReqCourse" class="course-dotRow" @click="openMenu">
             <img src="@/assets/images/dots/threeDots.svg" alt="open menu for course card" />
           </button>
@@ -22,7 +25,7 @@
         <div v-if="!compact" class="course-info">
           <span class="course-credits">{{ creditString }}</span>
           <span v-if="semesterString" class="course-semesters">{{ semesterString }}</span>
-          <course-caution v-if="!isReqCourse" :course="courseObj" />
+          <course-caution v-if="!isReqCourse" :course="courseObj" :isCompactView="false"/>
         </div>
       </div>
     </div>
@@ -205,7 +208,7 @@ export default defineComponent({
   &-dotRow {
     padding: 8px 0;
     display: flex;
-    position: relative;
+    position: right;
     &:hover,
     &:active,
     &:focus {
@@ -217,8 +220,13 @@ export default defineComponent({
     width: calc(100% - #{$colored-grabber-width});
     padding: 0 1rem;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
     align-items: center;
+  }
+
+  &-left{
+        display: flex;
+        align-items: center;
   }
 
   &-top {
@@ -229,7 +237,6 @@ export default defineComponent({
   }
 
   &-code {
-    flex: 1 1 auto;
     font-size: 14px;
     line-height: 17px;
     color: $primaryGray;

--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -212,7 +212,8 @@ export default defineComponent({
   &-dotRow {
     padding: 8px 0;
     display: flex;
-    position: right;
+    position: relative;
+
     &:hover,
     &:active,
     &:focus {

--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -2,7 +2,7 @@
   <course-base-tooltip
     v-if="hasCourseCautions"
     :isInformation="false"
-    :hideVerticalBar="courseCautions.isPlaceholderWrongSemester"
+    :hideVerticalBar="courseCautions.isPlaceholderWrongSemester || isCompactView"
   >
     <div v-if="singleWarning">
       <div v-if="courseCautions.noMatchedRequirement">
@@ -92,6 +92,7 @@ export default defineComponent({
       required: true,
     },
     semesterIndex: { type: Number, required: false, default: 0 },
+    isCompactView: { type: Boolean, required: true}
   },
   computed: {
     courseCautions(): CourseCautions {

--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -92,7 +92,7 @@ export default defineComponent({
       required: true,
     },
     semesterIndex: { type: Number, required: false, default: 0 },
-    isCompactView: { type: Boolean, required: true}
+    isCompactView: { type: Boolean, required: true },
   },
   computed: {
     courseCautions(): CourseCautions {

--- a/src/components/Course/Placeholder.vue
+++ b/src/components/Course/Placeholder.vue
@@ -7,7 +7,11 @@
       <div class="placeholder-name" :class="{ 'placeholder-name--min': compact }">
         {{ placeholderObj.name }}
       </div>
-      <course-caution :course="placeholderObj" :semesterIndex="semesterIndex" :isCompactView="compact"/>
+      <course-caution
+        :course="placeholderObj"
+        :semesterIndex="semesterIndex"
+        :isCompactView="compact"
+      />
     </div>
   </div>
 </template>

--- a/src/components/Course/Placeholder.vue
+++ b/src/components/Course/Placeholder.vue
@@ -7,7 +7,7 @@
       <div class="placeholder-name" :class="{ 'placeholder-name--min': compact }">
         {{ placeholderObj.name }}
       </div>
-      <course-caution :course="placeholderObj" :semesterIndex="semesterIndex" />
+      <course-caution :course="placeholderObj" :semesterIndex="semesterIndex" :isCompactView="compact"/>
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Summary <!-- Required -->
Previously, the warning icon for courses did not display when in Compact view. This PR displays the warning icon to the right of the course name and ID in Compact view without modifying the Default view.

- [x] added `isCompactView` prop to CourseCaution.vue
- [x] modified style and structure of components in Course.vue

### Test Plan <!-- Required -->

1. Add a course to your plan that displays a warning (such as for being in the wrong semester)
2. Add a placeholder course to your plan
3. Verify that the appearance of the courses have not changed in Default view
4. Switch to Compact view
5. Verify that the warning icon is displayed and that the warning icon and the three dots are aligned correctly and that the placeholder course has not changed from before

#### Appearance Before PR
<img width="300" alt="image" src="https://user-images.githubusercontent.com/47431797/154626796-958e33ac-2a8f-4bbb-bc81-aea3b4458430.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/47431797/154626833-66a8b7d0-12ff-4bb1-ba33-2a4e887f535e.png">

#### Appearance After PR
<img width="300" alt="image" src="https://user-images.githubusercontent.com/47431797/154626880-400468b6-568e-4156-ae1a-bbf47c4bb425.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/47431797/154626917-6332849d-fc7b-425e-8f41-60abfb049232.png">