### PR TITLE
Extend firebase deploy link expiration time

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,6 +21,7 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_CORNELLDTI_COURSEPLAN_DEV }}'
           projectId: cornelldti-courseplan-dev
+          expires: 30d
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels
           SECRET: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CORNELLDTI_COURSEPLAN_DEV }}


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request extends the firebase deploy link expiration date to last for 30 days after the most recent change instead of the default (~7 days). Documentation [here](https://github.com/marketplace/actions/deploy-to-firebase-hosting).

### Test Plan <!-- Required -->

Check if the expiration link on this PR is 30 days from today instead of 7 👀 

![image](https://user-images.githubusercontent.com/25535093/160936097-22673f46-f6c1-44ee-8513-696fe8dd7964.png)

### Notes <!-- Optional -->

This was done because with current PR progress, links have been expiring quite frequently.
