### PR TITLE
Add Advisors Data

### DIFF
--- a/src/components/Tools/AdvisorCard.vue
+++ b/src/components/Tools/AdvisorCard.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="advisors">
-    <div class="advisors-content">
+    <div class="advisors-content" v-if="advisors.length === 0">
+      <span class="advisors-empty"> Sorry, you don't have an advisor yet. </span>
+    </div>
+    <div v-else class="advisors-content">
       <div class="advisors-heading-row">
         <span class="advisors-info advisors-heading-content">Type</span>
         <span class="advisors-info advisors-heading-content">Name</span>
@@ -78,6 +81,11 @@ export default defineComponent({
     flex-direction: column;
     justify-content: flex-start;
     margin: 0 1.5rem 0 1.5rem;
+  }
+
+  &-empty {
+    display: flex;
+    justify-content: space-around;
   }
 
   &-info {

--- a/src/requirements/data/colleges/ag.ts
+++ b/src/requirements/data/colleges/ag.ts
@@ -4,7 +4,7 @@ import {
   courseIsFWS,
   includesWithSingleRequirement,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const calsCreditsRequirement: CollegeOrMajorRequirement = {
   name: 'CALS Credits',

--- a/src/requirements/data/colleges/ag.ts
+++ b/src/requirements/data/colleges/ag.ts
@@ -664,5 +664,5 @@ const calsRequirements: readonly CollegeOrMajorRequirement[] = [
 export default calsRequirements;
 
 export const calsAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Kerri Lai', email: 'kll225@cornell.edu' }],
 };

--- a/src/requirements/data/colleges/ag.ts
+++ b/src/requirements/data/colleges/ag.ts
@@ -4,6 +4,7 @@ import {
   courseIsFWS,
   includesWithSingleRequirement,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const calsCreditsRequirement: CollegeOrMajorRequirement = {
   name: 'CALS Credits',
@@ -661,3 +662,7 @@ const calsRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default calsRequirements;
+
+export const calsAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/colleges/ar.ts
+++ b/src/requirements/data/colleges/ar.ts
@@ -1,5 +1,5 @@
 import { CollegeOrMajorRequirement } from '../../types';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const aapRequirements: readonly CollegeOrMajorRequirement[] = [];
 // As of Fall 2020, there are no college-level graduation requirements in addition

--- a/src/requirements/data/colleges/ar.ts
+++ b/src/requirements/data/colleges/ar.ts
@@ -10,5 +10,5 @@ export default aapRequirements;
 // This can be accounted for in the checker
 
 export const aapAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Becky Baines', email: 'rb786@cornell.edu' }],
 };

--- a/src/requirements/data/colleges/ar.ts
+++ b/src/requirements/data/colleges/ar.ts
@@ -1,4 +1,5 @@
 import { CollegeOrMajorRequirement } from '../../types';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const aapRequirements: readonly CollegeOrMajorRequirement[] = [];
 // As of Fall 2020, there are no college-level graduation requirements in addition
@@ -7,3 +8,7 @@ export default aapRequirements;
 
 // Note: writing requirement does not accept FWS credit
 // This can be accounted for in the checker
+
+export const aapAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -1,6 +1,7 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseIsFWS, ifCodeMatch, courseIsForeignLang } from '../checkers-common';
 import { AdvisorGroup } from '@/requirements/tools-types';
+import { lastNameRange } from '../../advisor-checkers';
 
 const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -103,5 +104,11 @@ const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
 export default casFA2020Requirements;
 
 export const casAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [
+    {
+      name: 'Jayla Greene',
+      email: 'jng65@cornell.edu',
+      checker: lastNameRange('https://as.cornell.edu/advising', ''),
+    },
+  ],
 };

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -1,6 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseIsFWS, ifCodeMatch, courseIsForeignLang } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 import { lastNameRange } from '../../advisor-checkers';
 
 const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -1,5 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseIsFWS, ifCodeMatch, courseIsForeignLang } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -100,3 +101,7 @@ const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default casFA2020Requirements;
+
+export const casAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -1,7 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseIsFWS, ifCodeMatch, courseIsForeignLang } from '../checkers-common';
 import { AdvisorGroup } from '../../tools-types';
-import { lastNameRange } from '../../advisor-checkers';
 
 const casFA2020Requirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/colleges/asFA2020.ts
+++ b/src/requirements/data/colleges/asFA2020.ts
@@ -108,7 +108,7 @@ export const casAdvisors: AdvisorGroup = {
     {
       name: 'Jayla Greene',
       email: 'jng65@cornell.edu',
-      checker: lastNameRange('https://as.cornell.edu/advising', ''),
     },
   ],
+  source: 'https://as.cornell.edu/advising',
 };

--- a/src/requirements/data/colleges/bu.ts
+++ b/src/requirements/data/colleges/bu.ts
@@ -1,5 +1,10 @@
 import { CollegeOrMajorRequirement } from '../../types';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const businessRequirements: readonly CollegeOrMajorRequirement[] = [];
 // offers two undergraduate majors: AEM and Hotel Admin
 export default businessRequirements;
+
+export const businessAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/colleges/bu.ts
+++ b/src/requirements/data/colleges/bu.ts
@@ -1,5 +1,5 @@
 import { CollegeOrMajorRequirement } from '../../types';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const businessRequirements: readonly CollegeOrMajorRequirement[] = [];
 // offers two undergraduate majors: AEM and Hotel Admin

--- a/src/requirements/data/colleges/bu.ts
+++ b/src/requirements/data/colleges/bu.ts
@@ -6,5 +6,5 @@ const businessRequirements: readonly CollegeOrMajorRequirement[] = [];
 export default businessRequirements;
 
 export const businessAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Brooke Tobey', email: 'gm-registrar@cornell.edu' }],
 };

--- a/src/requirements/data/colleges/he.ts
+++ b/src/requirements/data/colleges/he.ts
@@ -1,6 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseIsFWS } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const humanEcologyRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/colleges/he.ts
+++ b/src/requirements/data/colleges/he.ts
@@ -1,5 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseIsFWS } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const humanEcologyRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -38,3 +39,7 @@ const humanEcologyRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default humanEcologyRequirements;
+
+export const humanEcologyAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/colleges/he.ts
+++ b/src/requirements/data/colleges/he.ts
@@ -41,5 +41,5 @@ const humanEcologyRequirements: readonly CollegeOrMajorRequirement[] = [
 export default humanEcologyRequirements;
 
 export const humanEcologyAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Darryl Scott', email: 'ds42@cornell.edu' }],
 };

--- a/src/requirements/data/colleges/il.ts
+++ b/src/requirements/data/colleges/il.ts
@@ -709,5 +709,5 @@ const ilrRequirements: readonly CollegeOrMajorRequirement[] = [
 export default ilrRequirements;
 
 export const ilrAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Rebecca Schimenti', email: 'rss347@cornell.edu' }],
 };

--- a/src/requirements/data/colleges/il.ts
+++ b/src/requirements/data/colleges/il.ts
@@ -5,6 +5,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const FLcourses: readonly string[] = [
   'ARAB',
@@ -706,3 +707,7 @@ const ilrRequirements: readonly CollegeOrMajorRequirement[] = [
   },
 ];
 export default ilrRequirements;
