### PR TITLE
Added a warning to the profile page before leaving and fixed spacing issue on transfer credits

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -432,6 +432,7 @@ input {
       width: 380px;
     }
     &--columnFill {
+      margin: 5px;
       display: flex;
       flex-direction: column;
       width: 100%;

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -302,7 +302,6 @@ input {
     cursor: pointer;
     margin-left: 1rem;
     color: $emGreen;
-    padding-bottom: 0.5rem;
   }
 
   &-bottom {
@@ -424,7 +423,7 @@ input {
     }
     &--column-removeExam {
       display: flex;
-      flex-direction: column-reverse;
+      flex-direction: column;
     }
     &--columnWide {
       display: flex;
@@ -432,7 +431,7 @@ input {
       width: 380px;
     }
     &--columnFill {
-      margin: 5px;
+      margin: 1rem;
       display: flex;
       flex-direction: column;
       width: 100%;

--- a/src/components/Modals/Onboarding/Onboarding.scss
+++ b/src/components/Modals/Onboarding/Onboarding.scss
@@ -431,7 +431,7 @@ input {
       width: 380px;
     }
     &--columnFill {
-      margin: 1rem;
+      margin: 0.313rem;
       display: flex;
       flex-direction: column;
       width: 100%;

--- a/src/components/Modals/Onboarding/OnboardingTransferExamPropertyDropdown.vue
+++ b/src/components/Modals/Onboarding/OnboardingTransferExamPropertyDropdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="columnWide ? 'onboarding-select--columnWide' : 'onboarding-select--column'"
+    :class="'onboarding-select--columnFill'"
     :style="{ borderColor: boxBorder }"
     v-click-outside="closeDropdownIfOpen"
   >

--- a/src/components/Modals/ProfileSaveReminder.vue
+++ b/src/components/Modals/ProfileSaveReminder.vue
@@ -1,6 +1,6 @@
 <template>
   <teleport-modal
-    title="Warning: Possibly Unsaved Changes"
+    title="Warning: Unsaved Changes"
     leftButtonText="Go Back"
     rightButtonText="Continue"
     content-class="content-clear"
@@ -9,7 +9,7 @@
     @right-button-clicked="confirmLeaveProfilePage"
   >
     <span
-      >There may be unsaved changes in your profile! Please make sure your changes are saved before
+      >There are unsaved changes in your profile! Please make sure your changes are saved before
       leaving!</span
     >
   </teleport-modal>

--- a/src/components/Modals/ProfileSaveReminder.vue
+++ b/src/components/Modals/ProfileSaveReminder.vue
@@ -1,0 +1,34 @@
+<template>
+  <teleport-modal
+    title="Warning: Possibly Unsaved Changes"
+    leftButtonText="Go Back"
+    rightButtonText="Continue"
+    content-class="content-clear"
+    @modal-closed="returnToProfilePage"
+    @left-button-clicked="returnToProfilePage"
+    @right-button-clicked="confirmLeaveProfilePage"
+  >
+    <span
+      >There may be unsaved changes in your profile! Please make sure your changes are saved before
+      leaving!</span
+    >
+  </teleport-modal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TeleportModal from '@/components/Modals/TeleportModal.vue';
+
+export default defineComponent({
+  components: { TeleportModal },
+  emits: { 'confirm-leave': () => true, 'cancel-leave': () => true },
+  methods: {
+    returnToProfilePage() {
+      this.$emit('cancel-leave');
+    },
+    confirmLeaveProfilePage() {
+      this.$emit('confirm-leave');
+    },
+  },
+});
+</script>

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -275,8 +275,9 @@ export default defineComponent({
     },
     openTools() {
       if (this.isProfileOpen) {
-        this.closeProfile();
         this.shouldOpenTools = true;
+        this.closeProfile();
+        this.showToolsPage = true;
       } else {
         this.showToolsPage = true;
       }

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -55,6 +55,8 @@
         class="profilePage"
         :onboardingData="onboardingData"
         :userName="userName"
+        @set-profile-changed="setProfileChanged"
+        @set-profile-unchanged="setProfileUnchanged"
         v-if="isProfileOpen"
       />
     </div>
@@ -77,6 +79,11 @@
       @closeTourWindow="closeTour"
       v-if="showTourEndWindow"
     />
+    <profile-save-reminder
+      v-if="isProfileSaveReminderOpen"
+      @confirm-leave="confirmLeaveProfile"
+      @cancel-leave="cancelLeaveProfile"
+    />
   </div>
 </template>
 
@@ -92,6 +99,7 @@ import Onboarding from '@/components/Modals/Onboarding/Onboarding.vue';
 import TourWindow from '@/components/Modals/TourWindow.vue';
 import ToolsContainer from '@/containers/Tools.vue';
 import ProfileEditor from '@/containers/Profile.vue';
+import ProfileSaveReminder from '@/components/Modals/ProfileSaveReminder.vue';
 import featureFlagCheckers from '@/feature-flags';
 
 import store, { initializeFirestoreListeners } from '@/store';
@@ -141,6 +149,7 @@ export default defineComponent({
     TourWindow,
     ToolsContainer,
     ProfileEditor,
+    ProfileSaveReminder,
   },
   data() {
     return {
@@ -159,6 +168,9 @@ export default defineComponent({
       showTourEndWindow: false,
       showToolsPage: false,
       isProfileOpen: false,
+      isProfileSaveReminderOpen: false,
+      shouldOpenTools: false,
+      profileChanged: false,
     };
   },
   computed: {
@@ -241,16 +253,6 @@ export default defineComponent({
       }
     },
 
-    openPlan() {
-      this.showToolsPage = false;
-      this.isProfileOpen = false;
-    },
-
-    openTools() {
-      this.showToolsPage = true;
-      this.isProfileOpen = false;
-    },
-
     editProfile() {
       this.isEditingProfile = true;
       this.startOnboarding();
@@ -263,6 +265,50 @@ export default defineComponent({
       } else {
         this.editProfile();
       }
+    },
+
+    openPlan() {
+      this.closeProfile();
+      if (!this.isProfileOpen) {
+        this.showToolsPage = false;
+      }
+    },
+    openTools() {
+      if (this.isProfileOpen) {
+        this.closeProfile();
+        this.shouldOpenTools = true;
+      } else {
+        this.showToolsPage = true;
+      }
+    },
+
+    closeProfile() {
+      if (this.isProfileOpen && this.profileChanged) {
+        this.isProfileSaveReminderOpen = true;
+        this.profileChanged = false;
+      } else {
+        this.isProfileOpen = false;
+      }
+    },
+
+    confirmLeaveProfile() {
+      this.isProfileSaveReminderOpen = false;
+      this.isProfileOpen = false;
+      this.showToolsPage = this.shouldOpenTools;
+      this.shouldOpenTools = false;
+    },
+
+    cancelLeaveProfile() {
+      this.isProfileSaveReminderOpen = false;
+      this.showToolsPage = false;
+    },
+
+    setProfileChanged() {
+      this.profileChanged = true;
+    },
+
+    setProfileUnchanged() {
+      this.profileChanged = false;
     },
 
     closeWelcome() {

--- a/src/containers/Profile.vue
+++ b/src/containers/Profile.vue
@@ -88,7 +88,7 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ['onboard', 'cancelOnboarding'],
+  emits: ['onboard', 'cancelOnboarding', 'set-profile-changed', 'set-profile-unchanged'],
   data() {
     return {
       currentPage: 1,
@@ -204,6 +204,7 @@ export default defineComponent({
       setAppOnboardingData(this.name, this.onboarding);
       this.changed = false;
       this.$emit('onboard');
+      this.$emit('set-profile-unchanged');
     },
     updateBasic(
       gradYear: string,
@@ -229,6 +230,7 @@ export default defineComponent({
         grad,
       };
       this.changed = true;
+      this.$emit('set-profile-changed');
     },
     // clear transfer credits if the student is only in a graduate program, but previously set transfer credits
     clearTransferCreditIfGraduate() {
@@ -246,6 +248,7 @@ export default defineComponent({
         tookSwim,
       };
       this.changed = true;
+      this.$emit('set-profile-changed');
     },
     openBasicInfo() {
       this.currentPage = 1;


### PR DESCRIPTION
### Summary Added 
Created a new modal which warns the user if they try to leave the profile page with unsaved changes
Fixed the spacing issues on the AP/IB exam credits page

This pull request is hopefully the last step we need for the profile page

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:
- None

### Test Plan 
Test that the behaviour for switching between the Plan, Tools, and Profile Pages behaves as expected
- Try all possibilities of navigating between the pages
Test that the save reminder modal only pops up when changes were made
Test that the new spacing works for screens of all sizes
Test that the onboarding modal is unaffected by the changes to the profile page

New Spacing: 
![image](https://user-images.githubusercontent.com/66176696/188485101-f515ab61-1895-47ed-b481-20d58cdb4e01.png)
New Modal: 
![image](https://user-images.githubusercontent.com/66176696/188485174-11786e58-28f0-4330-a1fd-58d3a17c89fa.png)

