### PR TITLE
[easy] Put AP/IB fulfillment behind feature flag

### DIFF
--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -3,6 +3,7 @@ const GateKeeperTogglers: Record<string, () => void> = {};
 
 // Register your new feature flags below, both in type and in `registerFeatureFlagChecker`.
 type FeatureFlagName =
+  | 'APIBFulfillment'
   | 'Case'
   | 'RequirementConflicts'
   | 'RequirementDebugger'
@@ -10,6 +11,7 @@ type FeatureFlagName =
   | 'Tools';
 /* | 'AddYourFeatureFlagNameHere' */
 const featureFlagCheckers: FeatureFlagCheckers = registerFeatureFlagChecker(
+  'APIBFulfillment',
   'Case',
   'RequirementConflicts',
   'RequirementDebugger',

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -2,6 +2,7 @@ import requirementJson from './typed-requirement-json';
 import specialized from './specialize';
 import { examCourseIds } from './requirement-exam-mapping';
 import { getConstraintViolationsForSingleCourse } from './requirement-constraints-utils';
+import featureFlagCheckers from '@/feature-flags';
 
 /**
  * A collection of helper functions
@@ -263,6 +264,9 @@ export function getMatchedRequirementFulfillmentSpecification(
   ) =>
     coursesList.map(courses =>
       courses.filter(courseId => {
+        // do not include ap/ib course if feature flag is not toggled
+        if (!featureFlagCheckers.isAPIBFulfillmentEnabled() && examCourseIds.has(courseId))
+          return false;
         // allow course if there are no requirement conditions
         if (!(conditions && courseId in conditions)) return true;
         // otherwise, inspect conditions to see if we should disallow course

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -2,7 +2,7 @@ import requirementJson from './typed-requirement-json';
 import specialized from './specialize';
 import { examCourseIds } from './requirement-exam-mapping';
 import { getConstraintViolationsForSingleCourse } from './requirement-constraints-utils';
-import featureFlagCheckers from '@/feature-flags';
+import featureFlagCheckers from '../feature-flags';
 
 /**
  * A collection of helper functions


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request puts AP/IB fulfillment behind the feature flag `APIBFulfillment`.

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Check that AP/IB credit does not count until you set the flag via `GK.enableAPIBFulfillment()`.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
By default, this stops AP/IB credit from counting. When pushed to prod, all users will have AP/IB fulfillments removed (maybe this motivates a public change log if people end up being confused).
