### PR TITLE
Course Conflict Modal Frontend

### DIFF
--- a/src/components/Modals/NewCourse/CourseConflictModal.vue
+++ b/src/components/Modals/NewCourse/CourseConflictModal.vue
@@ -1,0 +1,86 @@
+<template>
+  <TeleportModal
+    title="Fix Course Conflict"
+    content-class="content-course"
+    :rightButtonText="rightButtonText"
+    :rightButtonIsDisabled="selectedCourse == null"
+    @modal-closed="closeCurrentModal"
+    @right-button-clicked="addItem"
+  >
+    <!-- TODO @willespencer factor out selected course? -->
+    <div class="courseConflict-text">Selected Course</div>
+    <div class="selected-course" data-cyId="courseConflict-selectedCourse">
+      {{ selectedCourse.code }}:
+      {{ selectedCourse.name }}
+    </div>
+  </TeleportModal>
+</template>
+
+<script lang="ts">
+import { PropType, defineComponent } from 'vue';
+import TeleportModal from '@/components/Modals/TeleportModal.vue';
+
+export default defineComponent({
+  components: { TeleportModal },
+  emits: {
+    'close-course-modal': () => true,
+    'add-course': (course: CornellCourseRosterCourse, choice: FirestoreCourseOptInOptOutChoices) =>
+      typeof course === 'object' && typeof choice === 'object',
+  },
+  props: {
+    selectedCourse: { type: Object as PropType<FirestoreSemesterCourse>, required: true },
+  },
+  computed: {
+    conflictsResolved(): boolean {
+      // TODO @willespencer update method to determine if conflicts are fully resolved
+      return true;
+    },
+    rightButtonText(): string {
+      return this.conflictsResolved ? 'Done' : 'Save';
+    },
+  },
+  methods: {
+    closeCurrentModal() {
+      this.$emit('close-course-modal');
+    },
+    addItem() {
+      this.addCourse();
+    },
+    addCourse() {
+      // TODO @willespencer handle what happens when conflicts are saved or resolved
+      this.closeCurrentModal();
+    },
+  },
+});
+</script>
+
+<style lang="scss">
+@import '@/assets/scss/_variables.scss';
+.courseConflict {
+  &-text {
+    font-size: 14px;
+    line-height: 17px;
+    color: $lightPlaceholderGray;
+  }
+}
+
+.selected-course {
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 14px;
+  color: $black;
+  margin-bottom: 20px;
+  margin-top: 8px;
+}
+
+.content-course {
+  width: 27.75rem;
+}
+
+@media only screen and (max-width: $small-medium-breakpoint) {
+  .content-course {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/Modals/NewCourse/CourseConflictModal.vue
+++ b/src/components/Modals/NewCourse/CourseConflictModal.vue
@@ -87,7 +87,7 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 @import '@/assets/scss/_variables.scss';
 .courseConflict {
   &-text {

--- a/src/components/Modals/NewCourse/CourseConflictModal.vue
+++ b/src/components/Modals/NewCourse/CourseConflictModal.vue
@@ -13,6 +13,15 @@
       {{ selectedCourse.code }}:
       {{ selectedCourse.name }}
     </div>
+
+    <div class="courseConflict-description">
+      <span v-if="numConflicts <= 1"> This course can fulfill these requirements. Select one </span>
+      <div v-else>
+        <span>Please fix the following</span
+        ><span class="courseConflict--bold">{{ ` ${numConflicts} ` }}</span
+        ><span>conflicts</span>
+      </div>
+    </div>
   </TeleportModal>
 </template>
 
@@ -38,6 +47,10 @@ export default defineComponent({
     rightButtonText(): string {
       return this.conflictsResolved ? 'Done' : 'Save';
     },
+    numConflicts(): number {
+      // TODO @willespencer programatically determine this number instead of hardcoding
+      return 2;
+    },
   },
   methods: {
     closeCurrentModal() {
@@ -61,6 +74,10 @@ export default defineComponent({
     font-size: 14px;
     line-height: 17px;
     color: $lightPlaceholderGray;
+  }
+
+  &--bold {
+    font-weight: bold;
   }
 }
 

--- a/src/components/Modals/NewCourse/CourseConflictModal.vue
+++ b/src/components/Modals/NewCourse/CourseConflictModal.vue
@@ -26,10 +26,10 @@
       </div>
     </div>
 
-    <div v-for="index in numConflicts" :key="index">
+    <div v-for="index in numConflicts" :key="index" class="courseConflict-conflict">
       <div v-if="numConflicts > 1">{{ `${index}. Choose only one requirement:` }}</div>
       <single-conflict-editor />
-      <div v-if="index === 1">
+      <div v-if="index === 1" class="courseConflict-warning">
         <span>*Requirements with</span>
         <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning icon" />
         <span>are broad so check carefully before selecting them</span>
@@ -63,7 +63,7 @@ export default defineComponent({
     },
     numConflicts(): number {
       // TODO @willespencer programatically determine this number instead of hardcoding
-      return 1;
+      return 2;
     },
     errorText(): string {
       if (!this.conflictsResolved) {
@@ -94,6 +94,16 @@ export default defineComponent({
     font-size: 14px;
     line-height: 17px;
     color: $lightPlaceholderGray;
+  }
+
+  &-conflict {
+    margin-top: 1rem;
+  }
+
+  &-warning {
+    font-size: 12px;
+    color: $medium;
+    margin-top: 1rem;
   }
 
   &--bold {

--- a/src/components/Modals/NewCourse/CourseConflictModal.vue
+++ b/src/components/Modals/NewCourse/CourseConflictModal.vue
@@ -4,6 +4,7 @@
     content-class="content-course"
     :rightButtonText="rightButtonText"
     :rightButtonIsDisabled="selectedCourse == null"
+    :errorText="errorText"
     @modal-closed="closeCurrentModal"
     @right-button-clicked="addItem"
   >
@@ -15,11 +16,23 @@
     </div>
 
     <div class="courseConflict-description">
-      <span v-if="numConflicts <= 1"> This course can fulfill these requirements. Select one </span>
+      <span v-if="numConflicts <= 1">
+        This course can fulfill these requirements. Select one:
+      </span>
       <div v-else>
         <span>Please fix the following</span
         ><span class="courseConflict--bold">{{ ` ${numConflicts} ` }}</span
         ><span>conflicts</span>
+      </div>
+    </div>
+
+    <div v-for="index in numConflicts" :key="index">
+      <div v-if="numConflicts > 1">{{ `${index}. Choose only one requirement:` }}</div>
+      <single-conflict-editor />
+      <div v-if="index === 1">
+        <span>*Requirements with</span>
+        <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning icon" />
+        <span>are broad so check carefully before selecting them</span>
       </div>
     </div>
   </TeleportModal>
@@ -28,9 +41,10 @@
 <script lang="ts">
 import { PropType, defineComponent } from 'vue';
 import TeleportModal from '@/components/Modals/TeleportModal.vue';
+import SingleConflictEditor from '@/components/Modals/NewCourse/SingleConflictEditor.vue';
 
 export default defineComponent({
-  components: { TeleportModal },
+  components: { TeleportModal, SingleConflictEditor },
   emits: {
     'close-course-modal': () => true,
     'add-course': (course: CornellCourseRosterCourse, choice: FirestoreCourseOptInOptOutChoices) =>
@@ -49,7 +63,13 @@ export default defineComponent({
     },
     numConflicts(): number {
       // TODO @willespencer programatically determine this number instead of hardcoding
-      return 2;
+      return 1;
+    },
+    errorText(): string {
+      if (!this.conflictsResolved) {
+        return 'Conflict: Please only choose one requirement';
+      }
+      return '';
     },
   },
   methods: {
@@ -99,5 +119,13 @@ export default defineComponent({
   .content-course {
     width: 100%;
   }
+}
+
+.warning-icon {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  margin-bottom: 0.25rem;
+  width: 14px;
+  height: 14px;
 }
 </style>

--- a/src/components/Modals/NewCourse/SingleConflictEditor.vue
+++ b/src/components/Modals/NewCourse/SingleConflictEditor.vue
@@ -1,0 +1,1 @@
+<template><div></div></template>

--- a/src/components/Modals/NewCourse/SingleConflictEditor.vue
+++ b/src/components/Modals/NewCourse/SingleConflictEditor.vue
@@ -8,7 +8,10 @@
       </div>
       <div class="conflictEditor-req">
         <input type="checkbox" value="selectableReq" v-model="picked" />
-        <label for="selectableReq" class="conflictEditor-label">Selectable Req #1</label>
+        <label for="selectableReq" class="conflictEditor-label">
+          <img class="warning-icon" src="@/assets/images/warning.svg" alt="warning icon" />
+          Selectable Req #1</label
+        >
       </div>
     </div>
   </div>
@@ -19,7 +22,7 @@ import { defineComponent } from 'vue';
 export default defineComponent({});
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .conflictEditor {
   &-label {
     margin-left: 0.75rem;
@@ -39,5 +42,12 @@ export default defineComponent({});
     margin-top: 0.125rem;
     margin-bottom: 0.125rem;
   }
+}
+
+.warning-icon {
+  margin-right: 0.125rem;
+  margin-bottom: 0.25rem;
+  width: 14px;
+  height: 14px;
 }
 </style>

--- a/src/components/Modals/NewCourse/SingleConflictEditor.vue
+++ b/src/components/Modals/NewCourse/SingleConflictEditor.vue
@@ -1,1 +1,43 @@
-<template><div></div></template>
+<template>
+  <div>
+    <!-- TODO @willespencer programatically generate conflicts -->
+    <div class="conflictEditor-reqs">
+      <div class="conflictEditor-req">
+        <input type="checkbox" value="req" v-model="picked" />
+        <label for="req" class="conflictEditor-label">Requirement #1</label>
+      </div>
+      <div class="conflictEditor-req">
+        <input type="checkbox" value="selectableReq" v-model="picked" />
+        <label for="selectableReq" class="conflictEditor-label">Selectable Req #1</label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+export default defineComponent({});
+</script>
+
+<style lang="scss">
+.conflictEditor {
+  &-label {
+    margin-left: 0.75rem;
+  }
+
+  &-reqs {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &-req {
+    display: flex;
+    align-items: center;
+  }
+
+  &-label {
+    margin-top: 0.125rem;
+    margin-bottom: 0.125rem;
+  }
+}
+</style>

--- a/src/components/Modals/TeleportModal.vue
+++ b/src/components/Modals/TeleportModal.vue
@@ -26,6 +26,7 @@
           <button v-if="leftButtonText" class="modal-button" @click="leftButtonClicked">
             {{ leftButtonText }}
           </button>
+          <div v-if="errorText" class="modal-error">{{ errorText }}</div>
           <button
             class="modal-button modal-button--add"
             :class="{ 'modal-button--disabled': rightButtonIsDisabled }"
@@ -59,6 +60,7 @@ export default defineComponent({
     rightButtonImage: { type: String, default: '' },
     rightButtonAlt: { type: String, default: '' },
     rightButtonIsDisabled: { type: Boolean, default: false },
+    errorText: { type: String, default: '' },
     isSimpleModal: { type: Boolean, default: false }, // true if the modal will set its own styling for its position
     hasNoBackground: { type: Boolean, default: false }, // true for modals without the gray overlay behind them
     hasClickableTransparentBackground: { type: Boolean, default: false }, // modals without a gray overlay behind them AND clicking on the background closes the modal
@@ -176,6 +178,7 @@ export default defineComponent({
     margin-top: 1rem;
     display: flex;
     justify-content: flex-end;
+    align-items: center;
   }
 
   &-button {
@@ -202,6 +205,11 @@ export default defineComponent({
       border: 1px solid $sangBlue;
       background-color: $disabledGray;
     }
+  }
+
+  &-error {
+    color: $error;
+    margin-right: 0.5rem;
   }
 }
 

--- a/src/components/Modals/TeleportModal.vue
+++ b/src/components/Modals/TeleportModal.vue
@@ -23,7 +23,7 @@
         </div>
         <slot class="modal-body"></slot>
         <div v-if="!isSimpleModal" class="modal-buttonWrapper">
-          <button class="modal-button" @click="leftButtonClicked">
+          <button v-if="leftButtonText" class="modal-button" @click="leftButtonClicked">
             {{ leftButtonText }}
           </button>
           <button

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -397,6 +397,7 @@ export default defineComponent({
       this.openConfirmationModal(`Added ${courseCode} to ${this.season} ${this.year}`);
 
       // TODO @willespencer handle opening conflict modal better
+      // should not add course if it is opening, should happen after first step of adding a course, and should not happen if no conflicts
       if (this.handleRequirementConflicts) {
         this.openConflictModal(newCourse);
       }

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -2,10 +2,16 @@
 const GateKeeperTogglers: Record<string, () => void> = {};
 
 // Register your new feature flags below, both in type and in `registerFeatureFlagChecker`.
-type FeatureFlagName = 'Case' | 'RequirementDebugger' | 'ToggleRequirementsBarBtn' | 'Tools';
+type FeatureFlagName =
+  | 'Case'
+  | 'RequirementConflicts'
+  | 'RequirementDebugger'
+  | 'ToggleRequirementsBarBtn'
+  | 'Tools';
 /* | 'AddYourFeatureFlagNameHere' */
 const featureFlagCheckers: FeatureFlagCheckers = registerFeatureFlagChecker(
   'Case',
+  'RequirementConflicts',
   'RequirementDebugger',
   'ToggleRequirementsBarBtn',
   'Tools'


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements the course conflict resolution modal front-end

- [x] implemented X
- [x] fixed Y

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:
- [ ] style checkboxes to be CP blue
- [ ] fix when the modal pops up with gatekeep
- [ ] count conflict as resolved when only 1 checkmark selected
- [ ] fix all my TODOs
- [ ] implement Z

<!--- Note dependencies on other PRs if any. -->

Depends on #{number of PR}


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Blockers <!-- Optional -->

<!--- Note and itemize any blockers (especially for WIP PRs) here and on Notion -->

- A newly discovered dependency that hasn’t been addressed

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->

- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)
