### PR TITLE
[Easy] Fix Navigation Bug

### DIFF
--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -257,9 +257,9 @@ export default defineComponent({
     },
 
     openProfile() {
-      this.showToolsPage = false;
       if (featureFlagCheckers.isProfileEnabled()) {
         this.isProfileOpen = true;
+        this.showToolsPage = false;
       } else {
         this.editProfile();
       }


### PR DESCRIPTION
### Summary <!-- Required -->

Fixes a bug where closing the profile modal from the tools page brings you back to the plan page. Note this is still currently broken for the new gatekept profile page, but resolved in #712.

### Test Plan <!-- Required -->

Open the profile while on tools and then close the profile. Ensure you're still on tools.
