### PR TITLE
Redo A&S 100 and 120 Credit Minimum Requirements

### DIFF
--- a/src/requirements/__test__/__snapshots__/requirement-data-id.test.ts.snap
+++ b/src/requirements/__test__/__snapshots__/requirement-data-id.test.ts.snap
@@ -18,6 +18,7 @@ Array [
   "College-AS1-Geographic Breadth Requirement (GB)",
   "College-AS1-Historic Breadth Requirement (HB)",
   "College-AS1-PBS and MQR courses",
+  "College-AS2-120 Total Credits",
   "College-AS2-A&S Credits",
   "College-AS2-Distribution Requirements",
   "College-AS2-First-Year Writing Seminars (FWS)",

--- a/src/requirements/__test__/__snapshots__/requirement-data-id.test.ts.snap
+++ b/src/requirements/__test__/__snapshots__/requirement-data-id.test.ts.snap
@@ -18,7 +18,6 @@ Array [
   "College-AS1-Geographic Breadth Requirement (GB)",
   "College-AS1-Historic Breadth Requirement (HB)",
   "College-AS1-PBS and MQR courses",
-  "College-AS2-120 Total Credits",
   "College-AS2-A&S Credits",
   "College-AS2-Distribution Requirements",
   "College-AS2-First-Year Writing Seminars (FWS)",

--- a/src/requirements/data/checkers-common.ts
+++ b/src/requirements/data/checkers-common.ts
@@ -95,6 +95,17 @@ export const courseIsFWS = (course: Course): boolean =>
   (course.catalogSatisfiesReq?.includes('First-Year Writing Seminar') ?? false);
 
 /**
+ * The 120 Credits and 100 A&S Credits for the College of Arts and Sciences both only count certain courses for as academic credit for the degree. Use this function for both requirements to ensure they agree.
+ *
+ * The full list of courses that don't count can be found at https://as.cornell.edu/registrar/courses-that-dont-count.
+ *
+ * @param course course object with useful information retrieved from Cornell courses API.
+ * @returns if the course counts for the A&S credit requirement.
+ */
+export const courseCountsForASCredit = (course: Course): boolean =>
+  !(course.subject === 'PE' || ifCodeMatch(course.catalogNbr, '10**'));
+
+/**
  * Call this function to check if a course meets a foreign language requirement, since the 'FL'
  * category is missing from course data
  *

--- a/src/requirements/data/checkers-common.ts
+++ b/src/requirements/data/checkers-common.ts
@@ -95,17 +95,6 @@ export const courseIsFWS = (course: Course): boolean =>
   (course.catalogSatisfiesReq?.includes('First-Year Writing Seminar') ?? false);
 
 /**
- * The 120 Credits and 100 A&S Credits for the College of Arts and Sciences both only count certain courses for as academic credit for the degree. Use this function for both requirements to ensure they agree.
- *
- * The full list of courses that don't count can be found at https://as.cornell.edu/registrar/courses-that-dont-count.
- *
- * @param course course object with useful information retrieved from Cornell courses API.
- * @returns if the course counts for the A&S credit requirement.
- */
-export const courseCountsForASCredit = (course: Course): boolean =>
-  !(course.subject === 'PE' || ifCodeMatch(course.catalogNbr, '10**'));
-
-/**
  * Call this function to check if a course meets a foreign language requirement, since the 'FL'
  * category is missing from course data
  *

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -1,20 +1,37 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
-import { courseIsFWS, ifCodeMatch, courseIsForeignLang } from '../checkers-common';
+import {
+  courseIsFWS,
+  ifCodeMatch,
+  courseIsForeignLang,
+  courseCountsForASCredit,
+} from '../checkers-common';
 
 const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
   {
-    name: 'A&S Credits',
+    name: '120 Total Credits',
     description:
-      '100 credits in Arts & Sciences are required. ' +
-      'Students can take more than 20 credits outside of the College as long as they take 100 credits within; ' +
-      'they can also take all their credits in Arts & Sciences and accumulate more than 120. ' +
-      'Note: AP, IB, and A-Level credits count toward the 120 total credits but not toward the 100 A&S credits.',
+      'Students must earn a minimum of 120 academic credits, which may include AP/test credits. ' +
+      'However, courses in military training, service as a teaching assistant, physical education, remedial or developmental training, ' +
+      'precalculus mathematics, supplemental science and mathematics, and offered by the Learning Strategies Center and English as a second language do not count. ' +
+      'The College\'s "Courses That Won\'t Count" website has a full list of excluded courses.',
+    source: 'https://as.cornell.edu/education/degree-requirements',
+    checker: [(course: Course): boolean => courseCountsForASCredit(course)],
+    fulfilledBy: 'credits',
+    perSlotMinCount: [120],
+    allowCourseDoubleCounting: true,
+  },
+  {
+    name: '100 A&S Credits',
+    description:
+      'Of the 120 Total Credits, a minimum of 100 credits must be taken in the College of Arts & Sciences. ' +
+      'Note: AP, IB, and A-Level credits do not count.',
     source: 'https://as.cornell.edu/education/degree-requirements',
     checker: [
       (course: Course): boolean =>
-        course.acadGroup.includes('AS') ||
-        course.subject === 'CS' ||
-        (course.catalogDistr?.includes('-AS') ?? false),
+        courseCountsForASCredit(course) &&
+        (course.acadGroup.includes('AS') ||
+          course.subject === 'CS' ||
+          (course.catalogDistr?.includes('-AS') ?? false)),
     ],
     fulfilledBy: 'credits',
     perSlotMinCount: [100],

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -5,8 +5,10 @@ const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
   {
     name: 'A&S Credits',
     description:
-      'Of the 120 Total Credits, a minimum of 100 credits must be taken in the College of Arts & Sciences. ' +
-      'Note: AP, IB, and A-Level credits do not count.',
+      '100 credits in Arts & Sciences are required. ' +
+      'Students can take more than 20 credits outside of the College as long as they take 100 credits within; ' +
+      'they can also take all their credits in Arts & Sciences and accumulate more than 120. ' +
+      'Note: AP, IB, and A-Level credits do not count toward the 100 A&S credits.',
     source: 'https://as.cornell.edu/education/degree-requirements',
     checker: [
       (course: Course): boolean =>

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -8,7 +8,7 @@ const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
       '100 credits in Arts & Sciences are required. ' +
       'Students can take more than 20 credits outside of the College as long as they take 100 credits within; ' +
       'they can also take all their credits in Arts & Sciences and accumulate more than 120. ' +
-      'Note: AP, IB, and A-Level credits do not count toward the 100 A&S credits.',
+      'Note: AP, IB, and A-Level credits do not count toward this requirement.',
     source: 'https://as.cornell.edu/education/degree-requirements',
     checker: [
       (course: Course): boolean =>

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -1,25 +1,7 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
-import {
-  courseIsFWS,
-  ifCodeMatch,
-  courseIsForeignLang,
-  courseCountsForASCredit,
-} from '../checkers-common';
+import { courseIsFWS, ifCodeMatch, courseIsForeignLang } from '../checkers-common';
 
 const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
-  // {
-  //   name: '120 Total Credits',
-  //   description:
-  //     'Students must earn a minimum of 120 academic credits, which may include AP/test credits. ' +
-  //     'However, courses in military training, service as a teaching assistant, physical education, remedial or developmental training, ' +
-  //     'precalculus mathematics, supplemental science and mathematics, and offered by the Learning Strategies Center and English as a second language do not count. ' +
-  //     'The College\'s "Courses That Won\'t Count" website has a full list of excluded courses.',
-  //   source: 'https://as.cornell.edu/education/degree-requirements',
-  //   checker: [(course: Course): boolean => courseCountsForASCredit(course)],
-  //   fulfilledBy: 'credits',
-  //   perSlotMinCount: [120],
-  //   allowCourseDoubleCounting: true,
-  // },
   {
     name: 'A&S Credits',
     description:
@@ -28,7 +10,9 @@ const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
     source: 'https://as.cornell.edu/education/degree-requirements',
     checker: [
       (course: Course): boolean =>
-        courseCountsForASCredit(course) &&
+        // Note that this does not completely agree with the 120 total academic credits because that incorrectly includes courses cross-listed with PE
+        course.subject !== 'PE' &&
+        !ifCodeMatch(course.catalogNbr, '10**') &&
         (course.acadGroup.includes('AS') ||
           course.subject === 'CS' ||
           (course.catalogDistr?.includes('-AS') ?? false)),

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -7,19 +7,19 @@ import {
 } from '../checkers-common';
 
 const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
-  {
-    name: '120 Total Credits',
-    description:
-      'Students must earn a minimum of 120 academic credits, which may include AP/test credits. ' +
-      'However, courses in military training, service as a teaching assistant, physical education, remedial or developmental training, ' +
-      'precalculus mathematics, supplemental science and mathematics, and offered by the Learning Strategies Center and English as a second language do not count. ' +
-      'The College\'s "Courses That Won\'t Count" website has a full list of excluded courses.',
-    source: 'https://as.cornell.edu/education/degree-requirements',
-    checker: [(course: Course): boolean => courseCountsForASCredit(course)],
-    fulfilledBy: 'credits',
-    perSlotMinCount: [120],
-    allowCourseDoubleCounting: true,
-  },
+  // {
+  //   name: '120 Total Credits',
+  //   description:
+  //     'Students must earn a minimum of 120 academic credits, which may include AP/test credits. ' +
+  //     'However, courses in military training, service as a teaching assistant, physical education, remedial or developmental training, ' +
+  //     'precalculus mathematics, supplemental science and mathematics, and offered by the Learning Strategies Center and English as a second language do not count. ' +
+  //     'The College\'s "Courses That Won\'t Count" website has a full list of excluded courses.',
+  //   source: 'https://as.cornell.edu/education/degree-requirements',
+  //   checker: [(course: Course): boolean => courseCountsForASCredit(course)],
+  //   fulfilledBy: 'credits',
+  //   perSlotMinCount: [120],
+  //   allowCourseDoubleCounting: true,
+  // },
   {
     name: 'A&S Credits',
     description:

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -21,7 +21,7 @@ const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
     allowCourseDoubleCounting: true,
   },
   {
-    name: '100 A&S Credits',
+    name: 'A&S Credits',
     description:
       'Of the 120 Total Credits, a minimum of 100 credits must be taken in the College of Arts & Sciences. ' +
       'Note: AP, IB, and A-Level credits do not count.',

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -19,6 +19,7 @@ const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
     fulfilledBy: 'credits',
     perSlotMinCount: [100],
     allowCourseDoubleCounting: true,
+    disallowTransferCredit: true,
   },
   {
     name: 'First-Year Writing Seminars (FWS)',

--- a/src/requirements/data/colleges/asPreFA2020.ts
+++ b/src/requirements/data/colleges/asPreFA2020.ts
@@ -8,7 +8,7 @@ const casPreFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
       '100 credits in Arts & Sciences are required. ' +
       'Students can take more than 20 credits outside of the College as long as they take 100 credits within; ' +
       'they can also take all their credits in Arts & Sciences and accumulate more than 120. ' +
-      'Note: AP, IB, and A-Level credits count toward the 120 total credits but not toward the 100 A&S credits.',
+      'Note: AP, IB, and A-Level credits do not count toward the 100 A&S credits.',
     source: 'https://as.cornell.edu/education/old-degree-requirements',
     checker: [
       (course: Course): boolean =>

--- a/src/requirements/data/colleges/asPreFA2020.ts
+++ b/src/requirements/data/colleges/asPreFA2020.ts
@@ -8,7 +8,7 @@ const casPreFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
       '100 credits in Arts & Sciences are required. ' +
       'Students can take more than 20 credits outside of the College as long as they take 100 credits within; ' +
       'they can also take all their credits in Arts & Sciences and accumulate more than 120. ' +
-      'Note: AP, IB, and A-Level credits do not count toward the 100 A&S credits.',
+      'Note: AP, IB, and A-Level credits do not count toward this requirement.',
     source: 'https://as.cornell.edu/education/old-degree-requirements',
     checker: [
       (course: Course): boolean =>

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -62,7 +62,8 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-AS2-total-credits',
         description:
           '120 academic credits are required. ' +
-          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits.',
+          'AP credits count towards this requirement, but PE courses and courses numbered 1000-1099 do not. ' +
+          'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'https://courses.cornell.edu/content.php?catoid=45&navoid=17977#credit-req',
       };
       break;

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -56,16 +56,16 @@ const getTotalCreditsFulfillmentStatistics = (
         source: 'http://courses.cornell.edu/content.php?catoid=41&navoid=11570#credit-req',
       };
       break;
-    // case 'AS2':
-    //   requirement = {
-    //     ...requirementCommon,
-    //     id: 'College-AS2-total-credits',
-    //     description:
-    //       '120 academic credits are required. ' +
-    //       'PE courses and courses numbered 1000-1099 do not count towards the 120 credits.',
-    //     source: 'http://courses.cornell.edu/content.php?catoid=41&navoid=11570#credit-req',
-    //   };
-    //   break;
+    case 'AS2':
+      requirement = {
+        ...requirementCommon,
+        id: 'College-AS2-total-credits',
+        description:
+          '120 academic credits are required. ' +
+          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits.',
+        source: 'https://courses.cornell.edu/content.php?catoid=45&navoid=17977#credit-req',
+      };
+      break;
     case 'HE':
       requirement = {
         ...requirementCommon,

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -51,7 +51,7 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-AS1-total-credits',
         description:
           '120 academic credits are required. ' +
-          'AP, IB, and A-Level credits count towards this requirement, but PE courses and courses numbered 1000-1099 do not. ' +
+          'AP, IB, and A-Level credits count toward this requirement, but PE courses and courses numbered 1000-1099 do not. ' +
           'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'http://courses.cornell.edu/content.php?catoid=41&navoid=11570#credit-req',
       };
@@ -62,7 +62,7 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-AS2-total-credits',
         description:
           '120 academic credits are required. ' +
-          'AP, IB, and A-Level credits count towards this requirement, but PE courses and courses numbered 1000-1099 do not. ' +
+          'AP, IB, and A-Level credits count toward this requirement, but PE courses and courses numbered 1000-1099 do not. ' +
           'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'https://courses.cornell.edu/content.php?catoid=45&navoid=17977#credit-req',
       };

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -51,7 +51,7 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-AS1-total-credits',
         description:
           '120 academic credits are required. ' +
-          'PE courses and courses numbered 1000-1099 do not count towards the 120 credits. ' +
+          'AP, IB, and A-Level credits count towards this requirement, but PE courses and courses numbered 1000-1099 do not. ' +
           'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'http://courses.cornell.edu/content.php?catoid=41&navoid=11570#credit-req',
       };
@@ -62,7 +62,7 @@ const getTotalCreditsFulfillmentStatistics = (
         id: 'College-AS2-total-credits',
         description:
           '120 academic credits are required. ' +
-          'AP credits count towards this requirement, but PE courses and courses numbered 1000-1099 do not. ' +
+          'AP, IB, and A-Level credits count towards this requirement, but PE courses and courses numbered 1000-1099 do not. ' +
           'Repeated courses may not apply to this requirement, but we do not check this.',
         source: 'https://courses.cornell.edu/content.php?catoid=45&navoid=17977#credit-req',
       };


### PR DESCRIPTION
### Summary <!-- Required -->

- [x] Use existing 120 Total Credit requirement for A&S.
- [x] Excludes transfer (including AP) credits from counting for the required 100 credits from Arts and Sciences.

The [A&S Degree Requirements page](**url**) links to a [**website with information**](https://courses.cornell.edu/content.php?catoid=45&navoid=17977#credit-req) about the credit requirement, including exclusions for 100 & 120 requirements:

> The College of Arts and Sciences does not grant credit toward the degree for every course offered by the university. Courses in military training, service as a teaching assistant, physical education, remedial or developmental training, precalculus mathematics, supplemental science and mathematics, offered by the Learning Strategies Center and English as a second language are among those for which degree credit.

> Courses that do not count toward the 100 required Arts and Sciences credits include credits earned in other colleges at Cornell (except in the cases specifically noted in this section), transfer credits earned in any subject at institutions other than Cornell, and advanced placement/test credits. **AP/test credits** count as part of the 120 credits required for the degree but **not as part of the 100 Arts and Sciences credits** and may not be applied to distribution requirements. AP credits are posted on the transcript. If, subsequently, a student takes the course out of which they had placed, the AP credit will be removed because of the overlap in content.

### Test Plan <!-- Required -->

1. Check that all credits (except for courses numbered 1000 - 1099 and PE classes) count for the 120 Total requirements. _Note that cross-listed PE courses will incorrectly count for the 120 total; this needs to be addressed later but it will require a bigger change than we have time for now._
2. Ensure that AP credits are not counted towards the 100 A&S credits. ~~Note that this PR was made **before** #684 was merged into master, so **AP credits are disabled by default for every requirement.**~~ _This should not be an issue anymore since master was updated, but it would be helpful to still_ run `GK.enableAPIBFulfillment()` in the console first, and it would be helpful to make sure that your AP credits still count for something they should (like AP Computer Science A for Computer Science major in A&S).
3. Ensure that only classes that count for the 120 Total Credits can count for the 100 A&S Credits. The 100 A&S Credits **must come from the 120 Total Credits**.

### Notes

- I don't currently include all the courses from the [Courses That Don't Count](https://as.cornell.edu/registrar/courses-that-dont-count) website.
- I'm not sure about the wording for the descriptions.
- I'd like to link to the [Courses That Don't Count](https://as.cornell.edu/registrar/courses-that-dont-count) website, but our source ("Learn More" link) usually goes to a more general page, not a page of exclusions.
- I only added the 120 total credit requirement to the current A&S college. Do I also add it to pre 2020?