### PR TITLE
Cypress: Add accessibility testing suite

### DIFF
--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -3,29 +3,29 @@
  * Can and should be expanded in the future.
  */
 
-// Before running tests, starts on landing page, logs in to firebase, then visits the dashboard
+// Before running tests, start on landing page, login to firebase, and inject accessibility scripts
 // Log in occurs with TEST_UID of the courseplan testing account using a function from the cypress-firebase package
-before('Visit site logged in', () => {
+before('Visit landing page logged in', () => {
   cy.visit('localhost:8080/login');
   cy.login(Cypress.env('TEST_UID'));
-  cy.visit('localhost:8080');
+
   // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(5000); // ensure the page has time to load
+  cy.wait(2000); // ensure the page has time to load
+
+  cy.injectAxe(); // inject the axe-core library to check accessibility
 });
 
-// Confirm that a semester can be added to the plan
-it('Add a semester (Fall of oldest year)', () => {
-  // open the new semester modal
-  cy.get('[data-cyId=semesterView-addSemesterButton]').click();
+it('Check landing page accessibility', () => {
+  cy.checkA11y();
+});
 
-  // click Fall
-  cy.get('[data-cyId=newSemester-seasonWrapper]').click();
-  cy.get('[data-cyId=newSemester-seasonItem]').first().click();
+it('Visit dashboard and check dashboard accessibility', () => {
+  cy.visit('localhost:8080');
 
-  // click oldest year
-  cy.get('[data-cyId=newSemester-yearWrapper]').click();
-  cy.get('[data-cyId=newSemester-yearItem]').first().click();
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(5000); // ensure the page has time to load
 
-  // add semester
-  cy.get('[data-cyId=modal-button]').click();
+  cy.injectAxe(); // re-inject the library due to switching page
+
+  cy.checkA11y();
 });

--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -1,5 +1,5 @@
 /**
- * A test file that tests accessibility on all parts of CoursePlan
+ * A test file that tests accessibility on all views of CoursePlan
  * Can and should be expanded in the future.
  */
 
@@ -19,7 +19,7 @@ it('Check landing page accessibility', () => {
   cy.checkA11y();
 });
 
-it('Visit dashboard and check dashboard accessibility', () => {
+it('Visit dashboard and check semesterview accessibility', () => {
   cy.visit('localhost:8080');
 
   // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -27,13 +27,26 @@ it('Visit dashboard and check dashboard accessibility', () => {
 
   cy.injectAxe(); // re-inject the library due to switching page
 
-  cy.checkA11y();
+  cy.checkA11y('[data-cyId=semesterView]'); // only check accessibility within the semesterView
 });
 
-// Check the accessibility of the bottom bar
-// Note that a course must be added in case the plan is empty to do so
+it('Check navbar accessibility', () => {
+  cy.checkA11y('[data-cyId=navbar]'); // only check accessibility within the navbar
+});
+
+// Check the accessibility of the requirements sidebar with all toggles fully open
+// Note that the selector in checkA11y ensures only the sidebar is inspected
+it('Check accessibility of the requirements sidebar', () => {
+  // open all dropdowns in the sidebar
+  cy.get('[data-cyId=requirements-viewMore]').click({ multiple: true });
+  cy.get('[data-cyId=requirements-showCompleted]').click({ multiple: true });
+  cy.get('[data-cyId=requirements-displayToggle]').click({ multiple: true });
+
+  cy.checkA11y('[data-cyId=reqsSidebar]');
+});
+
 it('Check accessibility of the bottom bar', () => {
-  // open add modal and try to add CS 1110
+  // Note that a course must be added in case the plan is empty to do so
   cy.get('[data-cyId=semester-addCourse]').click();
   cy.get('[data-cyId=newCourse-dropdown]').type('CS 1110');
   cy.get('[data-cyId=newCourse-searchResult]').first().click();

--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -30,23 +30,43 @@ it('Visit dashboard and check dashboard accessibility', () => {
   cy.checkA11y();
 });
 
+// Check the accessibility of the bottom bar
+// Note that a course must be added in case the plan is empty to do so
+it('Check accessibility of the bottom bar', () => {
+  // open add modal and try to add CS 1110
+  cy.get('[data-cyId=semester-addCourse]').click();
+  cy.get('[data-cyId=newCourse-dropdown]').type('CS 1110');
+  cy.get('[data-cyId=newCourse-searchResult]').first().click();
+  cy.get('[data-cyId=modal-button]').click();
+
+  // open the bottom bar
+  cy.get('[data-cyId=semester-course]').eq(0).click();
+
+  cy.checkA11y('[data-cyId=bottombar]'); // only check accessibility within the bottom bar
+});
+
 // Check the accessibility of each page of Onboarding
 // Note that the selector in checkA11y ensures violations behind the modal are not caught
 it('Check accessibility of onboarding modal pages', () => {
   cy.get('[data-cyId=editProfile]').click();
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(500);
   cy.checkA11y('[data-cyId=onboarding]'); // only check accessibility within the onboarding modal
 
   cy.get('[data-cyId=onboarding-nextButton]').click();
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(500);
   cy.checkA11y('[data-cyId=onboarding]');
 
   cy.get('[data-cyId=onboarding-nextButton]').click();
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(500);
   cy.checkA11y('[data-cyId=onboarding]');
 
   cy.get('[data-cyId=onboarding-finishButton]').click();
+});
+
+it('Visit privacy policy and check accessibility', () => {
+  cy.visit('localhost:8080/policy');
+
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(2000); // ensure the page has time to load
+
+  cy.injectAxe(); // re-inject the library due to switching page
+
+  cy.checkA11y();
 });

--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -29,3 +29,24 @@ it('Visit dashboard and check dashboard accessibility', () => {
 
   cy.checkA11y();
 });
+
+// Check the accessibility of each page of Onboarding
+// Note that the selector in checkA11y ensures violations behind the modal are not caught
+it('Check accessibility of onboarding modal pages', () => {
+  cy.get('[data-cyId=editProfile]').click();
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(500);
+  cy.checkA11y('[data-cyId=onboarding]'); // only check accessibility within the onboarding modal
+
+  cy.get('[data-cyId=onboarding-nextButton]').click();
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(500);
+  cy.checkA11y('[data-cyId=onboarding]');
+
+  cy.get('[data-cyId=onboarding-nextButton]').click();
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(500);
+  cy.checkA11y('[data-cyId=onboarding]');
+
+  cy.get('[data-cyId=onboarding-finishButton]').click();
+});

--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -1,0 +1,31 @@
+/**
+ * A test file that tests accessibility on all parts of CoursePlan
+ * Can and should be expanded in the future.
+ */
+
+// Before running tests, starts on landing page, logs in to firebase, then visits the dashboard
+// Log in occurs with TEST_UID of the courseplan testing account using a function from the cypress-firebase package
+before('Visit site logged in', () => {
+  cy.visit('localhost:8080/login');
+  cy.login(Cypress.env('TEST_UID'));
+  cy.visit('localhost:8080');
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(5000); // ensure the page has time to load
+});
+
+// Confirm that a semester can be added to the plan
+it('Add a semester (Fall of oldest year)', () => {
+  // open the new semester modal
+  cy.get('[data-cyId=semesterView-addSemesterButton]').click();
+
+  // click Fall
+  cy.get('[data-cyId=newSemester-seasonWrapper]').click();
+  cy.get('[data-cyId=newSemester-seasonItem]').first().click();
+
+  // click oldest year
+  cy.get('[data-cyId=newSemester-yearWrapper]').click();
+  cy.get('[data-cyId=newSemester-yearItem]').first().click();
+
+  // add semester
+  cy.get('[data-cyId=modal-button]').click();
+});

--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -1,6 +1,7 @@
 /**
  * A test file that tests accessibility on all views of CoursePlan
  * Can and should be expanded in the future.
+ * TODO @willespencer remove the skipFailures flag set to true in checkA11y once accessibility issues have been resolved
  */
 
 // Before running tests, start on landing page, login to firebase, and inject accessibility scripts
@@ -16,7 +17,7 @@ before('Visit landing page logged in', () => {
 });
 
 it('Check landing page accessibility', () => {
-  cy.checkA11y();
+  cy.checkA11y(null, null, null, true);
 });
 
 it('Visit dashboard and check semesterview accessibility', () => {
@@ -27,11 +28,11 @@ it('Visit dashboard and check semesterview accessibility', () => {
 
   cy.injectAxe(); // re-inject the library due to switching page
 
-  cy.checkA11y('[data-cyId=semesterView]'); // only check accessibility within the semesterView
+  cy.checkA11y('[data-cyId=semesterView]', null, null, true); // only check accessibility within the semesterView
 });
 
 it('Check navbar accessibility', () => {
-  cy.checkA11y('[data-cyId=navbar]'); // only check accessibility within the navbar
+  cy.checkA11y('[data-cyId=navbar]', null, null, true); // only check accessibility within the navbar
 });
 
 // Check the accessibility of the requirements sidebar with all toggles fully open
@@ -55,20 +56,20 @@ it('Check accessibility of the bottom bar', () => {
   // open the bottom bar
   cy.get('[data-cyId=semester-course]').eq(0).click();
 
-  cy.checkA11y('[data-cyId=bottombar]'); // only check accessibility within the bottom bar
+  cy.checkA11y('[data-cyId=bottombar]', null, null, true); // only check accessibility within the bottom bar
 });
 
 // Check the accessibility of each page of Onboarding
 // Note that the selector in checkA11y ensures violations behind the modal are not caught
 it('Check accessibility of onboarding modal pages', () => {
   cy.get('[data-cyId=editProfile]').click();
-  cy.checkA11y('[data-cyId=onboarding]'); // only check accessibility within the onboarding modal
+  cy.checkA11y('[data-cyId=onboarding]', null, null, true); // only check accessibility within the onboarding modal
 
   cy.get('[data-cyId=onboarding-nextButton]').click();
-  cy.checkA11y('[data-cyId=onboarding]');
+  cy.checkA11y('[data-cyId=onboarding]', null, null, true);
 
   cy.get('[data-cyId=onboarding-nextButton]').click();
-  cy.checkA11y('[data-cyId=onboarding]');
+  cy.checkA11y('[data-cyId=onboarding]', null, null, true);
 
   cy.get('[data-cyId=onboarding-finishButton]').click();
 });
@@ -81,5 +82,5 @@ it('Visit privacy policy and check accessibility', () => {
 
   cy.injectAxe(); // re-inject the library due to switching page
 
-  cy.checkA11y();
+  cy.checkA11y(null, null, null, true);
 });

--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -84,3 +84,14 @@ it('Visit privacy policy and check accessibility', () => {
 
   cy.checkA11y(null, null, null, true);
 });
+
+it('Visit 404 page and check accessibility', () => {
+  cy.visit('localhost:8080/404');
+
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(2000); // ensure the page has time to load
+
+  cy.injectAxe(); // re-inject the library due to switching page
+
+  cy.checkA11y(null, null, null, true);
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,5 +16,8 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
+// Import cypress-axe commands to test accessibility
+import 'cypress-axe';
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "bootstrap": "^4.6.0",
         "bootstrap-vue": "^2.21.2",
         "core-js": "^3.6.5",
+        "cypress-axe": "^0.14.0",
         "cypress-firebase": "^1.8.0",
         "firebase": "^8.3.1",
         "firebase-admin": "^9.6.0",
@@ -6235,6 +6236,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
       "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
+    "node_modules/axe-core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+      "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -8059,6 +8069,18 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.14.0.tgz",
+      "integrity": "sha512-7Rdjnko0MjggCmndc1wECAkvQBIhuy+DRtjF7bd5YPZRFvubfMNvrxfqD8PWQmxm7MZE0ffS4Xr43V6ZmvLopg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
     "node_modules/cypress-firebase": {
@@ -26471,6 +26493,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
       "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
+    "axe-core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+      "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+      "peer": true
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -28165,6 +28193,12 @@
           }
         }
       }
+    },
+    "cypress-axe": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.14.0.tgz",
+      "integrity": "sha512-7Rdjnko0MjggCmndc1wECAkvQBIhuy+DRtjF7bd5YPZRFvubfMNvrxfqD8PWQmxm7MZE0ffS4Xr43V6ZmvLopg==",
+      "requires": {}
     },
     "cypress-firebase": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bootstrap": "^4.6.0",
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",
+    "cypress-axe": "^0.14.0",
     "cypress-firebase": "^1.8.0",
     "firebase": "^8.3.1",
     "firebase-admin": "^9.6.0",

--- a/src/components/BottomBar/BottomBar.vue
+++ b/src/components/BottomBar/BottomBar.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="bottombar" :class="{ wideBar: isNavbarWide }" v-if="hasBottomBarCourses">
+  <div
+    class="bottombar"
+    data-cyId="bottombar"
+    :class="{ wideBar: isNavbarWide }"
+    v-if="hasBottomBarCourses"
+  >
     <div class="bottombar-tabview" :class="{ expandedTabView: isExpanded }">
       <bottom-bar-tab-view :maxBottomBarTabs="maxBottomBarTabs" />
     </div>

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -1,6 +1,7 @@
 <template>
   <main
     class="semesterView"
+    data-cyId="semesterView"
     :class="{
       bottomBar: isBottomBar && isBottomBarExpanded,
       expandedBottomBarSemesterView: isBottomBarExpanded,

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -13,6 +13,7 @@
       <div class="dashboard-menus">
         <nav-bar
           class="dashboard-nav"
+          data-cyId="navbar"
           :isDisplayingRequirementsMobile="requirementsIsDisplayedMobile"
           @openPlan="openPlan"
           @openTools="openTools"
@@ -21,6 +22,7 @@
         />
         <requirement-side-bar
           class="dashboard-reqs"
+          data-cyId="reqsSidebar"
           v-if="loaded && !showToolsPage"
           :isMobile="isTablet"
           :isDisplayingMobile="requirementsIsDisplayedMobile"


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request creates a testing suite for accessibility issues on all views of CoursePlan. Specifically, the [cypress-axe](https://www.npmjs.com/package/cypress-axe) package is imported, which can be used to find "57% of WCAG issues automatically" based on this [ruleset](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)

See [Dev Assignment](https://www.notion.so/courseplan/Dev-Assignments-a40f92912d0248dab11df9a68df4ba5c?p=3569fff1cf2c4fb49d0f76dbd17e4707) for more details.

- [x] Install the `cypress-axe` package, add to Cypress, and inject after visiting a page
- [x] Create a new spec test file `accessibility-spec.ts` 
- [x] Add tests for the main components of CoursePlan (semester view, reqs bar, and navbar)
- [x] Add tests for hidden large components of CoursePlan (bottom bar and onboarding modal pages)
- [x] Add tests for other public-facing pages (landing page, 404 page, and privacy policy)

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs (for a follow-up PR)

- [ ] Resolve the WCAG errors found by the new testing suite
- [ ] Remove the `skipFailures` flag so that errors on these tests fail the CI in the future (after current ones are resolved)

### Test Plan <!-- Required -->

1. Confirm that (without the `skipFailures` flag) the new tests correctly identify WCAG errors in the components they are meant to test.

Example: Bottom bar test, only identifies 2 WCAG issues on the bottom bar
![image](https://user-images.githubusercontent.com/25535093/157335595-6cf3a380-73d9-4e2e-8467-17f1c7df224f.png)
(Additionally note that 7/8 of the tests fail)

2. Confirm that after the flag is added, the CI check passes (meaning all the tests pass).
![image](https://user-images.githubusercontent.com/25535093/157335754-fc5db25a-8d96-4acf-bb21-1cff07e0aec1.png)

### Notes <!-- Optional -->

Instead of using the `skipFailures` flag, I could have instead opted to set an option to only allow certain types of WCAG issues to cause a CI error ("minor", "moderate", "serious", or "critical"). Because setting it to critical still caused 3+ of the new tests to fail, I decided to opt to skip them entirely until a new PR resolves them, at which point the `options` flag could be considered.