### PR TITLE
Profile Page Feature Flag

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -14,7 +14,7 @@
           <img class="navbar-icon hairline" src="@/assets/images/navbar/hairline.svg" />
         </div>
         <div
-          v-if="toolsEnabled"
+          v-if="showOpenPlan"
           class="navbar-buttonWrapper desktop"
           @click="openPlan"
           data-cyId="openPlan"
@@ -60,7 +60,7 @@
           </span>
         </button>
         <button
-          v-if="toolsEnabled"
+          v-if="showOpenPlan"
           class="nav-mobile-button"
           data-cyId="navbar-openPlan"
           @click="openPlan"
@@ -119,6 +119,9 @@ export default defineComponent({
   computed: {
     toolsEnabled(): boolean {
       return featureFlagCheckers.isToolsEnabled();
+    },
+    showOpenPlan(): boolean {
+      return this.toolsEnabled || featureFlagCheckers.isProfileEnabled();
     },
   },
   methods: {

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -257,9 +257,9 @@ export default defineComponent({
     },
 
     openProfile() {
-      if (featureFlagCheckers.isToolsEnabled()) {
+      this.showToolsPage = false;
+      if (featureFlagCheckers.isProfileEnabled()) {
         this.isProfileOpen = true;
-        this.showToolsPage = false;
       } else {
         this.editProfile();
       }

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -8,7 +8,8 @@ type FeatureFlagName =
   | 'RequirementConflicts'
   | 'RequirementDebugger'
   | 'ToggleRequirementsBarBtn'
-  | 'Tools';
+  | 'Tools'
+  | 'Profile';
 /* | 'AddYourFeatureFlagNameHere' */
 const featureFlagCheckers: FeatureFlagCheckers = registerFeatureFlagChecker(
   'APIBFulfillment',
@@ -16,7 +17,8 @@ const featureFlagCheckers: FeatureFlagCheckers = registerFeatureFlagChecker(
   'RequirementConflicts',
   'RequirementDebugger',
   'ToggleRequirementsBarBtn',
-  'Tools'
+  'Tools',
+  'Profile'
   /* 'AddYourFeatureFlagNameHere' */
 );
 export default featureFlagCheckers;


### PR DESCRIPTION
### Summary <!-- Required -->

Added a feature flag `Profile` for the new profile page, decoupling it from the `Tools` feature flag. Run `GK.enableProfile()` and `GK.disableProfile()` to show and gate the new profile page, respectively.

### Test Plan <!-- Required -->

Test every combination of enabling/disabling the tools and profile page, navigating between them and the plan page and checking for any unexpected behavior.

