### PR TITLE
Create Export Schedule Tool Card

### DIFF
--- a/src/assets/images/download.svg
+++ b/src/assets/images/download.svg
@@ -1,0 +1,6 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M31.5 22.5V28.5C31.5 29.2956 31.1839 30.0587 30.6213 30.6213C30.0587 31.1839 29.2956 31.5 28.5 31.5H7.5C6.70435 31.5 5.94129 31.1839 5.37868 30.6213C4.81607 30.0587 4.5 29.2956 4.5 28.5V22.5"
+          stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10.5 15L18 22.5L25.5 15" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M18 22.5V4.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Tools/ExportCard.vue
+++ b/src/components/Tools/ExportCard.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="export">
+    <img class="export-icon" src="@/assets/images/download.svg" alt="export schedule" />
+    <span class="export-text">Export your schedule as PDF and share with your friends!</span>
+    <button class="export-button">Download</button>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  methods: {},
+});
+</script>
+
+<style scoped lang="scss">
+@import '@/assets/scss/_variables.scss';
+
+.export {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+
+  &-text {
+    text-align: center;
+    margin-bottom: 1rem;
+  }
+
+  &-icon {
+    size: 2rem;
+    margin-bottom: 1rem;
+  }
+
+  &-button {
+    border-radius: 3px;
+    background-color: #4d7d92;
+    color: white;
+    font-size: 1rem;
+    padding: 0.25rem 0 0.25rem 0;
+    width: 75%;
+  }
+}
+</style>

--- a/src/components/Tools/ExportCard.vue
+++ b/src/components/Tools/ExportCard.vue
@@ -2,7 +2,7 @@
   <div class="export">
     <img class="export-icon" src="@/assets/images/download.svg" alt="export schedule" />
     <span class="export-text">Export your schedule as PDF and share with your friends!</span>
-    <button class="export-button">Download</button>
+    <button class="export-button" @click="exportSchedule">Download</button>
   </div>
 </template>
 
@@ -10,7 +10,12 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-  methods: {},
+  methods: {
+    async exportSchedule() {
+      // eslint-disable-next-line no-console
+      console.info('Download PDF');
+    },
+  },
 });
 </script>
 

--- a/src/containers/Tools.vue
+++ b/src/containers/Tools.vue
@@ -95,14 +95,14 @@ export default {
       grid-column: 2/3;
       grid-row: 1/2;
       width: 300px;
-      height: min-content;
+      height: 250px;
     }
 
     &-links {
       grid-column: 2/3;
       grid-row: 2/3;
       width: 300px;
-      height: min-content;
+      height: 250px;
     }
   }
 }

--- a/src/containers/Tools.vue
+++ b/src/containers/Tools.vue
@@ -30,7 +30,7 @@
 import Card from '@/components/Tools/Card.vue';
 import AdvisorCard from '@/components/Tools/AdvisorCard.vue';
 import UsefulLinks from '@/components/Tools/UsefulLinks.vue';
-import ExportCard from '@/components/Tools/ExportCard';
+import ExportCard from '@/components/Tools/ExportCard.vue';
 
 export default {
   components: { ExportCard, UsefulLinks, AdvisorCard, Card },

--- a/src/containers/Tools.vue
+++ b/src/containers/Tools.vue
@@ -15,7 +15,9 @@
         <advisor-card></advisor-card>
       </card>
 
-      <card name="Export Schedule" class="toolsContainer-card-export" id="export"></card>
+      <card name="Export Schedule" class="toolsContainer-card-export" id="export">
+        <export-card></export-card>
+      </card>
 
       <card name="Useful Links" class="toolsContainer-card-links" id="links">
         <useful-links></useful-links>
@@ -28,9 +30,10 @@
 import Card from '@/components/Tools/Card.vue';
 import AdvisorCard from '@/components/Tools/AdvisorCard.vue';
 import UsefulLinks from '@/components/Tools/UsefulLinks.vue';
+import ExportCard from '@/components/Tools/ExportCard';
 
 export default {
-  components: { UsefulLinks, AdvisorCard, Card },
+  components: { ExportCard, UsefulLinks, AdvisorCard, Card },
 };
 </script>
 


### PR DESCRIPTION
### Summary <!-- Required -->

This PR creates the Export Schedule tool card and adds it to the Tools page. After this PR is merged into master, we can hook up the download button to the pdf generation in #730. If we merge this PR, we should close #744.

### Test Plan <!-- Required -->

Enable the tools page by running `GK.enableTools()` in the javascript console. Look at the Export Schedule tool card.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/47431797/198392448-97b2b8ae-a97b-4428-93ab-a433078a3150.png">