### PR TITLE
Disallow Transfer Credit for A&S Required 100 Credits

### DIFF
--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -19,6 +19,7 @@ const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
     fulfilledBy: 'credits',
     perSlotMinCount: [100],
     allowCourseDoubleCounting: true,
+    disallowTransferCredit: true,
   },
   {
     name: 'First-Year Writing Seminars (FWS)',


### PR DESCRIPTION
### Summary <!-- Required -->

Excludes transfer (including AP) credits from counting for the required 100 credits from Arts and Sciences. We already do this correctly for the Pre 2020 A&S, but interestingly not for the current A&S.

The [A&S Degree Requirements page](**url**) links to a [**website with information**](https://courses.cornell.edu/content.php?catoid=45&navoid=17977#credit-req) about the credit requirement:
> Courses that do not count toward the 100 required Arts and Sciences credits include credits earned in other colleges at Cornell (except in the cases specifically noted in this section), transfer credits earned in any subject at institutions other than Cornell, and advanced placement/test credits. **AP/test credits** count as part of the 120 credits required for the degree but **not as part of the 100 Arts and Sciences credits** and may not be applied to distribution requirements. AP credits are posted on the transcript. If, subsequently, a student takes the course out of which they had placed, the AP credit will be removed because of the overlap in content.
### Test Plan <!-- Required -->

Ensure that AP credits are not counted towards the 100 A&S credits. Note that this PR was made **before** #684 was merged into master, so **AP credits are disabled by default for every requirement.** Therefore, you **must make sure to run `GK.enableAPIBFulfillment()`** in the console first, and it would be helpful to make sure that your AP credits still count for something they should (like AP Computer Science A for Computer Science major in A&S).