### PR TITLE
Remove Unnecessary Information from Requirements JSON

### DIFF
--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -341,14 +341,14 @@ const generateDecoratedRequirementsJson = (): DecoratedRequirementsJson => {
       sortRequirementCourses
     );
   Object.entries(university).forEach(([universityName, universityRequirement]) => {
-    const { requirements, advisors, ...rest } = universityRequirement;
+    const { requirements, advisors, abbr, ...rest } = universityRequirement;
     decoratedJson.university[universityName] = {
       ...rest,
       requirements: decorateRequirements(requirements),
     };
   });
   Object.entries(college).forEach(([collegeName, collegeRequirement]) => {
-    const { requirements, advisors, ...rest } = collegeRequirement;
+    const { requirements, advisors, abbr, ...rest } = collegeRequirement;
     decoratedJson.college[collegeName] = {
       ...rest,
       requirements: decorateRequirements(requirements),


### PR DESCRIPTION
### Summary <!-- Required -->

Removes the `abbr` field added to the requirements JSON.

### Notes

We don't want the abbr field to be in the requirements JSON. So, we can just remove it from the JSON generator. However, this brings up a bigger issue with our infrastructure. The data in index.ts is treated as the JSON data in terms of types. There's no way currently to include extra data in index.ts without it also being part of the JSON type. Our solution is to make the type optional so it doesn't have to appear in the JSON and we can remove it, but that isn't ideal.

Here's an example. If we want abbr to be in index.ts, we need to add it to `CollegeRequirements<R>`.
<img width="387" alt="image" src="https://user-images.githubusercontent.com/47431797/198374457-ef55525b-d412-4c56-9b71-ed21f45413b1.png">

However, the JSON uses this type.
![image](https://user-images.githubusercontent.com/47431797/198374606-aa652aea-84e4-427f-a1a4-2cdb51b1799c.png)

The req JSON generator returns a MutableRequirementsJSON that (I believe) becomes readonly when the data is read from the JSON. So, we need to add abbr to the MutableRequirementsJSON type so that we guarantee that the abbr is in the JSON.
![image](https://user-images.githubusercontent.com/47431797/198375002-37692982-0e44-4fe5-9fc5-c4738131d21f.png)

This is how we would use an actual type. As you can see, including something in index.ts requires us to include it in the JSON, which isn't what we want. I think we should try to decouple index.ts from the JSON, so the JSON uses the index.ts data, rather than it being the data.

### Test Plan <!-- Required -->

Run the req generator script and verify the abbr are not in the generated JSON.