### PR TITLE
[Easy] Fix linting for enums

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,6 +75,8 @@ module.exports = {
     'no-use-before-define': ['off'],
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "error"
   },
   settings: {
     'import/resolver': {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,8 +75,8 @@ module.exports = {
     'no-use-before-define': ['off'],
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    "no-shadow": "off",
-    "@typescript-eslint/no-shadow": "error"
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': 'error',
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
### Summary <!-- Required -->

Modifies our `.eslintrc` file to lint enums correctly. The `no-shadow` rule currently fails on enum declarations for some reason; this fixes it.