### PR TITLE
Add new warning to transfer page of onboarding

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -527,6 +527,7 @@ input {
   &-transferCreditDescription {
     font-size: 14px;
     color: $secondaryGray;
+    margin-top: 1rem;
     a {
       color: $yuxuanBlue;
     }

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -533,6 +533,18 @@ input {
     }
   }
 
+  &-transferCreditWarning {
+    color: $warning;
+    margin-top: 1.5rem;
+  }
+
+  &-warningIcon {
+    float: left;
+    margin: 0.125rem 0.25rem 0 0;
+    width: 14px;
+    height: 14px;
+  }
+
   &-transferCredits {
     padding-top: 0;
   }

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -52,6 +52,10 @@
             >here</a
           >.
         </div>
+        <div class="onboarding-transferCreditDescription">
+          *Some transfer credits may incorrectly apply to requirements. We are working to fix these
+          bugs, so please double check transfer credits!
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/Modals/Onboarding/OnboardingTransfer.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransfer.vue
@@ -9,6 +9,17 @@
         <span class="onboarding-subHeader--font"> Transfer Credits (Optional)</span>
       </div>
       <div class="onboarding-transferCredits onboarding-inputs">
+        <div>
+          <img
+            class="onboarding-warningIcon"
+            src="@/assets/images/warning.svg"
+            alt="warning icon"
+          />
+          <div class="onboarding-transferCreditDescription onboarding-transferCreditWarning">
+            Some transfer credits may incorrectly apply to requirements. We are working to fix these
+            bugs, so please double check transfer credits!
+          </div>
+        </div>
         <div
           class="onboarding-inputWrapper onboarding-inputWrapper--college onboarding-inputWrapper--description"
         >
@@ -51,10 +62,6 @@
           <a target="_blank" href="https://courses.cornell.edu/content.php?catoid=41&navoid=11629"
             >here</a
           >.
-        </div>
-        <div class="onboarding-transferCreditDescription">
-          *Some transfer credits may incorrectly apply to requirements. We are working to fix these
-          bugs, so please double check transfer credits!
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request adds a new warning to the transfer page of onboarding. The purpose of this warning is to notify users about AP/IB bugs before merging the next release (#680).

![image](https://user-images.githubusercontent.com/25535093/164997348-c4ee9356-e964-4b0a-8781-69f1dfe4265c.png)

### Test Plan <!-- Required -->

👀 

### Notes <!-- Optional -->

As a follow-up to this PR, the gatekeep to hide AP/IB fulfillment will be removed.