+
+export const ilrAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/colleges/il.ts
+++ b/src/requirements/data/colleges/il.ts
@@ -5,7 +5,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const FLcourses: readonly string[] = [
   'ARAB',

--- a/src/requirements/data/grad/mpa.ts
+++ b/src/requirements/data/grad/mpa.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const mpaRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -560,3 +561,7 @@ const mpaRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default mpaRequirements;
+
+export const mpaAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/grad/mpa.ts
+++ b/src/requirements/data/grad/mpa.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const mpaRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/grad/mpa.ts
+++ b/src/requirements/data/grad/mpa.ts
@@ -563,5 +563,5 @@ const mpaRequirements: readonly CollegeOrMajorRequirement[] = [
 export default mpaRequirements;
 
 export const mpaAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Rebecca Morgenstern Brenner', email: 'rjm478@cornell.edu' }],
 };

--- a/src/requirements/data/index.ts
+++ b/src/requirements/data/index.ts
@@ -48,28 +48,28 @@ import physRequirements, { physAdvisors } from './majors/phys';
 import spanishRequirements, { spanishAdvisors } from './majors/spanish';
 import psychRequirements, { psychAdvisors } from './majors/psych';
 import stsRequirements, { stsAdvisors } from './majors/sts';
-import aerospaceMinorRequirements from './minors/aerospace';
-import appliedMathMinorRequirements from './minors/applied-math';
-import buMinorRequirements from './minors/bu';
-import cogsciMinorRequirements from './minors/cogsci';
-import csMinorRequirements from './minors/cs';
-import dbmeMinorRequirements from './minors/dbme';
+import aerospaceMinorRequirements, { aerospaceMinorAdvisors } from './minors/aerospace';
+import appliedMathMinorRequirements, { appliedMathMinorAdvisors } from './minors/applied-math';
+import buMinorRequirements, { buMinorAdvisors } from './minors/bu';
+import cogsciMinorRequirements, { cogsciMinorAdvisors } from './minors/cogsci';
+import csMinorRequirements, { csMinorAdvisors } from './minors/cs';
+import dbmeMinorRequirements, { dbmeAdvisors } from './minors/dbme';
 import deaMinorRequirements from './minors/dea';
-import eceMinorRequirements from './minors/ece';
-import hpMinorRequirements from './minors/hp';
-import hdMinorRequirements from './minors/hd';
-import inequalityRequirements from './minors/ineq';
-import infoENMinorRequirements from './minors/infoEN';
-import lingMinorRequirements from './minors/ling';
-import mathMinorRequirements from './minors/math';
-import ormsMinorRequirements from './minors/orms';
-import policyMinorRequirements from './minors/policy';
-import psychMinorRequirements from './minors/psych';
-import roboticsMinorRequirements from './minors/robotics';
-import spanishMinorRequirements from './minors/spanish';
+import eceMinorRequirements, { eceMinorAdvisors } from './minors/ece';
+import hpMinorRequirements, { hpMinorAdvisors } from './minors/hp';
+import hdMinorRequirements, { hdMinorAdvisors } from './minors/hd';
+import inequalityRequirements, { inequalityAdvisors } from './minors/ineq';
+import infoENMinorRequirements, { infoENMinorAdvisors } from './minors/infoEN';
+import lingMinorRequirements, { lingMinorAdvisors } from './minors/ling';
+import mathMinorRequirements, { mathMinorAdvisors } from './minors/math';
+import ormsMinorRequirements, { ormsMinorAdvisors } from './minors/orms';
+import policyMinorRequirements, { policyMinorAdvisors } from './minors/policy';
+import psychMinorRequirements, { psychMinorAdvisors } from './minors/psych';
+import roboticsMinorRequirements, { roboticsMinorAdvisors } from './minors/robotics';
+import spanishMinorRequirements, { spanishMinorAdvisors } from './minors/spanish';
 
 // import mengCSRequirements from './grad/meng-cs';
-import mpaRequirements from './grad/mpa';
+import mpaRequirements, { mpaAdvisors } from './grad/mpa';
 
 import { MATH2940, CHEM2080 } from './specializations/en';
 
@@ -370,96 +370,115 @@ const json: RequirementsJson = {
       name: 'Aerospace Engineering',
       schools: ['EN'],
       requirements: aerospaceMinorRequirements,
+      advisors: aerospaceMinorAdvisors,
     },
     APPLIEDMATH: {
       name: 'Applied Mathematics',
       schools: ['EN'],
       requirements: appliedMathMinorRequirements,
+      advisors: appliedMathMinorAdvisors,
     },
     BU: {
       name: 'Business',
       schools: ['BU'],
       requirements: buMinorRequirements,
+      advisors: buMinorAdvisors,
     },
     COGSCI: {
       name: 'Cognitive Science',
       schools: ['AS1', 'AS2'],
       requirements: cogsciMinorRequirements,
+      advisors: cogsciMinorAdvisors,
     },
     CS: {
       name: 'Computer Science',
       schools: ['EN', 'AS1', 'AS2'],
       requirements: csMinorRequirements,
+      advisors: csMinorAdvisors,
     },
     DBME: {
       name: 'Dyson Business Minor for Engineers',
       schools: ['BU'],
       requirements: dbmeMinorRequirements,
+      advisors: dbmeAdvisors,
     },
     DEA: {
       name: 'Design and Environmental Analysis',
       schools: ['HE'],
       requirements: deaMinorRequirements,
+      advisors: deaAdvisors,
     },
     ECE: {
       name: 'Electrical and Computer Engineering',
       schools: ['EN'],
       requirements: eceMinorRequirements,
+      advisors: eceMinorAdvisors,
     },
     HP: {
       name: 'Health Policy',
       schools: ['HE'],
       requirements: hpMinorRequirements,
+      advisors: hpMinorAdvisors,
     },
     HD: {
       name: 'Human Development',
       schools: ['HE'],
       requirements: hdMinorRequirements,
+      advisors: hdMinorAdvisors,
     },
     INEQ: {
       name: 'Inequality Studies',
       schools: ['AS1', 'AS2'],
       requirements: inequalityRequirements,
+      advisors: inequalityAdvisors,
     },
     ISST: {
       name: 'Information Science [Engineering]',
       schools: ['EN'],
       requirements: infoENMinorRequirements,
+      advisors: infoENMinorAdvisors,
     },
     LING: {
       name: 'Linguistics',
       schools: ['AS1', 'AS2'],
       requirements: lingMinorRequirements,
+      advisors: lingMinorAdvisors,
     },
     MATH: {
       name: 'Mathematics',
       schools: ['AS1', 'AS2'],
       requirements: mathMinorRequirements,
+      advisors: mathMinorAdvisors,
     },
     ORMS: {
       name: 'Operations Research and Management Science',
       schools: ['EN'],
       requirements: ormsMinorRequirements,
+      advisors: ormsMinorAdvisors,
     },
     POLICY: {
       name: 'Public Policy',
       schools: ['AS1', 'AS2'],
       requirements: policyMinorRequirements,
+      advisors: policyMinorAdvisors,
     },
     PSYCH: {
       name: 'Psychology',
       schools: ['AS1', 'AS2'],
       requirements: psychMinorRequirements,
+      advisors: psychMinorAdvisors,
     },
     ROBOTICS: {
       name: 'Robotics',
       schools: ['EN'],
       requirements: roboticsMinorRequirements,
+      advisors: roboticsMinorAdvisors,
     },
     SPAN: {
       name: 'Spanish',
       schools: ['AS1', 'AS2'],
       requirements: spanishMinorRequirements,
+      advisors: spanishMinorAdvisors,
     },
   },
   grad: {
@@ -474,6 +493,7 @@ const json: RequirementsJson = {
       name: 'Master of Public Administration (MPA) Program',
       schools: ['HE'],
       requirements: mpaRequirements,
+      advisors: mpaAdvisors,
     },
   },
 };

--- a/src/requirements/data/index.ts
+++ b/src/requirements/data/index.ts
@@ -1,53 +1,53 @@
 import { RequirementsJson } from '../types';
 import universityRequirements from './university';
-import calsRequirements from './colleges/ag';
-import aapRequirements from './colleges/ar';
+import calsRequirements, { calsAdvisors } from './colleges/ag';
+import aapRequirements, { aapAdvisors } from './colleges/ar';
 import casPreFA2020Requirements from './colleges/asPreFA2020';
-import casFA2020Requirements from './colleges/asFA2020';
-import businessRequirements from './colleges/bu';
+import casFA2020Requirements, { casAdvisors } from './colleges/asFA2020';
+import businessRequirements, { businessAdvisors } from './colleges/bu';
 import engineeringRequirements, { engineeringAdvisors } from './colleges/en';
-import humanEcologyRequirements from './colleges/he';
-import ilrRequirements from './colleges/il';
-import aemRequirements from './majors/aem';
-import asRequirements from './majors/as';
-import astroRequrements from './majors/astro';
-import bioRequirements from './majors/bio';
-import bioEngineeringRequirements from './majors/be';
+import humanEcologyRequirements, { humanEcologyAdvisors } from './colleges/he';
+import ilrRequirements, { ilrAdvisors } from './colleges/il';
+import aemRequirements, { aemAdvisors } from './majors/aem';
+import asRequirements, { asAdvisors } from './majors/as';
+import astroRequrements, { astroAdvisors } from './majors/astro';
+import bioRequirements, { bioAdvisors } from './majors/bio';
+import bioEngineeringRequirements, { bioEngineeringAdvisors } from './majors/be';
 import bsocRequirements from './majors/bsoc';
-import biomedicalEngineeringRequirements from './majors/bme';
-import chemRequirements from './majors/chem';
-import chemERequirements from './majors/chemE';
-import civilRequirements from './majors/ce';
-import commRequirements from './majors/comm';
-import crpRequirements from './majors/crp';
+import biomedicalEngineeringRequirements, { biomedicalEngineeringAdvisors } from './majors/bme';
+import chemRequirements, { chemAdvisors } from './majors/chem';
+import chemERequirements, { chemEAdvisors } from './majors/chemE';
+import civilRequirements, { civilAdvisors } from './majors/ce';
+import commRequirements, { commAdvisors } from './majors/comm';
+import crpRequirements, { crpAdvisors } from './majors/crp';
 import csRequirements, { csAdvisors } from './majors/cs';
-import deaRequirements from './majors/dea';
-import easRequirements from './majors/eas';
-import economicsRequirements from './majors/econ';
-import eceRequirements from './majors/ece';
-import essRequirements from './majors/ess';
-import englishRequirements from './majors/engl';
-import envEngineeringRequirements from './majors/envE';
-import epRequirements from './majors/ep';
-import fashionDesignRequirements from './majors/fsad';
-import foodSciRequirements from './majors/foodsci';
-import governmentRequirements from './majors/govt';
-import hdRequirements from './majors/hd';
-import hotelAdminRequirements from './majors/hadm';
-import historyRequirements from './majors/hist';
-import infoRequirements from './majors/info';
-import isstRequirements from './majors/isst';
-import lingRequirements from './majors/ling';
-import mathRequirements from './majors/math';
-import mechnicalEngineeringRequirements from './majors/me';
-import mseRequirements from './majors/mse';
+import deaRequirements, { deaAdvisors } from './majors/dea';
+import easRequirements, { easAdvisors } from './majors/eas';
+import economicsRequirements, { economicsAdvisors } from './majors/econ';
+import eceRequirements, { eceAdvisors } from './majors/ece';
+import essRequirements, { essAdvisors } from './majors/ess';
+import englishRequirements, { englishAdvisors } from './majors/engl';
+import envEngineeringRequirements, { envEngineeringAdvisors } from './majors/envE';
+import epRequirements, { epAdvisors } from './majors/ep';
+import fashionDesignRequirements, { fashionDesignAdvisors } from './majors/fsad';
+import foodSciRequirements, { foodSciAdvisors } from './majors/foodsci';
+import governmentRequirements, { governmentAdvisors } from './majors/govt';
+import hdRequirements, { hdAdvisors } from './majors/hd';
+import hotelAdminRequirements, { hotelAdminAdvisors } from './majors/hadm';
+import historyRequirements, { historyAdvisors } from './majors/hist';
+import infoRequirements, { infoAdvisors } from './majors/info';
+import isstRequirements, { isstAdvisors } from './majors/isst';
+import lingRequirements, { lingAdvisors } from './majors/ling';
+import mathRequirements, { mathAdvisors } from './majors/math';
+import mechnicalEngineeringRequirements, { mechanicalEngineeringAdvisors } from './majors/me';
+import mseRequirements, { mseAdvisors } from './majors/mse';
 import oldIsstRequirements from './majors/oldIsst';
