### PR TITLE
Refactor Teleport Modal to Use Composition API

### DIFF
--- a/src/components/Modals/TeleportModal.vue
+++ b/src/components/Modals/TeleportModal.vue
@@ -49,66 +49,83 @@
     </div>
   </Teleport>
 </template>
-<script lang="ts">
-import { defineComponent, ref, PropType } from 'vue';
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
 import store from '@/store';
 
-export default defineComponent({
-  props: {
-    title: { type: String, default: '' },
-    contentClass: { type: String, required: true },
-    leftButtonText: { type: String, default: '' },
-    rightButtonText: { type: String, default: '' },
-    rightButtonImage: { type: String, default: '' },
-    rightButtonAlt: { type: String, default: '' },
-    rightButtonIsDisabled: { type: Boolean, default: false },
-    rightButtonIsHighlighted: { type: Boolean, default: false },
-    isSimpleModal: { type: Boolean, default: false }, // true if the modal will set its own styling for its position
-    hasNoBackground: { type: Boolean, default: false }, // true for modals without the gray overlay behind them
-    hasClickableTransparentBackground: { type: Boolean, default: false }, // modals without a gray overlay behind them AND clicking on the background closes the modal
-    hasCustomPosition: { type: Boolean, default: false }, // true if you want to set custom position for modal
-    position: {
-      type: Object as PropType<{ x: number; y: number }>,
-      default: () => ({ x: 0, y: 0 }),
-    }, // custom position (hasCustomPosition must be true)
-  },
-  data() {
-    const customPosition = this.hasCustomPosition
-      ? {
-          left: `${this.position.x}px`,
-          top: `${this.position.y}px`,
-        }
-      : {};
-    return {
-      customPosition,
-    };
-  },
-  emits: ['left-button-clicked', 'right-button-clicked', 'modal-closed'],
-  setup(props, { emit }) {
-    const modalBackground = ref((null as unknown) as HTMLDivElement);
+type Props = {
+  title?: string;
+  contentClass: string;
+  leftButtonText?: string;
+  rightButtonText?: string;
+  rightButtonImage?: string;
+  rightButtonAlt?: string;
+  rightButtonIsDisabled?: boolean;
+  rightButtonIsHighlighted?: boolean;
+  /** `true` if the modal will set its own styling for its position */
+  isSimpleModal?: boolean;
+  /** `true` for modals without the gray overlay behind them */
+  hasNoBackground?: boolean;
+  /** modals without a gray overlay behind them AND clicking on the background closes the modal */
+  hasClickableTransparentBackground?: boolean;
+  /** `true` if you want to set custom position for modal */
+  hasCustomPosition?: boolean;
+  /** custom position (hasCustomPosition must be true) */
+  position?: { x: number; y: number };
+};
 
-    const close = () => {
-      store.commit('setIsTeleportModalOpen', false);
-      emit('modal-closed', true);
-    };
-
-    const closeOnClickOutside = (e: MouseEvent) => {
-      if (e.target === modalBackground.value) close();
-    };
-
-    const leftButtonClicked = () => {
-      emit('left-button-clicked');
-    };
-
-    const rightButtonClicked = () => {
-      emit('right-button-clicked');
-    };
-
-    store.commit('setIsTeleportModalOpen', true);
-
-    return { close, closeOnClickOutside, leftButtonClicked, rightButtonClicked, modalBackground };
-  },
+const props = withDefaults(defineProps<Props>(), {
+  title: '',
+  leftButtonText: '',
+  rightButtonText: '',
+  rightButtonImage: '',
+  rightButtonAlt: '',
+  rightButtonIsDisabled: false,
+  rightButtonIsHighlighted: false,
+  isSimpleModal: false,
+  hasNoBackground: false,
+  hasClickableTransparentBackground: false,
+  hasCustomPosition: false,
+  position: () => ({ x: 0, y: 0 }),
 });
+
+type Emits = {
+  (e: 'left-button-clicked'): void;
+  (e: 'right-button-clicked'): void;
+  (e: 'modal-closed', closed: boolean): void;
+};
+
+const emit = defineEmits<Emits>();
+
+const close = () => {
+  store.commit('setIsTeleportModalOpen', false);
+  emit('modal-closed', true);
+};
+
+const modalBackground = ref<HTMLDivElement | null>(null);
+
+const closeOnClickOutside = (e: MouseEvent) => {
+  if (e.target === modalBackground.value) close();
+};
+
+const leftButtonClicked = () => {
+  emit('left-button-clicked');
+};
+
+const rightButtonClicked = () => {
+  emit('right-button-clicked');
+};
+
+const customPosition = computed(() => {
+  const {
+    hasCustomPosition,
+    position: { x, y },
+  } = props;
+  return hasCustomPosition ? { left: `${x}px`, top: `${y}px` } : {};
+});
+
+store.commit('setIsTeleportModalOpen', true);
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
### Summary <!-- Required -->

This PR refactors `TeleportModal.vue` to use the new Vue composition API. I plan to create a modal similar to the Teleport Modal, but the options API which we currently use makes composing components very difficult. This PR also shows how the composition API allows us to make emits and props much, much more type safe. Looking ahead, I think a future refactor of the codebase to use the composition API would definitely be worth it.

### Test Plan <!-- Required -->

E2E tests should assure us that this doesn't break anything--if it did, nearly every test would fail. Regardless, you can perform the usual tasks that use the teleport modal (such as adding a course) and ensure everything looks OK.
