### PR TITLE
Tools Page Formatting & Useful Links

### DIFF
--- a/src/components/Tools/AdvisorCard.vue
+++ b/src/components/Tools/AdvisorCard.vue
@@ -12,7 +12,7 @@
           {{ advisor.name }}
         </span>
         <a class="advisors-info advisors-email" :href="`mailto:${advisor.email}`">
-          {{ advisor.email }}
+          <span class="advisors-email-text"> {{ advisor.email }} </span>
           <img
             class="advisors-email-icon"
             src="@/assets/images/link-gray.svg"
@@ -85,6 +85,7 @@ export default defineComponent({
     color: #3d3d3d;
     align-self: center;
     justify-self: start;
+    max-width: 100%;
   }
 
   &-row {
@@ -128,6 +129,10 @@ export default defineComponent({
 
     &-icon {
       margin-left: 0.25rem;
+    }
+
+    &-text {
+      max-width: 100%;
     }
   }
 

--- a/src/components/Tools/Card.vue
+++ b/src/components/Tools/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card" :style="cssVars" :class="{ 'card--collapsed': isCollapsed }">
+  <div class="card" :class="{ 'card--collapsed': isCollapsed }">
     <div class="card-top">
       <div class="card-minspacer">
         <img v-if="!isCollapsed" src="@/assets/images/minimize.svg" alt="minimize card" />
@@ -41,13 +41,6 @@ export default defineComponent({
     collapse() {
       this.isCollapsed = !this.isCollapsed;
       localStorage.setItem(JSON.stringify(this.name), JSON.stringify(this.isCollapsed));
-    },
-  },
-  computed: {
-    cssVars() {
-      return {
-        '--h': `${this.desiredHeight}px`,
-      };
     },
   },
 });

--- a/src/components/Tools/Card.vue
+++ b/src/components/Tools/Card.vue
@@ -26,8 +26,6 @@ export default defineComponent({
   props: {
     id: { type: String, required: true },
     name: { type: String, required: true },
-    desiredWidth: { type: Number, required: false, default: 575 },
-    desiredHeight: { type: Number, required: false, default: 150 },
   },
 
   data() {
@@ -48,7 +46,6 @@ export default defineComponent({
   computed: {
     cssVars() {
       return {
-        '--w': `${this.desiredWidth}px`,
         '--h': `${this.desiredHeight}px`,
       };
     },
@@ -60,8 +57,6 @@ export default defineComponent({
 @import '@/assets/scss/_variables.scss';
 
 .card {
-  width: var(--w);
-  min-height: var(--h);
   box-sizing: border-box;
   box-shadow: 0 0 10px 4px $boxShadowGray;
   position: relative;
@@ -72,8 +67,8 @@ export default defineComponent({
   margin: 0;
 
   &--collapsed {
-    min-height: 0;
-    height: 50px;
+    min-height: 0 !important;
+    height: 50px !important;
   }
 
   &-top {

--- a/src/components/Tools/UsefulLinks.vue
+++ b/src/components/Tools/UsefulLinks.vue
@@ -25,7 +25,7 @@ export default defineComponent({
           link: 'https://classes.cornell.edu/scheduler/',
         },
         {
-          title: 'Course Roster',
+          title: 'Class Roster',
           link: 'https://classes.cornell.edu/browse/',
         },
         {

--- a/src/components/Tools/UsefulLinks.vue
+++ b/src/components/Tools/UsefulLinks.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="links">
+    <div v-for="{ title, link } in list" :key="title" class="links-group">
+      <a class="links-link" :href="link">
+        {{ title }}
+        <img class="links-link-icon" src="@/assets/images/link-gray.svg" alt="external link" />
+      </a>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  computed: {
+    list(): { link: string; title: string }[] {
+      return [
+        {
+          title: 'Google',
+          link: 'https://google.com',
+        },
+      ];
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/assets/scss/_variables.scss';
+
+.links {
+  display: flex;
+  flex-direction: column;
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  &-link {
+    color: #3d3d3d;
+    text-decoration: underline;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: $yuxuanBlue;
+    }
+
+    display: flex;
+    align-items: center;
+
+    &-icon {
+      margin-left: 0.25rem;
+    }
+
+    margin-bottom: 0.5rem;
+  }
+}
+</style>

--- a/src/components/Tools/UsefulLinks.vue
+++ b/src/components/Tools/UsefulLinks.vue
@@ -17,8 +17,16 @@ export default defineComponent({
     list(): { link: string; title: string }[] {
       return [
         {
-          title: 'Google',
-          link: 'https://google.com',
+          title: 'Student Center',
+          link: 'https://studentcenter.cornell.edu/',
+        },
+        {
+          title: 'Course Catalog',
+          link: 'https://courses.cornell.edu/',
+        },
+        {
+          title: 'Cornell DTI',
+          link: 'https://www.cornelldti.org/',
         },
       ];
     },

--- a/src/components/Tools/UsefulLinks.vue
+++ b/src/components/Tools/UsefulLinks.vue
@@ -21,8 +21,12 @@ export default defineComponent({
           link: 'https://studentcenter.cornell.edu/',
         },
         {
-          title: 'Course Catalog',
-          link: 'https://courses.cornell.edu/',
+          title: 'Scheduler',
+          link: 'https://classes.cornell.edu/scheduler/',
+        },
+        {
+          title: 'Course Roster',
+          link: 'https://classes.cornell.edu/browse/',
         },
         {
           title: 'Cornell DTI',

--- a/src/containers/Tools.vue
+++ b/src/containers/Tools.vue
@@ -103,19 +103,6 @@ export default {
       grid-column: 2/3;
       grid-row: 2/3;
     }
-
-    @media only screen and (max-width: 1300px) {
-      &-progress {
-        flex-grow: 1;
-      }
-      &-advisors {
-        flex-grow: 1;
-      }
-      &-export {
-      }
-      &-links {
-      }
-    }
   }
 }
 </style>

--- a/src/containers/Tools.vue
+++ b/src/containers/Tools.vue
@@ -18,7 +18,7 @@
       <card name="Export Schedule" class="toolsContainer-card-export" id="export"></card>
 
       <card name="Useful Links" class="toolsContainer-card-links" id="links">
-        <p>cornell.edu</p>
+        <useful-links></useful-links>
       </card>
     </div>
   </div>
@@ -27,9 +27,10 @@
 <script>
 import Card from '@/components/Tools/Card.vue';
 import AdvisorCard from '@/components/Tools/AdvisorCard.vue';
+import UsefulLinks from '@/components/Tools/UsefulLinks.vue';
 
 export default {
-  components: { AdvisorCard, Card },
+  components: { UsefulLinks, AdvisorCard, Card },
 };
 </script>
 

--- a/src/containers/Tools.vue
+++ b/src/containers/Tools.vue
@@ -66,7 +66,7 @@ export default {
     column-gap: 5rem;
     row-gap: 3rem;
 
-    @media only screen and (max-width: 1300px) {
+    @media only screen and (max-width: 1250px) {
       display: flex;
       flex-wrap: wrap;
       justify-content: flex-start;

--- a/src/containers/Tools.vue
+++ b/src/containers/Tools.vue
@@ -67,8 +67,6 @@ export default {
     color: #757575;
     padding-bottom: 30px;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   &-cards {
@@ -81,7 +79,7 @@ export default {
     @media only screen and (max-width: 1300px) {
       display: flex;
       flex-wrap: wrap;
-      justify-content: space-around;
+      justify-content: flex-start;
     }
   }
 

--- a/src/containers/Tools.vue
+++ b/src/containers/Tools.vue
@@ -11,24 +11,13 @@
     <div class="toolsContainer-cards">
       <card name="Progress Tracker" class="toolsContainer-card-progress" id="progress"></card>
 
-      <card
-        name="Contact Your Advisors"
-        class="toolsContainer-card-advisors"
-        id="advisors"
-        :desired-height="275"
-      >
+      <card name="Contact Your Advisors" class="toolsContainer-card-advisors" id="advisors">
         <advisor-card></advisor-card>
       </card>
 
-      <card
-        name="Export Schedule"
-        class="toolsContainer-card-export"
-        id="export"
-        :desired-width="400"
-      >
-      </card>
+      <card name="Export Schedule" class="toolsContainer-card-export" id="export"></card>
 
-      <card name="Useful Links" class="toolsContainer-card-links" id="links" :desired-width="400">
+      <card name="Useful Links" class="toolsContainer-card-links" id="links">
         <p>cornell.edu</p>
       </card>
     </div>
@@ -87,21 +76,29 @@ export default {
     &-progress {
       grid-column: 1/2;
       grid-row: 1/2;
+      width: 600px;
+      height: min-content;
     }
 
     &-advisors {
       grid-column: 1/2;
       grid-row: 2/3;
+      width: 600px;
+      height: min-content;
     }
 
     &-export {
       grid-column: 2/3;
       grid-row: 1/2;
+      width: 300px;
+      height: min-content;
     }
 
     &-links {
       grid-column: 2/3;
       grid-row: 2/3;
+      width: 300px;
+      height: min-content;
     }
   }
 }


### PR DESCRIPTION
### Summary <!-- Required -->

This PR changes how tool card sizes are specified by moving it to the Tools component CSS. This PR also adds the Useful Links tool card and changes the behavior for changing the screen width. (As a bonus, it makes some tweaks to the Advisors Card for when the screen width is too small).

TODO: No advisors case

### Test Plan <!-- Required -->

1. Run `GK.enableTools()` in the javascript console.
2. Add the CS major to see some advisors data.
3. Look at Tools Page
4. Verify that the links in Useful Links work and are correct. (What do you think about the links' position?)
6. Resize the screen width
7. Collapse and expand cards

### Screenshots

<img  alt="normal" src="https://user-images.githubusercontent.com/47431797/197325196-0ef4953d-2e91-42c7-a4ab-f2176be17ebc.png">
<img  height=400 alt="smaller" src="https://user-images.githubusercontent.com/47431797/197325451-c8d21044-87dd-4c29-850a-d559784b63b2.png">