### PR TITLE
Remove Star from Info Fields in Onboarding Review Page

### DIFF
--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -15,9 +15,7 @@
         </div>
         <div class="onboarding-selectWrapperRow-review">
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span> First Name<span class="onboarding-required-star">*</span></span></label
-            >
+            <label class="onboarding-label"><span> First Name</span></label>
             <label class="onboarding-label--review"
               ><span> {{ userName.firstName }}</span></label
             >
@@ -29,9 +27,7 @@
             >
           </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span>Last Name<span class="onboarding-required-star">*</span></span></label
-            >
+            <label class="onboarding-label"><span>Last Name</span></label>
             <label class="onboarding-label--review"
               ><span> {{ userName.lastName }}</span></label
             >
@@ -39,17 +35,13 @@
           <div
             class="onboarding-inputWrapper onboarding-inputWrapper--name onboarding-inputWrapper--description"
           >
-            <label class="onboarding-label"
-              ><span>Entrance Season<span class="onboarding-required-star">*</span></span></label
-            >
+            <label class="onboarding-label"><span>Entrance Season</span></label>
             <label class="onboarding-label--review"
               ><span data-cyId="onboarding-entranceSeason">{{ entranceSemText }}</span></label
             >
           </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span>Entrance Year<span class="onboarding-required-star">*</span></span></label
-            >
+            <label class="onboarding-label"><span>Entrance Year</span></label>
             <label class="onboarding-label--review"
               ><span data-cyId="onboarding-entranceYear">{{ entranceYearText }}</span></label
             >
@@ -58,17 +50,13 @@
           <div
             class="onboarding-inputWrapper onboarding-inputWrapper--name onboarding-inputWrapper--noMargin"
           >
-            <label class="onboarding-label"
-              ><span>Graduation Season<span class="onboarding-required-star">*</span></span></label
-            >
+            <label class="onboarding-label"><span>Graduation Season</span></label>
             <label class="onboarding-label--review"
               ><span data-cyId="onboarding-gradSeason">{{ gradSemText }}</span></label
             >
           </div>
           <div class="onboarding-inputWrapper onboarding-inputWrapper--name">
-            <label class="onboarding-label"
-              ><span>Graduation Year<span class="onboarding-required-star">*</span></span></label
-            >
+            <label class="onboarding-label"><span>Graduation Year</span></label>
             <label class="onboarding-label--review"
               ><span data-cyId="onboarding-gradYear">{{ gradYearText }}</span></label
             >


### PR DESCRIPTION
### Summary <!-- Required -->

- [x] Removes the green star (*) after required fields on the Onboarding Review page.

Users can only reach the review page if they have filled out all the required information on the previous pages, so the star is not necessary. Furthermore, users cannot edit their information directly from this page, so it's not useful to remind the user that a field is required. I spoke with Kehui about this change, and she agreed that we can remove the star.

### Test Plan <!-- Required -->

Navigate to the Onboarding modal by clicking on "Profile" on the left sidebar, and verify that there are no green stars on the Review page. Also, ensure that there are still green stars for the required fields under the Basic Information page and general page structure and formatting has not changed.

<!-- Provide screenshots or point out the additional unit tests -->

#### Screenshots

| | Basic Information | Review Page |
|-| ----------- | ----------- |
| Before | <img alt="before" src="https://user-images.githubusercontent.com/47431797/159145021-7faa9003-cec1-4c62-b01c-36fd002223b4.png">      | <img alt="before" src="https://user-images.githubusercontent.com/47431797/159145026-7e89e459-27e7-445e-bcbb-0426a17b7f51.png">       |
|After | <img  alt="after" src="https://user-images.githubusercontent.com/47431797/159144996-dc60fdcc-f349-4e6a-b501-53effdd2ef92.png"> | <img  alt="after" src="https://user-images.githubusercontent.com/47431797/159145015-d156c3d3-3516-419e-851a-6a6968ef12a5.png">