### PR TITLE
Fix Script Copy Data Between Users

### DIFF
--- a/scripts/copy-user-data.ts
+++ b/scripts/copy-user-data.ts
@@ -3,7 +3,7 @@
  * BE CAREFUL WHEN COPYING TO PROD!
  * Script to copy data from one user on production or dev to another user on dev.
  * Requires service accounts for database.
- * serviceAccount.json (if using dev) and serviceAccountProd.json (if using prod) must be at the root.
+ * serviceAccountDev.json (if using dev) and serviceAccountProd.json (if using prod) must be at the root.
  * The output will be the data written or to be written to the target.
  *
  * From root, run: `npm run ts-node -- scripts/copy-user-data.ts -f <FROM_ENV>/<FROM_USER> -t <TO_ENV>/<TO_USER> -o <OUTPUT>`
@@ -77,7 +77,7 @@ async function execute(
   let toDb;
   if (options.fromEnv === 'dev' || options.toEnv === 'dev') {
     const dev = initializeApp({
-      credential: cert('serviceAccount.json'),
+      credential: cert('serviceAccountDev.json'),
       databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
     });
     const devDb = getFirestore(dev);

--- a/scripts/copy-user-data.ts
+++ b/scripts/copy-user-data.ts
@@ -76,20 +76,26 @@ async function execute(
   let fromDb;
   let toDb;
   if (options.fromEnv === 'dev' || options.toEnv === 'dev') {
-    const dev = initializeApp({
-      credential: cert('serviceAccountDev.json'),
-      databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
-    });
+    const dev = initializeApp(
+      {
+        credential: cert('serviceAccountDev.json'),
+        databaseURL: 'https://cornelldti-courseplan-dev.firebaseio.com',
+      },
+      'dev'
+    );
     const devDb = getFirestore(dev);
     if (options.fromEnv === 'dev') fromDb = devDb;
     if (options.toEnv === 'dev') toDb = devDb;
   }
 
   if (options.fromEnv === 'prod' || options.toEnv === 'prod') {
-    const prod = initializeApp({
-      credential: cert('serviceAccountProd.json'),
-      databaseURL: 'https://cornell-courseplan.firebaseio.com',
-    });
+    const prod = initializeApp(
+      {
+        credential: cert('serviceAccountProd.json'),
+        databaseURL: 'https://cornell-courseplan.firebaseio.com',
+      },
+      'prod'
+    );
     const prodDb = getFirestore(prod);
     if (options.fromEnv === 'prod') fromDb = prodDb;
     if (options.toEnv === 'prod') toDb = prodDb;


### PR DESCRIPTION
### Summary <!-- Required -->

This PR provides a quick fix to the script introduced in #711. `initializeApp()` from `firebase-admin` was missing a specific name in order to initialize multiple apps, which is necessary to copy data between dev and prod. This PR also changes the name of the dev service account to make the script clearer.

### Test Plan <!-- Required -->

Run the script from the command line with various arguments in preview mode and actually copy between documents on dev (e.g. copy from your account on dev to another google account that you have). You don't actually have to copy to another user if you want; the "user" only refers to the name of a document, so you can name your documents what you want. However, you'll need an email that corresponds to the document name to actually use the data. I recommend only having the dev service account in your repo at first until you have **thoroughly read through the code** and are confident that it will behave as it is supposed to once a prod service account credentials are in the repo.

Example script: preview a copy from a dummy account to your data on dev:
```
npm run ts-node -- scripts/copy-user-data.ts -f dev/dummyaccount -t dev/your-netid@cornell.edu -o "log.json"
```
Example script: copy from a dummy account to your data on dev:
```
npm run ts-node -- scripts/copy-user-data.ts -f dev/dummyaccount -t dev/your-netid@cornell.edu -o "log.json" --execute
```