-import orieRequirements from './majors/orie';
-import pamRequirements from './majors/pam';
-import physRequirements from './majors/phys';
-import spanishRequirements from './majors/spanish';
-import psychRequirements from './majors/psych';
-import stsRequirements from './majors/sts';
+import orieRequirements, { orieAdvisors } from './majors/orie';
+import pamRequirements, { pamAdvisors } from './majors/pam';
+import physRequirements, { physAdvisors } from './majors/phys';
+import spanishRequirements, { spanishAdvisors } from './majors/spanish';
+import psychRequirements, { psychAdvisors } from './majors/psych';
+import stsRequirements, { stsAdvisors } from './majors/sts';
 import aerospaceMinorRequirements from './minors/aerospace';
 import appliedMathMinorRequirements from './minors/applied-math';
 import buMinorRequirements from './minors/bu';
@@ -84,18 +84,22 @@ const json: RequirementsJson = {
     AG: {
       name: 'Agriculture and Life Sciences',
       requirements: calsRequirements,
+      advisors: calsAdvisors,
     },
     AR: {
       name: 'Architecture, Art and Planning',
       requirements: aapRequirements,
+      advisors: aapAdvisors,
     },
     AS1: {
       name: 'Arts and Sciences [before Fall 2020]',
       requirements: casPreFA2020Requirements,
+      advisors: casAdvisors,
     },
     AS2: {
       name: 'Arts and Sciences [Fall 2020 and later]',
       requirements: casFA2020Requirements,
+      advisors: casAdvisors,
     },
     EN: {
       name: 'Engineering',
@@ -105,14 +109,17 @@ const json: RequirementsJson = {
     HE: {
       name: 'Human Ecology',
       requirements: humanEcologyRequirements,
+      advisors: humanEcologyAdvisors,
     },
     IL: {
       name: 'Industrial Labor Relations',
       requirements: ilrRequirements,
+      advisors: ilrAdvisors,
     },
     BU: {
       name: 'SC Johnson College of Business',
       requirements: businessRequirements,
+      advisors: businessAdvisors,
     },
   },
   major: {
@@ -120,61 +127,73 @@ const json: RequirementsJson = {
       name: 'Applied Economics and Management',
       schools: ['AG', 'BU'],
       requirements: aemRequirements,
+      advisors: aemAdvisors,
     },
     AS: {
       name: 'Atmospheric Science',
       schools: ['AG'],
       requirements: asRequirements,
+      advisors: asAdvisors,
     },
     ASTRO: {
       name: 'Astronomy',
       schools: ['AS1', 'AS2'],
       requirements: astroRequrements,
+      advisors: astroAdvisors,
     },
     BIO: {
       name: 'Biological Sciences',
       schools: ['AG', 'AS1', 'AS2'],
       requirements: bioRequirements,
+      advisors: bioAdvisors,
     },
     BSOC: {
       name: 'Biology and Society',
       schools: ['AG', 'AS1', 'AS2'],
       requirements: bsocRequirements,
+      advisors: bioAdvisors,
     },
     BME: {
       name: 'Biomedical Engineering',
       schools: ['EN'],
       requirements: biomedicalEngineeringRequirements,
+      advisors: biomedicalEngineeringAdvisors,
     },
     BE: {
       name: 'Biological Engineering',
       schools: ['EN'],
       requirements: bioEngineeringRequirements,
+      advisors: bioEngineeringAdvisors,
     },
     CE: {
       name: 'Civil Engineering',
       schools: ['EN'],
       requirements: civilRequirements,
+      advisors: civilAdvisors,
     },
     CHEM: {
       name: 'Chemistry',
       schools: ['AS1', 'AS2'],
       requirements: chemRequirements,
+      advisors: chemAdvisors,
     },
     CHEME: {
       name: 'Chemical and Biomolecular Engineering',
       schools: ['EN'],
       requirements: chemERequirements,
+      advisors: chemEAdvisors,
     },
     COMM: {
       name: 'Communication',
       schools: ['AG'],
       requirements: commRequirements,
+      advisors: commAdvisors,
     },
     CRP: {
       name: 'City and Regional Planning',
       schools: ['AR'],
       requirements: crpRequirements,
+      advisors: crpAdvisors,
     },
     CS: {
       name: 'Computer Science',
@@ -187,136 +206,163 @@ const json: RequirementsJson = {
       name: 'Design and Environmental Analysis',
       schools: ['HE'],
       requirements: deaRequirements,
+      advisors: deaAdvisors,
     },
     EAS: {
       name: 'Earth and Atmospheric Sciences',
       schools: ['AG', 'AS1', 'AS2', 'EN'],
       requirements: easRequirements,
+      advisors: easAdvisors,
     },
     ECON: {
       name: 'Economics',
       schools: ['AS1', 'AS2'],
       requirements: economicsRequirements,
+      advisors: economicsAdvisors,
     },
     ECE: {
       name: 'Electrical and Computer Engineering',
       schools: ['EN'],
       requirements: eceRequirements,
+      advisors: eceAdvisors,
     },
     ENGL: {
       name: 'English',
       schools: ['AS1', 'AS2'],
       requirements: englishRequirements,
+      advisors: englishAdvisors,
     },
     ENV: {
       name: 'Environmental Engineering',
       schools: ['EN'],
       requirements: envEngineeringRequirements,
+      advisors: envEngineeringAdvisors,
     },
     ESS: {
       name: 'Environment and Sustainability',
       schools: ['AG', 'AS1', 'AS2'],
       requirements: essRequirements,
+      advisors: essAdvisors,
     },
     EP: {
       name: 'Engineering Physics',
       schools: ['EN'],
       requirements: epRequirements,
+      advisors: epAdvisors,
     },
     FSAD: {
       name: 'Fashion Design',
       schools: ['HE'],
       requirements: fashionDesignRequirements,
+      advisors: fashionDesignAdvisors,
     },
     FDSC: {
       name: 'Food Science',
       schools: ['AG'],
       requirements: foodSciRequirements,
+      advisors: foodSciAdvisors,
     },
     GOVT: {
       name: 'Government',
       schools: ['AS1', 'AS2'],
       requirements: governmentRequirements,
+      advisors: governmentAdvisors,
     },
     HADM: {
       name: 'Hotel Administration',
       schools: ['BU'],
       requirements: hotelAdminRequirements,
+      advisors: hotelAdminAdvisors,
     },
     HD: {
       name: 'Human Development',
       schools: ['HE'],
       requirements: hdRequirements,
+      advisors: hdAdvisors,
     },
     HIST: {
       name: 'History',
       schools: ['AS1', 'AS2'],
       requirements: historyRequirements,
+      advisors: historyAdvisors,
     },
     INFO: {
       name: 'Information Science',
       schools: ['AS1', 'AG', 'AS2'],
       requirements: infoRequirements,
+      advisors: infoAdvisors,
     },
     ISST1: {
       name: 'Information Science, Systems, and Technology [before Fall 2020]',
       schools: ['EN'],
       requirements: oldIsstRequirements,
+      advisors: isstAdvisors,
     },
     ISST2: {
       name: 'Information Science, Systems, and Technology [Fall 2020 and after]',
       schools: ['EN'],
       requirements: isstRequirements,
+      advisors: isstAdvisors,
     },
     LING: {
       name: 'Linguistics',
       schools: ['AS1', 'AS2'],
       requirements: lingRequirements,
+      advisors: lingAdvisors,
     },
     MATH: {
       name: 'Math',
       schools: ['AS1', 'AS2'],
       requirements: mathRequirements,
+      advisors: mathAdvisors,
     },
     ME: {
       name: 'Mechanical Engineering',
       schools: ['EN'],
       requirements: mechnicalEngineeringRequirements,
+      advisors: mechanicalEngineeringAdvisors,
     },
     MSE: {
       name: 'Materials Science & Engineering',
       schools: ['EN'],
       requirements: mseRequirements,
+      advisors: mseAdvisors,
     },
     ORIE: {
       name: 'Operations Research and Engineering',
       schools: ['EN'],
       requirements: orieRequirements,
+      advisors: orieAdvisors,
     },
     PAM: {
       name: 'Policy Analysis and Management',
       schools: ['HE'],
       requirements: pamRequirements,
+      advisors: pamAdvisors,
     },
     PHYS: {
       name: 'Physics',
       schools: ['AS1', 'AS2'],
       requirements: physRequirements,
+      advisors: physAdvisors,
     },
     PSYCH: {
       name: 'Psychology',
       schools: ['AS1', 'AS2'],
       requirements: psychRequirements,
+      advisors: psychAdvisors,
     },
     SPAN: {
       name: 'Spanish',
       schools: ['AS1', 'AS2'],
       requirements: spanishRequirements,
+      advisors: spanishAdvisors,
     },
     STS: {
       name: 'Science & Technology Studies',
       schools: ['AS1', 'AS2'],
       requirements: stsRequirements,
+      advisors: stsAdvisors,
     },
   },
   minor: {

--- a/src/requirements/data/index.ts
+++ b/src/requirements/data/index.ts
@@ -39,7 +39,7 @@ import infoRequirements, { infoAdvisors } from './majors/info';
 import isstRequirements, { isstAdvisors } from './majors/isst';
 import lingRequirements, { lingAdvisors } from './majors/ling';
 import mathRequirements, { mathAdvisors } from './majors/math';
-import mechnicalEngineeringRequirements, { mechanicalEngineeringAdvisors } from './majors/me';
+import mechanicalEngineeringRequirements, { mechanicalEngineeringAdvisors } from './majors/me';
 import mseRequirements, { mseAdvisors } from './majors/mse';
 import oldIsstRequirements from './majors/oldIsst';
 import orieRequirements, { orieAdvisors } from './majors/orie';
@@ -319,7 +319,7 @@ const json: RequirementsJson = {
     ME: {
       name: 'Mechanical Engineering',
       schools: ['EN'],
-      requirements: mechnicalEngineeringRequirements,
+      requirements: mechanicalEngineeringRequirements,
       advisors: mechanicalEngineeringAdvisors,
     },
     MSE: {

--- a/src/requirements/data/majors/aem.ts
+++ b/src/requirements/data/majors/aem.ts
@@ -481,5 +481,5 @@ const aemRequirements: readonly CollegeOrMajorRequirement[] = [
 export default aemRequirements;
 
 export const aemAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Dyson Office of Student Services', email: 'Dyson_OSS@cornell.edu' }],
 };

--- a/src/requirements/data/majors/aem.ts
+++ b/src/requirements/data/majors/aem.ts
@@ -1,5 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const aemRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -478,3 +479,7 @@ const aemRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default aemRequirements;
+
+export const aemAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/aem.ts
+++ b/src/requirements/data/majors/aem.ts
@@ -1,6 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const aemRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/as.ts
+++ b/src/requirements/data/majors/as.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '@/requirements/types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const asRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/as.ts
+++ b/src/requirements/data/majors/as.ts
@@ -94,5 +94,5 @@ const asRequirements: readonly CollegeOrMajorRequirement[] = [
 export default asRequirements;
 
 export const asAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Art DeGaetano', email: 'atd2@cornell.edu' }],
 };

--- a/src/requirements/data/majors/as.ts
+++ b/src/requirements/data/majors/as.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '@/requirements/types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const asRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -91,3 +92,7 @@ const asRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default asRequirements;
+
+export const asAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/astro.ts
+++ b/src/requirements/data/majors/astro.ts
@@ -1,10 +1,11 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const astroRequirements: readonly CollegeOrMajorRequirement[] = [
   {
     name: 'Introductory Physics Sequence',
-    description: `Three semesters of physics including: 
+    description: `Three semesters of physics including:
     PHYS 1112 or PHYS 1116, PHYS 2213 or PHYS 2217, and PHYS 2214 or PHYS 2218.`,
     source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19789',
     checker: includesWithSubRequirements(
@@ -18,7 +19,7 @@ const astroRequirements: readonly CollegeOrMajorRequirement[] = [
   },
   {
     name: 'Introductory Mathematics Sequence',
-    description: `Three semesters of math including: 
+    description: `Three semesters of math including:
     MATH 1910, MATH 1120, or MATH 1220, MATH 1920, MATH 2220, or MATH 2240, and MATH 2930, MATH 4710, or ASTRO 3340.`,
     source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19789',
     checker: includesWithSubRequirements(
@@ -36,7 +37,7 @@ const astroRequirements: readonly CollegeOrMajorRequirement[] = [
   },
   {
     name: 'Experimental or Data Analysis Course in Astronomy',
-    description: `One experimental or data analysis course in astronomy chosen from: 
+    description: `One experimental or data analysis course in astronomy chosen from:
     ASTRO 4410, ASTRO 3310, or ASTRO 3334.`,
     source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19789',
     checker: includesWithSubRequirements(['ASTRO 4410', 'ASTRO 3310', 'ASTRO 3334']),
@@ -91,3 +92,7 @@ const astroRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default astroRequirements;
+
+export const astroAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/astro.ts
+++ b/src/requirements/data/majors/astro.ts
@@ -5,8 +5,7 @@ import { AdvisorGroup } from '@/requirements/tools-types';
 const astroRequirements: readonly CollegeOrMajorRequirement[] = [
   {
     name: 'Introductory Physics Sequence',
-    description: `Three semesters of physics including:
-    PHYS 1112 or PHYS 1116, PHYS 2213 or PHYS 2217, and PHYS 2214 or PHYS 2218.`,
+    description: `Three semesters of physics including: PHYS 1112 or PHYS 1116, PHYS 2213 or PHYS 2217, and PHYS 2214 or PHYS 2218.`,
     source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19789',
     checker: includesWithSubRequirements(
       ['PHYS 1112', 'PHYS 1116'],
@@ -19,8 +18,7 @@ const astroRequirements: readonly CollegeOrMajorRequirement[] = [
   },
   {
     name: 'Introductory Mathematics Sequence',
-    description: `Three semesters of math including:
-    MATH 1910, MATH 1120, or MATH 1220, MATH 1920, MATH 2220, or MATH 2240, and MATH 2930, MATH 4710, or ASTRO 3340.`,
+    description: `Three semesters of math including: MATH 1910, MATH 1120, or MATH 1220, MATH 1920, MATH 2220, or MATH 2240, and MATH 2930, MATH 4710, or ASTRO 3340.`,
     source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19789',
     checker: includesWithSubRequirements(
       ['MATH 1910', 'MATH 1120', 'MATH 1220'],
@@ -37,8 +35,7 @@ const astroRequirements: readonly CollegeOrMajorRequirement[] = [
   },
   {
     name: 'Experimental or Data Analysis Course in Astronomy',
-    description: `One experimental or data analysis course in astronomy chosen from:
-    ASTRO 4410, ASTRO 3310, or ASTRO 3334.`,
+    description: `One experimental or data analysis course in astronomy chosen from: ASTRO 4410, ASTRO 3310, or ASTRO 3334.`,
     source: 'https://courses.cornell.edu/preview_program.php?catoid=41&poid=19789',
     checker: includesWithSubRequirements(['ASTRO 4410', 'ASTRO 3310', 'ASTRO 3334']),
     fulfilledBy: 'courses',

--- a/src/requirements/data/majors/astro.ts
+++ b/src/requirements/data/majors/astro.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const astroRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/astro.ts
+++ b/src/requirements/data/majors/astro.ts
@@ -91,5 +91,5 @@ const astroRequirements: readonly CollegeOrMajorRequirement[] = [
 export default astroRequirements;
 
 export const astroAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Gordon J Stacey', email: 'stacey@cornell.edu' }],
 };

--- a/src/requirements/data/majors/be.ts
+++ b/src/requirements/data/majors/be.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const bioEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/be.ts
+++ b/src/requirements/data/majors/be.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const bioEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -181,3 +182,7 @@ const bioEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default bioEngineeringRequirements;
+
+export const bioEngineeringAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/be.ts
+++ b/src/requirements/data/majors/be.ts
@@ -184,5 +184,5 @@ const bioEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
 export default bioEngineeringRequirements;
 
 export const bioEngineeringAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Jillian Goldfarb', email: 'jlg459@cornell.edu' }],
 };

--- a/src/requirements/data/majors/bio.ts
+++ b/src/requirements/data/majors/bio.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const bioRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -694,3 +695,7 @@ const bioRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default bioRequirements;
+
+export const bioAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/bio.ts
+++ b/src/requirements/data/majors/bio.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const bioRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/bio.ts
+++ b/src/requirements/data/majors/bio.ts
@@ -697,5 +697,5 @@ const bioRequirements: readonly CollegeOrMajorRequirement[] = [
 export default bioRequirements;
 
 export const bioAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Amy Drumluk', email: 'ard244@cornell.edu' }],
 };

--- a/src/requirements/data/majors/bme.ts
+++ b/src/requirements/data/majors/bme.ts
@@ -154,5 +154,5 @@ const biomedicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = 
 export default biomedicalEngineeringRequirements;
 
 export const biomedicalEngineeringAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Meinig School of Biomedical Engineering', email: 'bmeugrad@cornell.edu' }],
 };

--- a/src/requirements/data/majors/bme.ts
+++ b/src/requirements/data/majors/bme.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const biomedicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -151,3 +152,7 @@ const biomedicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = 
 ];
 
 export default biomedicalEngineeringRequirements;
+
+export const biomedicalEngineeringAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/bme.ts
+++ b/src/requirements/data/majors/bme.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const biomedicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/bsoc.ts
+++ b/src/requirements/data/majors/bsoc.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const biologyAndSocietyRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/bsoc.ts
+++ b/src/requirements/data/majors/bsoc.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const biologyAndSocietyRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -307,3 +308,7 @@ const biologyAndSocietyRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default biologyAndSocietyRequirements;
+
+export const bioAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/bsoc.ts
+++ b/src/requirements/data/majors/bsoc.ts
@@ -310,5 +310,5 @@ const biologyAndSocietyRequirements: readonly CollegeOrMajorRequirement[] = [
 export default biologyAndSocietyRequirements;
 
 export const bioAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'David Ryan', email: 'dwr28@cornell.edu' }],
 };

--- a/src/requirements/data/majors/ce.ts
+++ b/src/requirements/data/majors/ce.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const civilRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/ce.ts
+++ b/src/requirements/data/majors/ce.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const civilRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -142,3 +143,7 @@ const civilRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default civilRequirements;
+
+export const civilAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/ce.ts
+++ b/src/requirements/data/majors/ce.ts
@@ -145,5 +145,5 @@ const civilRequirements: readonly CollegeOrMajorRequirement[] = [
 export default civilRequirements;
 
 export const civilAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Laura Ricciuti', email: 'lr482@cornell.edu' }],
 };

--- a/src/requirements/data/majors/chem.ts
+++ b/src/requirements/data/majors/chem.ts
@@ -303,5 +303,5 @@ const chemRequirements: readonly CollegeOrMajorRequirement[] = [
 export default chemRequirements;
 
 export const chemAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Donald Austin', email: 'chemdus@cornell.edu' }],
 };

--- a/src/requirements/data/majors/chem.ts
+++ b/src/requirements/data/majors/chem.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const chemRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -300,3 +301,7 @@ const chemRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default chemRequirements;
+
+export const chemAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/chem.ts
+++ b/src/requirements/data/majors/chem.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const chemRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/chemE.ts
+++ b/src/requirements/data/majors/chemE.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { ifCodeMatch, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const chemERequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -260,3 +261,7 @@ const chemERequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default chemERequirements;
+
+export const chemEAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/chemE.ts
+++ b/src/requirements/data/majors/chemE.ts
@@ -263,5 +263,5 @@ const chemERequirements: readonly CollegeOrMajorRequirement[] = [
 export default chemERequirements;
 
 export const chemEAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Carol Casler', email: 'cad1@cornell.edu' }],
 };

--- a/src/requirements/data/majors/chemE.ts
+++ b/src/requirements/data/majors/chemE.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { ifCodeMatch, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const chemERequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/comm.ts
+++ b/src/requirements/data/majors/comm.ts
@@ -4,7 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const commRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/comm.ts
+++ b/src/requirements/data/majors/comm.ts
@@ -4,6 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const commRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -162,3 +163,7 @@ const commRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default commRequirements;
+
+export const commAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/comm.ts
+++ b/src/requirements/data/majors/comm.ts
@@ -165,5 +165,5 @@ const commRequirements: readonly CollegeOrMajorRequirement[] = [
 export default commRequirements;
 
 export const commAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Ashlee Cherry', email: 'ac2396@cornell.edu' }],
 };

--- a/src/requirements/data/majors/crp.ts
+++ b/src/requirements/data/majors/crp.ts
@@ -4,6 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const crpRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -161,3 +162,7 @@ const crpRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default crpRequirements;
+
+export const crpAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/crp.ts
+++ b/src/requirements/data/majors/crp.ts
@@ -164,5 +164,5 @@ const crpRequirements: readonly CollegeOrMajorRequirement[] = [
 export default crpRequirements;
 
 export const crpAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Nicholas Klein', email: 'njk8@cornell.edu' }],
 };

--- a/src/requirements/data/majors/crp.ts
+++ b/src/requirements/data/majors/crp.ts
@@ -4,7 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const crpRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/dea.ts
+++ b/src/requirements/data/majors/dea.ts
@@ -1,6 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseIsForeignLang, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const deaRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/dea.ts
+++ b/src/requirements/data/majors/dea.ts
@@ -213,5 +213,5 @@ const deaRequirements: readonly CollegeOrMajorRequirement[] = [
 export default deaRequirements;
 
 export const deaAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Rhonda Gilmore', email: 'rg35@cornell.edu' }],
 };

--- a/src/requirements/data/majors/dea.ts
+++ b/src/requirements/data/majors/dea.ts
@@ -1,5 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseIsForeignLang, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const deaRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -210,3 +211,7 @@ const deaRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default deaRequirements;
+
+export const deaAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/eas.ts
+++ b/src/requirements/data/majors/eas.ts
@@ -4,7 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const easRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/eas.ts
+++ b/src/requirements/data/majors/eas.ts
@@ -249,5 +249,5 @@ const easRequirements: readonly CollegeOrMajorRequirement[] = [
 export default easRequirements;
 
 export const easAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Bruce Monger', email: 'bcm3@cornell.edu' }],
 };

--- a/src/requirements/data/majors/eas.ts
+++ b/src/requirements/data/majors/eas.ts
@@ -4,6 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const easRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -246,3 +247,7 @@ const easRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default easRequirements;
+
+export const easAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/ece.ts
+++ b/src/requirements/data/majors/ece.ts
@@ -4,7 +4,7 @@ import {
   includesWithSubRequirements,
   courseMatchesCodeOptions,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const eceRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/ece.ts
+++ b/src/requirements/data/majors/ece.ts
@@ -4,6 +4,7 @@ import {
   includesWithSubRequirements,
   courseMatchesCodeOptions,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const eceRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -170,3 +171,7 @@ const eceRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default eceRequirements;
+
+export const eceAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/ece.ts
+++ b/src/requirements/data/majors/ece.ts
@@ -173,5 +173,5 @@ const eceRequirements: readonly CollegeOrMajorRequirement[] = [
 export default eceRequirements;
 
 export const eceAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Sharif Ewais-Orozco', email: 'ugrad-coordinator@ece.cornell.edu' }],
 };

--- a/src/requirements/data/majors/econ.ts
+++ b/src/requirements/data/majors/econ.ts
@@ -4,6 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const economicsRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -75,3 +76,7 @@ const economicsRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default economicsRequirements;
+
+export const economicsAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/econ.ts
+++ b/src/requirements/data/majors/econ.ts
@@ -4,7 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const economicsRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/econ.ts
+++ b/src/requirements/data/majors/econ.ts
@@ -78,5 +78,5 @@ const economicsRequirements: readonly CollegeOrMajorRequirement[] = [
 export default economicsRequirements;
 
 export const economicsAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Allison Barrett', email: 'aeb238@cornell.edu' }],
 };

--- a/src/requirements/data/majors/engl.ts
+++ b/src/requirements/data/majors/engl.ts
@@ -89,5 +89,5 @@ const englishRequirements: readonly CollegeOrMajorRequirement[] = [
 export default englishRequirements;
 
 export const englishAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Aurora Ricardo', email: 'ar2368@cornell.edu' }],
 };

--- a/src/requirements/data/majors/engl.ts
+++ b/src/requirements/data/majors/engl.ts
@@ -1,5 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseMatchesCodeOptions, ifCodeMatch } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const englishRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -86,3 +87,7 @@ const englishRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default englishRequirements;
+
+export const englishAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/engl.ts
+++ b/src/requirements/data/majors/engl.ts
@@ -1,6 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { courseMatchesCodeOptions, ifCodeMatch } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const englishRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/envE.ts
+++ b/src/requirements/data/majors/envE.ts
@@ -157,5 +157,5 @@ const envEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
 export default envEngineeringRequirements;
 
 export const envEngineeringAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Laura Ricciuti', email: 'lr482@cornell.edu' }],
 };

--- a/src/requirements/data/majors/envE.ts
+++ b/src/requirements/data/majors/envE.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const majorApproved: readonly string[] = [
   'BEE',
@@ -154,3 +155,7 @@ const envEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default envEngineeringRequirements;
+
+export const envEngineeringAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/envE.ts
+++ b/src/requirements/data/majors/envE.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const majorApproved: readonly string[] = [
   'BEE',

--- a/src/requirements/data/majors/ep.ts
+++ b/src/requirements/data/majors/ep.ts
@@ -1,5 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, ifCodeMatch } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const epRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -106,3 +107,7 @@ const epRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default epRequirements;
+
+export const epAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/ep.ts
+++ b/src/requirements/data/majors/ep.ts
@@ -1,6 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, ifCodeMatch } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const epRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/ep.ts
+++ b/src/requirements/data/majors/ep.ts
@@ -109,5 +109,5 @@ const epRequirements: readonly CollegeOrMajorRequirement[] = [
 export default epRequirements;
 
 export const epAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Craig Fennie', email: 'fennie@cornell.edu' }],
 };

--- a/src/requirements/data/majors/ess.ts
+++ b/src/requirements/data/majors/ess.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const environmentAndSustainability: readonly CollegeOrMajorRequirement[] = [
   {
@@ -639,3 +640,7 @@ const environmentAndSustainability: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default environmentAndSustainability;
+
+export const essAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/ess.ts
+++ b/src/requirements/data/majors/ess.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const environmentAndSustainability: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/ess.ts
+++ b/src/requirements/data/majors/ess.ts
@@ -642,5 +642,5 @@ const environmentAndSustainability: readonly CollegeOrMajorRequirement[] = [
 export default environmentAndSustainability;
 
 export const essAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Suzanne Wapner', email: 'sw38@cornell.edu' }],
 };

--- a/src/requirements/data/majors/foodsci.ts
+++ b/src/requirements/data/majors/foodsci.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const foodSciRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/foodsci.ts
+++ b/src/requirements/data/majors/foodsci.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const foodSciRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -284,3 +285,7 @@ const foodSciRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default foodSciRequirements;
+
+export const foodSciAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/foodsci.ts
+++ b/src/requirements/data/majors/foodsci.ts
@@ -287,5 +287,5 @@ const foodSciRequirements: readonly CollegeOrMajorRequirement[] = [
 export default foodSciRequirements;
 
 export const foodSciAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Jennifer Alcaine', email: 'jsa97@cornell.edu' }],
 };

--- a/src/requirements/data/majors/fsad.ts
+++ b/src/requirements/data/majors/fsad.ts
@@ -5,7 +5,7 @@ import {
   courseIsForeignLang,
   courseMatchesCodeOptions,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const fashionDesignAdditionalRequirements: readonly string[] = [
   'PBS',

--- a/src/requirements/data/majors/fsad.ts
+++ b/src/requirements/data/majors/fsad.ts
@@ -5,6 +5,7 @@ import {
   courseIsForeignLang,
   courseMatchesCodeOptions,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const fashionDesignAdditionalRequirements: readonly string[] = [
   'PBS',
@@ -233,3 +234,7 @@ const fashionDesignRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default fashionDesignRequirements;
+
+export const fashionDesignAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/fsad.ts
+++ b/src/requirements/data/majors/fsad.ts
@@ -236,5 +236,5 @@ const fashionDesignRequirements: readonly CollegeOrMajorRequirement[] = [
 export default fashionDesignRequirements;
 
 export const fashionDesignAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Fran Kozen', email: 'fhk2@cornell.edu' }],
 };

--- a/src/requirements/data/majors/govt.ts
+++ b/src/requirements/data/majors/govt.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { ifCodeMatch, includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const governmentRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -68,3 +69,7 @@ const governmentRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default governmentRequirements;
+
+export const governmentAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/govt.ts
+++ b/src/requirements/data/majors/govt.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { ifCodeMatch, includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const governmentRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/govt.ts
+++ b/src/requirements/data/majors/govt.ts
@@ -71,5 +71,5 @@ const governmentRequirements: readonly CollegeOrMajorRequirement[] = [
 export default governmentRequirements;
 
 export const governmentAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: "Danielle O'Connor", email: 'dko1@cornell.edu' }],
 };

--- a/src/requirements/data/majors/hadm.ts
+++ b/src/requirements/data/majors/hadm.ts
@@ -4,7 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const hotelAdminRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/hadm.ts
+++ b/src/requirements/data/majors/hadm.ts
@@ -136,5 +136,5 @@ const hotelAdminRequirements: readonly CollegeOrMajorRequirement[] = [
 export default hotelAdminRequirements;
 
 export const hotelAdminAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Nolan School Advising', email: 'ha-advising@cornell.edu' }],
 };

--- a/src/requirements/data/majors/hadm.ts
+++ b/src/requirements/data/majors/hadm.ts
@@ -4,6 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const hotelAdminRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -133,3 +134,7 @@ const hotelAdminRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default hotelAdminRequirements;
+
+export const hotelAdminAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/hd.ts
+++ b/src/requirements/data/majors/hd.ts
@@ -8,7 +8,7 @@ import {
   courseIsForeignLang,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const hdRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/hd.ts
+++ b/src/requirements/data/majors/hd.ts
@@ -276,5 +276,5 @@ const hdRequirements: readonly CollegeOrMajorRequirement[] = [
 export default hdRequirements;
 
 export const hdAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Vivian Zayas', email: 'psych-dus@cornell.edu' }],
 };

--- a/src/requirements/data/majors/hd.ts
+++ b/src/requirements/data/majors/hd.ts
@@ -8,6 +8,7 @@ import {
   courseIsForeignLang,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const hdRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -273,3 +274,7 @@ const hdRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default hdRequirements;
+
+export const hdAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/hist.ts
+++ b/src/requirements/data/majors/hist.ts
@@ -48,5 +48,5 @@ const historyRequirements: readonly CollegeOrMajorRequirement[] = [
 export default historyRequirements;
 
 export const historyAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Robert Travers', email: 'history_DUS@cornell.edu' }],
 };

--- a/src/requirements/data/majors/hist.ts
+++ b/src/requirements/data/majors/hist.ts
@@ -1,4 +1,5 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const historyRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -45,3 +46,7 @@ const historyRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default historyRequirements;
+
+export const historyAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/hist.ts
+++ b/src/requirements/data/majors/hist.ts
@@ -1,5 +1,5 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const historyRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/info.ts
+++ b/src/requirements/data/majors/info.ts
@@ -5,6 +5,7 @@ import {
   ifCodeMatch,
 } from '../checkers-common';
 import { AdvisorGroup } from '@/requirements/tools-types';
+import { lastNameRange } from '../../advisor-checkers';
 
 const infoRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -307,5 +308,9 @@ const infoRequirements: readonly CollegeOrMajorRequirement[] = [
 export default infoRequirements;
 
 export const infoAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [
+    { name: 'Ani Mercincavage', email: 'am2643@cornell.edu' },
+    { name: 'Terry Horgan', email: 'tmh233@cornell.edu', checker: lastNameRange('A', 'I') },
+    { name: 'Jess Wilkie', email: 'jlw433@cornell.edu', checker: lastNameRange('J', 'Z') },
+  ],
 };

--- a/src/requirements/data/majors/info.ts
+++ b/src/requirements/data/majors/info.ts
@@ -4,7 +4,7 @@ import {
   courseMatchesCodeOptions,
   ifCodeMatch,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 import { lastNameRange } from '../../advisor-checkers';
 
 const infoRequirements: readonly CollegeOrMajorRequirement[] = [

--- a/src/requirements/data/majors/info.ts
+++ b/src/requirements/data/majors/info.ts
@@ -4,6 +4,7 @@ import {
   courseMatchesCodeOptions,
   ifCodeMatch,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const infoRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -304,3 +305,7 @@ const infoRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default infoRequirements;
+
+export const infoAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/info.ts
+++ b/src/requirements/data/majors/info.ts
@@ -310,7 +310,6 @@ export default infoRequirements;
 export const infoAdvisors: AdvisorGroup = {
   advisors: [
     { name: 'Ani Mercincavage', email: 'am2643@cornell.edu' },
-    { name: 'Terry Horgan', email: 'tmh233@cornell.edu', checker: lastNameRange('A', 'I') },
-    { name: 'Jess Wilkie', email: 'jlw433@cornell.edu', checker: lastNameRange('J', 'Z') },
+    { name: 'Jess Wilkie', email: 'jlw433@cornell.edu' },
   ],
 };

--- a/src/requirements/data/majors/info.ts
+++ b/src/requirements/data/majors/info.ts
@@ -5,7 +5,6 @@ import {
   ifCodeMatch,
 } from '../checkers-common';
 import { AdvisorGroup } from '../../tools-types';
-import { lastNameRange } from '../../advisor-checkers';
 
 const infoRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/isst.ts
+++ b/src/requirements/data/majors/isst.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const isstRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -498,3 +499,7 @@ const isstRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default isstRequirements;
+
+export const isstAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/isst.ts
+++ b/src/requirements/data/majors/isst.ts
@@ -504,7 +504,6 @@ export default isstRequirements;
 export const isstAdvisors: AdvisorGroup = {
   advisors: [
     { name: 'Ani Mercincavage', email: 'am2643@cornell.edu' },
-    { name: 'Terry Horgan', email: 'tmh233@cornell.edu', checker: lastNameRange('A', 'I') },
-    { name: 'Jess Wilkie', email: 'jlw433@cornell.edu', checker: lastNameRange('J', 'Z') },
+    { name: 'Jess Wilkie', email: 'jlw433@cornell.edu' },
   ],
 };

--- a/src/requirements/data/majors/isst.ts
+++ b/src/requirements/data/majors/isst.ts
@@ -1,7 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, includesWithSingleRequirement } from '../checkers-common';
 import { AdvisorGroup } from '../../tools-types';
-import { lastNameRange } from '../../advisor-checkers';
 
 const isstRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/isst.ts
+++ b/src/requirements/data/majors/isst.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 import { lastNameRange } from '../../advisor-checkers';
 
 const isstRequirements: readonly CollegeOrMajorRequirement[] = [

--- a/src/requirements/data/majors/isst.ts
+++ b/src/requirements/data/majors/isst.ts
@@ -1,6 +1,7 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, includesWithSingleRequirement } from '../checkers-common';
 import { AdvisorGroup } from '@/requirements/tools-types';
+import { lastNameRange } from '../../advisor-checkers';
 
 const isstRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -501,5 +502,9 @@ const isstRequirements: readonly CollegeOrMajorRequirement[] = [
 export default isstRequirements;
 
 export const isstAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [
+    { name: 'Ani Mercincavage', email: 'am2643@cornell.edu' },
+    { name: 'Terry Horgan', email: 'tmh233@cornell.edu', checker: lastNameRange('A', 'I') },
+    { name: 'Jess Wilkie', email: 'jlw433@cornell.edu', checker: lastNameRange('J', 'Z') },
+  ],
 };

--- a/src/requirements/data/majors/ling.ts
+++ b/src/requirements/data/majors/ling.ts
@@ -121,5 +121,5 @@ const lingRequirements: readonly CollegeOrMajorRequirement[] = [
 export default lingRequirements;
 
 export const lingAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Abigail Cohn', email: 'acc4@cornell.edu' }],
 };

--- a/src/requirements/data/majors/ling.ts
+++ b/src/requirements/data/majors/ling.ts
@@ -8,6 +8,7 @@ import {
   courseMeetsCreditMinimum,
   courseHasAttribute,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const lingRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -118,3 +119,7 @@ const lingRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default lingRequirements;
+
+export const lingAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/ling.ts
+++ b/src/requirements/data/majors/ling.ts
@@ -8,7 +8,7 @@ import {
   courseMeetsCreditMinimum,
   courseHasAttribute,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const lingRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/math.ts
+++ b/src/requirements/data/majors/math.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const mathRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/math.ts
+++ b/src/requirements/data/majors/math.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const mathRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -414,3 +415,7 @@ const mathRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default mathRequirements;
+
+export const mathAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/math.ts
+++ b/src/requirements/data/majors/math.ts
@@ -417,5 +417,10 @@ const mathRequirements: readonly CollegeOrMajorRequirement[] = [
 export default mathRequirements;
 
 export const mathAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [
+    {
+      name: 'Michelle Klinger',
+      email: 'mmk8@cornell.edu',
+    },
+  ],
 };

--- a/src/requirements/data/majors/me.ts
+++ b/src/requirements/data/majors/me.ts
@@ -4,6 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const mechnicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -171,3 +172,7 @@ const mechnicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default mechnicalEngineeringRequirements;
+
+export const mechanicalEngineeringAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/me.ts
+++ b/src/requirements/data/majors/me.ts
@@ -4,7 +4,7 @@ import {
   includesWithSingleRequirement,
   includesWithSubRequirements,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const mechanicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/me.ts
+++ b/src/requirements/data/majors/me.ts
@@ -6,7 +6,7 @@ import {
 } from '../checkers-common';
 import { AdvisorGroup } from '@/requirements/tools-types';
 
-const mechnicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
+const mechanicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   {
     name: 'Engineering Distriubtions',
     description: 'ENGRD 2020',
@@ -171,7 +171,7 @@ const mechnicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = [
   },
 ];
 
-export default mechnicalEngineeringRequirements;
+export default mechanicalEngineeringRequirements;
 
 export const mechanicalEngineeringAdvisors: AdvisorGroup = {
   advisors: [],

--- a/src/requirements/data/majors/me.ts
+++ b/src/requirements/data/majors/me.ts
@@ -174,5 +174,5 @@ const mechanicalEngineeringRequirements: readonly CollegeOrMajorRequirement[] = 
 export default mechanicalEngineeringRequirements;
 
 export const mechanicalEngineeringAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Kae-Lynn Buchanan Wilson', email: 'kbw28@cornell.edu' }],
 };

--- a/src/requirements/data/majors/mse.ts
+++ b/src/requirements/data/majors/mse.ts
@@ -5,7 +5,7 @@ import {
   includesWithSubRequirements,
   includesWithSingleRequirement,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 // courses that can be used for the materials elective
 const materialsElectives = [

--- a/src/requirements/data/majors/mse.ts
+++ b/src/requirements/data/majors/mse.ts
@@ -5,6 +5,7 @@ import {
   includesWithSubRequirements,
   includesWithSingleRequirement,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 // courses that can be used for the materials elective
 const materialsElectives = [
@@ -303,3 +304,7 @@ const mseRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default mseRequirements;
+
+export const mseAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/mse.ts
+++ b/src/requirements/data/majors/mse.ts
@@ -306,5 +306,5 @@ const mseRequirements: readonly CollegeOrMajorRequirement[] = [
 export default mseRequirements;
 
 export const mseAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Michele Conrad', email: 'mmc2@cornell.edu' }],
 };

--- a/src/requirements/data/majors/orie.ts
+++ b/src/requirements/data/majors/orie.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { ifCodeMatch, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const orieRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -79,3 +80,7 @@ const orieRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default orieRequirements;
+
+export const orieAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/orie.ts
+++ b/src/requirements/data/majors/orie.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { ifCodeMatch, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const orieRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/orie.ts
+++ b/src/requirements/data/majors/orie.ts
@@ -82,5 +82,5 @@ const orieRequirements: readonly CollegeOrMajorRequirement[] = [
 export default orieRequirements;
 
 export const orieAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Heidi Russell', email: 'hjr27@cornell.edu' }],
 };

--- a/src/requirements/data/majors/pam.ts
+++ b/src/requirements/data/majors/pam.ts
@@ -8,7 +8,7 @@ import {
   includesWithSubRequirements,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const pamRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/pam.ts
+++ b/src/requirements/data/majors/pam.ts
@@ -228,5 +228,5 @@ const pamRequirements: readonly CollegeOrMajorRequirement[] = [
 export default pamRequirements;
 
 export const pamAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Jen Wright', email: 'jrd292@cornell.edu' }],
 };

--- a/src/requirements/data/majors/pam.ts
+++ b/src/requirements/data/majors/pam.ts
@@ -8,6 +8,7 @@ import {
   includesWithSubRequirements,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const pamRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -225,3 +226,7 @@ const pamRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default pamRequirements;
+
+export const pamAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/phys.ts
+++ b/src/requirements/data/majors/phys.ts
@@ -124,5 +124,5 @@ const physRequirements: readonly CollegeOrMajorRequirement[] = [
 export default physRequirements;
 
 export const physAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Tomas Arias', email: 'physicsdus@cornell.edu' }],
 };

--- a/src/requirements/data/majors/phys.ts
+++ b/src/requirements/data/majors/phys.ts
@@ -4,6 +4,7 @@ import {
   includesWithSubRequirements,
   ifCodeMatch,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const physRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -121,3 +122,7 @@ const physRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default physRequirements;
+
+export const physAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/phys.ts
+++ b/src/requirements/data/majors/phys.ts
@@ -4,7 +4,7 @@ import {
   includesWithSubRequirements,
   ifCodeMatch,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const physRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/psych.ts
+++ b/src/requirements/data/majors/psych.ts
@@ -114,5 +114,5 @@ const psychRequirements: readonly CollegeOrMajorRequirement[] = [
 export default psychRequirements;
 
 export const psychAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Vivian Zayas', email: 'psych-dus@cornell.edu' }],
 };

--- a/src/requirements/data/majors/psych.ts
+++ b/src/requirements/data/majors/psych.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const psychRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -111,3 +112,7 @@ const psychRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default psychRequirements;
+
+export const psychAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/psych.ts
+++ b/src/requirements/data/majors/psych.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements, includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const psychRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/spanish.ts
+++ b/src/requirements/data/majors/spanish.ts
@@ -4,7 +4,7 @@ import {
   ifCodeMatch,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const spanishRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/majors/spanish.ts
+++ b/src/requirements/data/majors/spanish.ts
@@ -4,6 +4,7 @@ import {
   ifCodeMatch,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const spanishRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -55,3 +56,7 @@ const spanishRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default spanishRequirements;
+
+export const spanishAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/spanish.ts
+++ b/src/requirements/data/majors/spanish.ts
@@ -58,5 +58,5 @@ const spanishRequirements: readonly CollegeOrMajorRequirement[] = [
 export default spanishRequirements;
 
 export const spanishAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Callean Hile', email: 'clh2@cornell.edu' }],
 };

--- a/src/requirements/data/majors/sts.ts
+++ b/src/requirements/data/majors/sts.ts
@@ -1,6 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { ifCodeMatch, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 // from here https://courses.cornell.edu/preview_program.php?catoid=31&poid=15425
 const stsScienceRequirement: readonly string[] = ['PBS', 'PBSS', 'OPHLS', 'BIOLS', 'BIO'];

--- a/src/requirements/data/majors/sts.ts
+++ b/src/requirements/data/majors/sts.ts
@@ -1,5 +1,6 @@
 import { Course, CollegeOrMajorRequirement } from '../../types';
 import { ifCodeMatch, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 // from here https://courses.cornell.edu/preview_program.php?catoid=31&poid=15425
 const stsScienceRequirement: readonly string[] = ['PBS', 'PBSS', 'OPHLS', 'BIOLS', 'BIO'];
@@ -93,3 +94,7 @@ const stsRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default stsRequirements;
+
+export const stsAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/majors/sts.ts
+++ b/src/requirements/data/majors/sts.ts
@@ -96,5 +96,5 @@ const stsRequirements: readonly CollegeOrMajorRequirement[] = [
 export default stsRequirements;
 
 export const stsAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Jessica Ratcliff', email: 'jrr47@cornell.edu' }],
 };

--- a/src/requirements/data/minors/aerospace.ts
+++ b/src/requirements/data/minors/aerospace.ts
@@ -112,5 +112,5 @@ const aerospaceMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default aerospaceMinorRequirements;
 
 export const aerospaceMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Kae-Lynn Buchanan Wilson', email: 'kbw28@cornell.edu' }],
 };

--- a/src/requirements/data/minors/aerospace.ts
+++ b/src/requirements/data/minors/aerospace.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const aerospaceMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -109,3 +110,7 @@ const aerospaceMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default aerospaceMinorRequirements;
+
+export const aerospaceMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/aerospace.ts
+++ b/src/requirements/data/minors/aerospace.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const aerospaceMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/applied-math.ts
+++ b/src/requirements/data/minors/applied-math.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const appliedMathMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/applied-math.ts
+++ b/src/requirements/data/minors/applied-math.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const appliedMathMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -26,3 +27,7 @@ const appliedMathMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default appliedMathMinorRequirements;
+
+export const appliedMathMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/applied-math.ts
+++ b/src/requirements/data/minors/applied-math.ts
@@ -29,5 +29,5 @@ const appliedMathMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default appliedMathMinorRequirements;
 
 export const appliedMathMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'David Bindel', email: 'bindel@cornell.edu' }],
 };

--- a/src/requirements/data/minors/bu.ts
+++ b/src/requirements/data/minors/bu.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const buMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -86,3 +87,7 @@ const buMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default buMinorRequirements;
+
+export const buMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/bu.ts
+++ b/src/requirements/data/minors/bu.ts
@@ -89,5 +89,5 @@ const buMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default buMinorRequirements;
 
 export const buMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Jenny VanAtta', email: 'jmv86@cornell.edu' }],
 };

--- a/src/requirements/data/minors/bu.ts
+++ b/src/requirements/data/minors/bu.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const buMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/cogsci.ts
+++ b/src/requirements/data/minors/cogsci.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const cogsciMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -33,3 +34,7 @@ const cogsciMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default cogsciMinorRequirements;
+
+export const cogsciMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/cogsci.ts
+++ b/src/requirements/data/minors/cogsci.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const cogsciMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/cogsci.ts
+++ b/src/requirements/data/minors/cogsci.ts
@@ -36,5 +36,5 @@ const cogsciMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default cogsciMinorRequirements;
 
 export const cogsciMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Julie Simmons-Lynch', email: 'jes257@cornell.edu' }],
 };

--- a/src/requirements/data/minors/cs.ts
+++ b/src/requirements/data/minors/cs.ts
@@ -6,6 +6,7 @@ import {
   courseMatchesCode,
 } from '../checkers-common';
 import { AdvisorGroup } from '@/requirements/tools-types';
+import { lastNameRange } from '@/requirements/advisor-checkers';
 
 const csMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -70,5 +71,9 @@ const csMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default csMinorRequirements;
 
 export const csMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [
+    { name: 'Ryan Marchenese ', email: 'ryan.m@cornell.edu', checker: lastNameRange('A', 'H') },
+    { name: 'Carl Cornell', email: 'cec232@cornell.edu', checker: lastNameRange('I', 'Q') },
+    { name: 'Nicole Roy', email: 'nicole.roy@cornell.edu', checker: lastNameRange('R', 'Z') },
+  ],
 };

--- a/src/requirements/data/minors/cs.ts
+++ b/src/requirements/data/minors/cs.ts
@@ -5,8 +5,8 @@ import {
   ifCodeMatch,
   courseMatchesCode,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
-import { lastNameRange } from '@/requirements/advisor-checkers';
+import { AdvisorGroup } from '../../tools-types';
+import { lastNameRange } from '../../advisor-checkers';
 
 const csMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/cs.ts
+++ b/src/requirements/data/minors/cs.ts
@@ -5,6 +5,7 @@ import {
   ifCodeMatch,
   courseMatchesCode,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const csMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -67,3 +68,7 @@ const csMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default csMinorRequirements;
+
+export const csMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/dbme.ts
+++ b/src/requirements/data/minors/dbme.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const dbmeMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -109,3 +110,7 @@ const dbmeMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default dbmeMinorRequirements;
+
+export const dbmeAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/dbme.ts
+++ b/src/requirements/data/minors/dbme.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const dbmeMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/dbme.ts
+++ b/src/requirements/data/minors/dbme.ts
@@ -112,5 +112,5 @@ const dbmeMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default dbmeMinorRequirements;
 
 export const dbmeAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Jenny VanAtta', email: 'jmv86@cornell.edu' }],
 };

--- a/src/requirements/data/minors/dea.ts
+++ b/src/requirements/data/minors/dea.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const deaMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/dea.ts
+++ b/src/requirements/data/minors/dea.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const deaMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -60,3 +61,7 @@ const deaMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default deaMinorRequirements;
+
+export const deaAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/dea.ts
+++ b/src/requirements/data/minors/dea.ts
@@ -63,5 +63,5 @@ const deaMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default deaMinorRequirements;
 
 export const deaAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Rhonda Gilmore', email: 'rg35@cornell.edu' }],
 };

--- a/src/requirements/data/minors/ece.ts
+++ b/src/requirements/data/minors/ece.ts
@@ -5,6 +5,7 @@ import {
   ifCodeMatch,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const eceMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -73,3 +74,7 @@ const eceMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default eceMinorRequirements;
+
+export const eceMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/ece.ts
+++ b/src/requirements/data/minors/ece.ts
@@ -76,5 +76,5 @@ const eceMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default eceMinorRequirements;
 
 export const eceMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Sharif Ewais-Orozco', email: 'ugrad-coordinator@ece.cornell.edu' }],
 };

--- a/src/requirements/data/minors/ece.ts
+++ b/src/requirements/data/minors/ece.ts
@@ -5,7 +5,7 @@ import {
   ifCodeMatch,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const eceMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/hd.ts
+++ b/src/requirements/data/minors/hd.ts
@@ -5,6 +5,7 @@ import {
   courseMatchesCodeOptions,
   includesWithSingleRequirement,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const hdMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -48,3 +49,7 @@ const hdMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default hdMinorRequirements;
+
+export const hdMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/hd.ts
+++ b/src/requirements/data/minors/hd.ts
@@ -5,7 +5,7 @@ import {
   courseMatchesCodeOptions,
   includesWithSingleRequirement,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const hdMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/hd.ts
+++ b/src/requirements/data/minors/hd.ts
@@ -51,5 +51,5 @@ const hdMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default hdMinorRequirements;
 
 export const hdMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Vivian Zayas', email: 'psych-dus@cornell.edu' }],
 };

--- a/src/requirements/data/minors/hp.ts
+++ b/src/requirements/data/minors/hp.ts
@@ -61,5 +61,5 @@ const hpMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default hpMinorRequirements;
 
 export const hpMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Jen Wright', email: 'jrd292@cornell.edu' }],
 };

--- a/src/requirements/data/minors/hp.ts
+++ b/src/requirements/data/minors/hp.ts
@@ -4,7 +4,7 @@ import {
   courseMatchesCodeOptions,
   ifCodeMatch,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const hpMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/hp.ts
+++ b/src/requirements/data/minors/hp.ts
@@ -4,6 +4,7 @@ import {
   courseMatchesCodeOptions,
   ifCodeMatch,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const hpMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -58,3 +59,7 @@ const hpMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default hpMinorRequirements;
+
+export const hpMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/ineq.ts
+++ b/src/requirements/data/minors/ineq.ts
@@ -232,5 +232,5 @@ const inequalityRequirements: readonly CollegeOrMajorRequirement[] = [
 export default inequalityRequirements;
 
 export const inequalityAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'John Niederbuhl', email: 'jwn3@cornell.edu' }],
 };

--- a/src/requirements/data/minors/ineq.ts
+++ b/src/requirements/data/minors/ineq.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const inequalityRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -229,3 +230,7 @@ const inequalityRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default inequalityRequirements;
+
+export const inequalityAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/ineq.ts
+++ b/src/requirements/data/minors/ineq.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const inequalityRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/infoEN.ts
+++ b/src/requirements/data/minors/infoEN.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const infoENMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -278,3 +279,7 @@ const infoENMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default infoENMinorRequirements;
+
+export const infoENMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/infoEN.ts
+++ b/src/requirements/data/minors/infoEN.ts
@@ -281,5 +281,5 @@ const infoENMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default infoENMinorRequirements;
 
 export const infoENMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Terry Horgan', email: 'tmh233@cornell.edu' }],
 };

--- a/src/requirements/data/minors/infoEN.ts
+++ b/src/requirements/data/minors/infoEN.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const infoENMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/infoEN.ts
+++ b/src/requirements/data/minors/infoEN.ts
@@ -281,5 +281,5 @@ const infoENMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default infoENMinorRequirements;
 
 export const infoENMinorAdvisors: AdvisorGroup = {
-  advisors: [{ name: 'Terry Horgan', email: 'tmh233@cornell.edu' }],
+  advisors: [{ name: 'Jess Wilkie', email: 'jlw433@cornell.edu' }],
 };

--- a/src/requirements/data/minors/ling.ts
+++ b/src/requirements/data/minors/ling.ts
@@ -84,5 +84,5 @@ const lingMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default lingMinorRequirements;
 
 export const lingMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Abigail Cohn', email: 'acc4@cornell.edu' }],
 };

--- a/src/requirements/data/minors/ling.ts
+++ b/src/requirements/data/minors/ling.ts
@@ -7,7 +7,7 @@ import {
   includesWithSingleRequirement,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const lingMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/ling.ts
+++ b/src/requirements/data/minors/ling.ts
@@ -7,6 +7,7 @@ import {
   includesWithSingleRequirement,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const lingMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -81,3 +82,7 @@ const lingMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default lingMinorRequirements;
+
+export const lingMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/math.ts
+++ b/src/requirements/data/minors/math.ts
@@ -75,5 +75,5 @@ const mathMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default mathMinorRequirements;
 
 export const mathMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Michelle Klinger', email: 'mmk8@cornell.edu' }],
 };

--- a/src/requirements/data/minors/math.ts
+++ b/src/requirements/data/minors/math.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const mathMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -72,3 +73,7 @@ const mathMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default mathMinorRequirements;
+
+export const mathMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/math.ts
+++ b/src/requirements/data/minors/math.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement, includesWithSubRequirements } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const mathMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/orms.ts
+++ b/src/requirements/data/minors/orms.ts
@@ -4,7 +4,7 @@ import {
   ifCodeMatch,
   includesWithSingleRequirement,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const ormsMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/orms.ts
+++ b/src/requirements/data/minors/orms.ts
@@ -4,6 +4,7 @@ import {
   ifCodeMatch,
   includesWithSingleRequirement,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const ormsMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -52,3 +53,7 @@ const ormsMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default ormsMinorRequirements;
+
+export const ormsMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/orms.ts
+++ b/src/requirements/data/minors/orms.ts
@@ -55,5 +55,5 @@ const ormsMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default ormsMinorRequirements;
 
 export const ormsMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Heidi Russell', email: 'hjr27@cornell.edu' }],
 };

--- a/src/requirements/data/minors/policy.ts
+++ b/src/requirements/data/minors/policy.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { includesWithSingleRequirement, courseMatchesCodeOptions } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const policyMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -37,3 +38,7 @@ const policyMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default policyMinorRequirements;
+
+export const policyMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/policy.ts
+++ b/src/requirements/data/minors/policy.ts
@@ -40,5 +40,5 @@ const policyMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default policyMinorRequirements;
 
 export const policyMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Aaron Childree', email: 'eac328@cornell.edu' }],
 };

--- a/src/requirements/data/minors/policy.ts
+++ b/src/requirements/data/minors/policy.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement, Course } from '../../types';
 import { includesWithSingleRequirement, courseMatchesCodeOptions } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const policyMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/psych.ts
+++ b/src/requirements/data/minors/psych.ts
@@ -26,5 +26,5 @@ const psychMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default psychMinorRequirements;
 
 export const psychMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Vivian Zayas', email: 'psych-dus@cornell.edu' }],
 };

--- a/src/requirements/data/minors/psych.ts
+++ b/src/requirements/data/minors/psych.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const psychMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/data/minors/psych.ts
+++ b/src/requirements/data/minors/psych.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const psychMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -23,3 +24,7 @@ const psychMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default psychMinorRequirements;
+
+export const psychMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/robotics.ts
+++ b/src/requirements/data/minors/robotics.ts
@@ -102,5 +102,5 @@ const roboticsMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default roboticsMinorRequirements;
 
 export const roboticsMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Kae-Lynn Buchanan Wilson', email: 'kbw28@cornell.edu' }],
 };

--- a/src/requirements/data/minors/robotics.ts
+++ b/src/requirements/data/minors/robotics.ts
@@ -1,6 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const roboticsMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   // TODO: can't handle major specific restrictions yet

--- a/src/requirements/data/minors/robotics.ts
+++ b/src/requirements/data/minors/robotics.ts
@@ -1,5 +1,6 @@
 import { CollegeOrMajorRequirement } from '../../types';
 import { includesWithSingleRequirement } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const roboticsMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   // TODO: can't handle major specific restrictions yet
@@ -99,3 +100,7 @@ const roboticsMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default roboticsMinorRequirements;
+
+export const roboticsMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/spanish.ts
+++ b/src/requirements/data/minors/spanish.ts
@@ -4,6 +4,7 @@ import {
   ifCodeMatch,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
+import { AdvisorGroup } from '@/requirements/tools-types';
 
 const spanishMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {
@@ -50,3 +51,7 @@ const spanishMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 ];
 
 export default spanishMinorRequirements;
+
+export const spanishMinorAdvisors: AdvisorGroup = {
+  advisors: [],
+};

--- a/src/requirements/data/minors/spanish.ts
+++ b/src/requirements/data/minors/spanish.ts
@@ -53,5 +53,5 @@ const spanishMinorRequirements: readonly CollegeOrMajorRequirement[] = [
 export default spanishMinorRequirements;
 
 export const spanishMinorAdvisors: AdvisorGroup = {
-  advisors: [],
+  advisors: [{ name: 'Callean Hile', email: 'clh2@cornell.edu' }],
 };

--- a/src/requirements/data/minors/spanish.ts
+++ b/src/requirements/data/minors/spanish.ts
@@ -4,7 +4,7 @@ import {
   ifCodeMatch,
   courseMeetsCreditMinimum,
 } from '../checkers-common';
-import { AdvisorGroup } from '@/requirements/tools-types';
+import { AdvisorGroup } from '../../tools-types';
 
 const spanishMinorRequirements: readonly CollegeOrMajorRequirement[] = [
   {

--- a/src/requirements/tools-types.ts
+++ b/src/requirements/tools-types.ts
@@ -14,7 +14,7 @@ export type Advisor = {
 export type AdvisorPackage = {
   readonly name: string;
   readonly type: 'major' | 'minor' | 'college';
-  readonly source: string;
+  readonly source?: string;
   readonly acronym: string;
   readonly email: string;
 };

--- a/src/requirements/tools-types.ts
+++ b/src/requirements/tools-types.ts
@@ -1,6 +1,6 @@
 export type AdvisorGroup = {
   readonly advisors: Advisor[];
-  readonly source: string;
+  readonly source?: string;
 };
 
 export type AdvisorChecker = (user: FirestoreUserName) => boolean;


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds the advisors data from @michaelfarkouh's research into the codebase. See #690 for an explanation of where this data is stored and how it is integrated into the app. Thanks @zachary0kent for helping to enter the data! This PR also fixes a misspelling in the mechanical engineering requirements data export, and it adds the front-end for no advisors.

### Test Plan <!-- Required -->

Run `GK.enableTools()` in the console. Set your college, major, and minor, and verify that the advisors in the Advisors tool card are correct and the email links work.
For anyone looking at the code: GitHub doesn't want to show you the diff for `src/requirements/data/index.ts`, but you **should view it!**