### PR TITLE
Honors Physics Track for College of Engineering

### DIFF
--- a/src/requirements/data/colleges/en.ts
+++ b/src/requirements/data/colleges/en.ts
@@ -38,13 +38,13 @@ const engineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {
     name: 'Physics',
     description:
-      'PHYS 1112 and 2213, and, depending on the Major, either PHYS 2214 or a designated mathematics or science course.',
+    'The normal program in physics includes PHYS 1112, PHYS 2213, and PHYS 2214 or the corresponding honors courses (PHYS 1116, PHYS 2217, and PHYS 2218). Depending on the major, a designated mathematics or science course can be substituted for PHYS 2214/2218.',
     source:
-      'https://www.engineering.cornell.edu/students/undergraduate-students/curriculum/undergraduate-requirements',
-    checker: includesWithSubRequirements(['PHYS 1112'], ['PHYS 2213']),
+      'https://courses.cornell.edu/content.php?catoid=45&navoid=17985#Engineering_Core_Requirements',
+    checker: includesWithSubRequirements(['PHYS 1112', 'PHYS 1116'], ['PHYS 2213', 'PHYS 2217']),
     fulfilledBy: 'courses',
     perSlotMinCount: [1, 1],
-    slotNames: ['PHYS 1112', 'PHYS 2213'],
+    slotNames: ['PHYS 1112 or PHYS 1116', 'PHYS 2213 or PHYS 2217'],
   },
   {
     name: 'Chemistry',

--- a/src/requirements/data/colleges/en.ts
+++ b/src/requirements/data/colleges/en.ts
@@ -38,7 +38,8 @@ const engineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {
     name: 'Physics',
     description:
-    'The normal program in physics includes PHYS 1112, PHYS 2213, and PHYS 2214 or the corresponding honors courses (PHYS 1116, PHYS 2217, and PHYS 2218). Depending on the major, a designated mathematics or science course can be substituted for PHYS 2214/2218.',
+      'The normal program in physics includes PHYS 1112, PHYS 2213, and PHYS 2214 or the corresponding honors courses (PHYS 1116, PHYS 2217, and PHYS 2218).' +
+      ' Depending on the major, a designated mathematics or science course can be substituted for PHYS 2214/2218.',
     source:
       'https://courses.cornell.edu/content.php?catoid=45&navoid=17985#Engineering_Core_Requirements',
     checker: includesWithSubRequirements(['PHYS 1112', 'PHYS 1116'], ['PHYS 2213', 'PHYS 2217']),


### PR DESCRIPTION
### Summary <!-- Required -->

Add the honors sequence for physics in the College of Engineering.

- [x] Add PHYS 1116 as an alternate option for PHYS 1112 and add PHYS 2217 as an alternate option for PHYS 2213.
- [x] Update description for physics requirement.

### Test Plan <!-- Required -->

Verify that PHYS 1116 can be substituted for PHYS 1112 and that PHYS 2217 can be substituted for PHYS 2213 in the physics requirement for Engineering.