### PR TITLE
Fix failing requirements sidebar Cypress test

### DIFF
--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -38,6 +38,12 @@ it('Check navbar accessibility', () => {
 // Check the accessibility of the requirements sidebar with all toggles fully open
 // Note that the selector in checkA11y ensures only the sidebar is inspected
 it('Check accessibility of the requirements sidebar', () => {
+  // Note that there must a completed requirement (i.e. swim test)
+  cy.get('[data-cyId=semester-addCourse]').click();
+  cy.get('[data-cyId=newCourse-dropdown]').type('PE 1100');
+  cy.get('[data-cyId=newCourse-searchResult]').first().click();
+  cy.get('[data-cyId=modal-button]').click();
+
   // open all dropdowns in the sidebar
   cy.get('[data-cyId=requirements-viewMore]').click({ multiple: true });
   cy.get('[data-cyId=requirements-showCompleted]').click({ multiple: true });

--- a/cypress/integration/accessibility-spec.ts
+++ b/cypress/integration/accessibility-spec.ts
@@ -47,7 +47,7 @@ it('Check accessibility of the requirements sidebar', () => {
   // open all dropdowns in the sidebar
   cy.get('[data-cyId=requirements-viewMore]').click({ multiple: true });
   cy.get('[data-cyId=requirements-showCompleted]').click({ multiple: true });
-  cy.get('[data-cyId=requirements-displayToggle]').click({ multiple: true });
+  cy.get('[data-cyId=requirements-displayToggle]').click({ multiple: true, force: true });
 
   cy.checkA11y('[data-cyId=reqsSidebar]');
 });


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes the requirements bar accessibility cypress test that ocassionally fails on master. This test opens all parts of the requirements sidebar before checking accessibility. However, it currently fails if there are no "Show completed" reqs toggle, which occurs when no courses are in the plan, which only happens sometimes depending on the order the tests were run. This PR adds the swim test course so that at least that one req will always be fulfilled.

![image](https://user-images.githubusercontent.com/25535093/172223375-8d714d02-4b15-4d12-b6a4-ccb4b027578f.png)

### Test Plan <!-- Required -->

Clear all courses on the testing account, and confirm the Cypress tests still pass.