### PR TITLE
Implement Alternate Options for Engineering Physics Major

### DIFF
--- a/src/requirements/__test__/__snapshots__/requirement-data-id.test.ts.snap
+++ b/src/requirements/__test__/__snapshots__/requirement-data-id.test.ts.snap
@@ -196,6 +196,8 @@ Array [
   "Major-ENV-Laboratory Course",
   "Major-ENV-Major Approved Electives",
   "Major-ENV-Organic Chemistry",
+  "Major-EP-Electronic Circuits Lab",
+  "Major-EP-Experimental Physics Lab",
   "Major-EP-Major-approved Elective(s)",
   "Major-EP-Required Courses",
   "Major-ESS-Biology",

--- a/src/requirements/data/majors/ep.ts
+++ b/src/requirements/data/majors/ep.ts
@@ -85,7 +85,8 @@ const epRequirements: readonly CollegeOrMajorRequirement[] = [
       'Six major-approved electives (18-24 credits). All must be technical courses taken for a letter grade. ' +
       'Five of the six courses must be upper-level courses (3000 level or above). ' +
       'Nine credits of major-approved electives must be outside of AEP.',
-    source: 'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg79',
+    source:
+      'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg79',
     // Currently, the user must override in order to apply a non-upper-level course
     // TODO implement as compound requirement:
     // at least 18 credits

--- a/src/requirements/data/majors/ep.ts
+++ b/src/requirements/data/majors/ep.ts
@@ -32,7 +32,7 @@ const epRequirements: readonly CollegeOrMajorRequirement[] = [
     name: 'Electronic Circuits Lab',
     description: 'Students can either take AEP 3630 or take ECE 2100 and ECE 2300.',
     source:
-      'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg76',
+      'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg79',
     fulfilledBy: 'toggleable',
     fulfillmentOptions: {
       'AEP 3630': {
@@ -55,7 +55,7 @@ const epRequirements: readonly CollegeOrMajorRequirement[] = [
     name: 'Experimental Physics Lab',
     description: 'Students can either take either PHYS 4410 or a combination of two courses.',
     source:
-      'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg76',
+      'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg79',
     fulfilledBy: 'toggleable',
     fulfillmentOptions: {
       'PHYS 4410': {
@@ -85,7 +85,7 @@ const epRequirements: readonly CollegeOrMajorRequirement[] = [
       'Six major-approved electives (18-24 credits). All must be technical courses taken for a letter grade. ' +
       'Five of the six courses must be upper-level courses (3000 level or above). ' +
       'Nine credits of major-approved electives must be outside of AEP.',
-    source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19775',
+    source: 'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg79',
     // Currently, the user must override in order to apply a non-upper-level course
     // TODO implement as compound requirement:
     // at least 18 credits

--- a/src/requirements/data/majors/ep.ts
+++ b/src/requirements/data/majors/ep.ts
@@ -5,48 +5,92 @@ const epRequirements: readonly CollegeOrMajorRequirement[] = [
   {
     name: 'Required Courses',
     description: 'The major requirements are as follows.',
-    source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19775',
+    source:
+      'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg76',
     checker: includesWithSubRequirements(
       ['AEP 3200'],
+      ['AEP 4200'],
       ['AEP 3330'],
       ['AEP 3550'],
-      ['AEP 3560'],
       ['AEP 3610'],
-      ['AEP 3620'],
-      ['AEP 3630'],
-      ['AEP 4200'],
       ['AEP 4230'],
-      ['AEP 4340'],
-      ['PHYS 4410']
+      ['AEP 3560', 'AEP 3620', 'AEP 4340']
     ),
     fulfilledBy: 'courses',
-    perSlotMinCount: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+    perSlotMinCount: [1, 1, 1, 1, 1, 1, 2],
     slotNames: [
       'AEP 3200',
+      'AEP 4200',
       'AEP 3330',
       'AEP 3550',
-      'AEP 3560',
       'AEP 3610',
-      'AEP 3620',
-      'AEP 3630',
-      'AEP 4200',
       'AEP 4230',
-      'AEP 4340',
-      'PHYS 4410',
+      'Intermediate Mechanics Course',
     ],
+  },
+  {
+    name: 'Electronic Circuits Lab',
+    description: 'Students can either take AEP 3630 or take ECE 2100 and ECE 2300.',
+    source:
+      'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg76',
+    fulfilledBy: 'toggleable',
+    fulfillmentOptions: {
+      'AEP 3630': {
+        description: '',
+        checker: includesWithSubRequirements(['AEP 3630']),
+        counting: 'courses',
+        perSlotMinCount: [1],
+        slotNames: ['AEP 3630'],
+      },
+      'ECE 2100 and ECE 2300': {
+        description: '',
+        checker: includesWithSubRequirements(['ECE 2100'], ['ECE 2300']),
+        counting: 'courses',
+        perSlotMinCount: [1, 1],
+        slotNames: ['ECE 2100', 'ECE 2300'],
+      },
+    },
+  },
+  {
+    name: 'Experimental Physics Lab',
+    description: 'Students can either take either PHYS 4410 or a combination of two courses.',
+    source:
+      'https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg76',
+    fulfilledBy: 'toggleable',
+    fulfillmentOptions: {
+      'PHYS 4410': {
+        description: '',
+        checker: includesWithSubRequirements(['PHYS 4410']),
+        counting: 'courses',
+        perSlotMinCount: [1],
+        slotNames: ['PHYS 4410'],
+      },
+      'Alternate Option': {
+        description:
+          'Two of the four credits of PHYS 4410 can be satisfied by completing AEP 3300/PHYS 3330, ASTRO 4410, or PHYS 3310. ' +
+          'The remaining two credits can be satisfied by taking PHYS 4400 for two credits, provided that the experiments in PHYS 4400 do not overlap with those in AEP 3300/PHYS 3330 or ASTRO 4410 or PHYS 3310.',
+        checker: includesWithSubRequirements(
+          ['AEP 3300', 'ASTRO 4410', 'PHYS 3310'],
+          ['PHYS 4400']
+        ),
+        counting: 'courses',
+        perSlotMinCount: [1, 1],
+        slotNames: ['AEP 3300, ASTRO 4410, or PHYS 3310', 'PHYS 4400'],
+      },
+    },
   },
   {
     name: 'Major-approved Elective(s)',
     description:
       'Six major-approved electives (18-24 credits). All must be technical courses taken for a letter grade. ' +
-      'Five of the six courses must be upper-level courses (3000 level or above).  ' +
+      'Five of the six courses must be upper-level courses (3000 level or above). ' +
       'Nine credits of major-approved electives must be outside of AEP.',
     source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19775',
     // Currently, the user must override in order to apply a non-upper-level course
     // TODO implement as compound requirement:
     // at least 18 credits
     // at least 5 courses 3000+ level
-    // at least 9 credits outside of aep
+    // at least 9 credits outside of AEP
     checker: [
       (course: Course): boolean => {
         const { catalogNbr } = course;


### PR DESCRIPTION
### Summary <!-- Required -->

- [x] Make AEP 3630 its own requirement and implement toggleable fulfillment options. 
- [x] Make PHYS 4410 its own requirement and implement toggleable fulfillment options. 
- [x] Combine AEP 3560, AEP 3620, and AEP 4340 into one slot where 2/3 need to be selected.

Remaining TODOs:

- Eventually improve the checker for the Major approved electives.

### Test Plan <!-- Required -->

First, set your major to EP on the dev build and add some courses (especially the ones that are being moved to their own requirement, like PHYS 4410 and AEP 3630). Then, switch over to the preview link for this build and ensure that the courses you added are counted correctly with the new requirements.

Then:
- Verify that the requirements match the source.
- Check that the alternate options for Electronic Circuits Lab and Experimental Physics Lab match the EP Major Notes in the handbook.

I'd suggest that you clear your data for `user-toggleable-requirement-choices` in Firestore after testing because you may encounter errors if you go to a branch that is behind this PR.

<img width="276" alt="image" src="https://user-images.githubusercontent.com/47431797/164957559-8b87ca13-93b9-4f00-8994-c385d8956ac1.png">

### Notes
Small: Should the sources for the toggleable requirements and major approved electives go to page [76](https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg76) or [79](https://cornellengineeringhandbook.freeflowdp.com/cornellengineeringhandbook/fall2021/#pg79)?