### PR TITLE
Clean Data in Course Generator Script

### DIFF
--- a/src/requirements/courses-json-generator.ts
+++ b/src/requirements/courses-json-generator.ts
@@ -37,9 +37,8 @@ const cleanString = (value: string | null) => {
   return value.replace(/\u00a0/g, ' ');
 };
 
-const cleanMaybeString = (value: string | null | undefined): string | undefined => {
-  return value?.replace(/\u00a0/g, ' ') || undefined;
-};
+const cleanMaybeString = (value: string | null | undefined): string | undefined =>
+  value?.replace(/\u00a0/g, ' ') || undefined;
 
 /** Throws away course object fields we don't need. Used for generate small-enough course json. */
 const courseFieldFilter = ({

--- a/src/requirements/courses-json-generator.ts
+++ b/src/requirements/courses-json-generator.ts
@@ -32,13 +32,7 @@ const getSubjects = async (semester: string): Promise<readonly string[]> => {
   }
 };
 
-const cleanString = (value: string | null) => {
-  if (value === null) return '';
-  return value.replace(/\u00a0/g, ' ');
-};
-
-const cleanMaybeString = (value: string | null | undefined): string | undefined =>
-  value?.replace(/\u00a0/g, ' ') || undefined;
+const cleanString = (value: string | null | undefined) => value?.replace(/\u00a0/g, ' ');
 
 /** Throws away course object fields we don't need. Used for generate small-enough course json. */
 const courseFieldFilter = ({
@@ -57,23 +51,23 @@ const courseFieldFilter = ({
   acadCareer,
   acadGroup,
 }: Course): Course => ({
-  subject: cleanString(subject),
+  subject: cleanString(subject) || '',
   crseId,
-  catalogNbr: cleanString(catalogNbr),
-  titleLong: cleanString(titleLong),
+  catalogNbr: cleanString(catalogNbr) || '',
+  titleLong: cleanString(titleLong) || '',
   enrollGroups: enrollGroups.map(({ unitsMaximum, unitsMinimum }) => ({
     unitsMaximum,
     unitsMinimum,
   })),
-  catalogWhenOffered: cleanMaybeString(catalogWhenOffered),
-  catalogBreadth: cleanMaybeString(catalogBreadth),
-  catalogDistr: cleanMaybeString(catalogDistr),
-  catalogComments: cleanMaybeString(catalogComments),
-  catalogSatisfiesReq: cleanMaybeString(catalogSatisfiesReq),
-  catalogCourseSubfield: cleanMaybeString(catalogCourseSubfield),
-  catalogAttribute: cleanMaybeString(catalogAttribute),
-  acadCareer: cleanString(acadCareer),
-  acadGroup: cleanString(acadGroup),
+  catalogWhenOffered: cleanString(catalogWhenOffered),
+  catalogBreadth: cleanString(catalogBreadth),
+  catalogDistr: cleanString(catalogDistr),
+  catalogComments: cleanString(catalogComments),
+  catalogSatisfiesReq: cleanString(catalogSatisfiesReq),
+  catalogCourseSubfield: cleanString(catalogCourseSubfield),
+  catalogAttribute: cleanString(catalogAttribute),
+  acadCareer: cleanString(acadCareer) || '',
+  acadGroup: cleanString(acadGroup) || '',
 });
 
 /** @returns a list of all course objects in a semester for a given subject. */

--- a/src/requirements/courses-json-generator.ts
+++ b/src/requirements/courses-json-generator.ts
@@ -32,7 +32,8 @@ const getSubjects = async (semester: string): Promise<readonly string[]> => {
   }
 };
 
-const cleanString = (value: string | null | undefined) => value?.replace(/\u00a0/g, ' ');
+const cleanString = (value: string | null | undefined) =>
+  value?.replace(/\u00a0/g, ' ') || undefined;
 
 /** Throws away course object fields we don't need. Used for generate small-enough course json. */
 const courseFieldFilter = ({

--- a/src/requirements/courses-json-generator.ts
+++ b/src/requirements/courses-json-generator.ts
@@ -32,7 +32,7 @@ const getSubjects = async (semester: string): Promise<readonly string[]> => {
   }
 };
 
-const cleanString = (value: string | null | undefined) =>
+const cleanField = (value: string | null | undefined) =>
   value?.replace(/\u00a0/g, ' ') || undefined;
 
 /** Throws away course object fields we don't need. Used for generate small-enough course json. */
@@ -52,23 +52,23 @@ const courseFieldFilter = ({
   acadCareer,
   acadGroup,
 }: Course): Course => ({
-  subject: cleanString(subject) || '',
+  subject: cleanField(subject) || '',
   crseId,
-  catalogNbr: cleanString(catalogNbr) || '',
-  titleLong: cleanString(titleLong) || '',
+  catalogNbr: cleanField(catalogNbr) || '',
+  titleLong: cleanField(titleLong) || '',
   enrollGroups: enrollGroups.map(({ unitsMaximum, unitsMinimum }) => ({
     unitsMaximum,
     unitsMinimum,
   })),
-  catalogWhenOffered: cleanString(catalogWhenOffered),
-  catalogBreadth: cleanString(catalogBreadth),
-  catalogDistr: cleanString(catalogDistr),
-  catalogComments: cleanString(catalogComments),
-  catalogSatisfiesReq: cleanString(catalogSatisfiesReq),
-  catalogCourseSubfield: cleanString(catalogCourseSubfield),
-  catalogAttribute: cleanString(catalogAttribute),
-  acadCareer: cleanString(acadCareer) || '',
-  acadGroup: cleanString(acadGroup) || '',
+  catalogWhenOffered: cleanField(catalogWhenOffered),
+  catalogBreadth: cleanField(catalogBreadth),
+  catalogDistr: cleanField(catalogDistr),
+  catalogComments: cleanField(catalogComments),
+  catalogSatisfiesReq: cleanField(catalogSatisfiesReq),
+  catalogCourseSubfield: cleanField(catalogCourseSubfield),
+  catalogAttribute: cleanField(catalogAttribute),
+  acadCareer: cleanField(acadCareer) || '',
+  acadGroup: cleanField(acadGroup) || '',
 });
 
 /** @returns a list of all course objects in a semester for a given subject. */

--- a/src/requirements/courses-json-generator.ts
+++ b/src/requirements/courses-json-generator.ts
@@ -32,6 +32,15 @@ const getSubjects = async (semester: string): Promise<readonly string[]> => {
   }
 };
 
+const cleanString = (value: string | null) => {
+  if (value === null) return '';
+  return value.replace(/\u00a0/g, ' ');
+};
+
+const cleanMaybeString = (value: string | null | undefined): string | undefined => {
+  return value?.replace(/\u00a0/g, ' ') || undefined;
+};
+
 /** Throws away course object fields we don't need. Used for generate small-enough course json. */
 const courseFieldFilter = ({
   subject,
@@ -49,23 +58,23 @@ const courseFieldFilter = ({
   acadCareer,
   acadGroup,
 }: Course): Course => ({
-  subject,
+  subject: cleanString(subject),
   crseId,
-  catalogNbr,
-  titleLong,
+  catalogNbr: cleanString(catalogNbr),
+  titleLong: cleanString(titleLong),
   enrollGroups: enrollGroups.map(({ unitsMaximum, unitsMinimum }) => ({
     unitsMaximum,
     unitsMinimum,
   })),
-  catalogWhenOffered: catalogWhenOffered || undefined,
-  catalogBreadth: catalogBreadth || undefined,
-  catalogDistr: catalogDistr || undefined,
-  catalogComments: catalogComments || undefined,
-  catalogSatisfiesReq: catalogSatisfiesReq || undefined,
-  catalogCourseSubfield: catalogCourseSubfield || undefined,
-  catalogAttribute: catalogAttribute || undefined,
-  acadCareer,
-  acadGroup,
+  catalogWhenOffered: cleanMaybeString(catalogWhenOffered),
+  catalogBreadth: cleanMaybeString(catalogBreadth),
+  catalogDistr: cleanMaybeString(catalogDistr),
+  catalogComments: cleanMaybeString(catalogComments),
+  catalogSatisfiesReq: cleanMaybeString(catalogSatisfiesReq),
+  catalogCourseSubfield: cleanMaybeString(catalogCourseSubfield),
+  catalogAttribute: cleanMaybeString(catalogAttribute),
+  acadCareer: cleanString(acadCareer),
+  acadGroup: cleanString(acadGroup),
 });
 
 /** @returns a list of all course objects in a semester for a given subject. */


### PR DESCRIPTION
### Summary <!-- Required -->

When running the course generator script for SP23, I noticed that we were running into errors using the data because a course was missing a value for `titleLong`, and we just put a null in the JSON. This is a very quick fix (and does not fix the issues in #688), but it should allow us to run the script and update data for SP23.

### Test Plan <!-- Required -->

Run the script on SP23 semester and verify there are no nulls and no NBSPs in the JSON. Also verify that the script does not include or exclude extra information.