### PR TITLE
[easy] Write script outputs to ignored directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ cypress/videos
 # Firebase service account, used for things like running scripts and logging in for e2e tests
 serviceAccount.json
 serviceAccountProd.json
+
+# App-specific output files that should be ignored
+scripts/out

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,9 @@ cypress/videos
 *.sw?
 
 # Firebase service account, used for things like running scripts and logging in for e2e tests
+serviceAccount**
 serviceAccount.json
+serviceAccountDev.json
 serviceAccountProd.json
 
 # App-specific output files that should be ignored

--- a/scripts/copy-user-data.ts
+++ b/scripts/copy-user-data.ts
@@ -14,7 +14,6 @@
  */
 
 import parseArgs from 'minimist';
-import { writeFileSync } from 'fs';
 import {
   DATABASE_URL_DEV,
   DATABASE_URL_PROD,
@@ -23,6 +22,7 @@ import {
   getDatabase,
   userCollectionNames,
 } from './firebase-config';
+import { writeToFile } from './util';
 
 const args = parseArgs(process.argv, {
   string: ['f', 't', 'o'],
@@ -104,7 +104,7 @@ async function execute(
     if (!options.output) {
       console.log(JSON.stringify(log, undefined, 2));
     } else {
-      writeFileSync(options.output, JSON.stringify(log, undefined, 2));
+      writeToFile(log, options.output);
     }
   }
 }

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -1,0 +1,21 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * Make sure this directory is in the .gitignore
+ * Otherwise, sensitive information may be accidentally pushed
+ */
+const DEFAULT_OUTPUT_DIRECTORY = path.join('scripts', 'out');
+
+export const writeToFile = (value, fileName: string) => {
+  try {
+    mkdirSync(DEFAULT_OUTPUT_DIRECTORY, { recursive: true });
+  } finally {
+    writeFileSync(
+      path.join(DEFAULT_OUTPUT_DIRECTORY, fileName),
+      JSON.stringify(value, undefined, 2)
+    );
+  }
+};
+
+export default { writeToFile };


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request writes script outputs to an ignored directory (currently `scripts/out`). It also adds `serviceAccountDev.json` and `serviceAccount**` to the .gitignore.

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Run the copy-user-data script and observe the output is gitignored.