### PR TITLE
Removed Conflicts Feature Flag

### DIFF
--- a/src/components/Requirements/RequirementDisplayToggle.vue
+++ b/src/components/Requirements/RequirementDisplayToggle.vue
@@ -31,12 +31,14 @@
 import { PropType, defineComponent } from 'vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 import { fulfillmentProgressString } from '@/requirements/requirement-frontend-utils';
-import featureFlagCheckers from '@/feature-flags';
 
 export default defineComponent({
   components: { DropDownArrow },
   props: {
-    requirementFulfillment: { type: Object as PropType<RequirementFulfillment>, required: true },
+    requirementFulfillment: {
+      type: Object as PropType<RequirementFulfillment>,
+      required: true,
+    },
     isCompleted: { type: Boolean, required: true },
     displayDescription: { type: Boolean, required: true },
   },
@@ -53,8 +55,6 @@ export default defineComponent({
       // Compute progress string x/y requirements fulfilled.
       // We also need to include the main requirement into consideration.
 
-      let totalFulfilledRequirements =
-        fulfillment.safeMinCountFulfilled >= fulfillment.minCountRequired ? 1 : 0;
       let dangerouslyFulfilledCount =
         fulfillment.dangerousMinCountFulfilled >= fulfillment.minCountRequired ? 1 : 0;
 
@@ -67,19 +67,10 @@ export default defineComponent({
         ) {
           dangerouslyFulfilledCount += 1;
         }
-
-        if (
-          additionalRequirementProgress.safeMinCountFulfilled >=
-          additionalRequirementProgress.minCountRequired
-        ) {
-          totalFulfilledRequirements += 1;
-        }
       }
 
       // count anything that fulfills requirement, including dangerous fulfillments
-      return featureFlagCheckers.isRequirementConflictsEnabled()
-        ? `${dangerouslyFulfilledCount}/${totalRequirementsCount} requirements`
-        : `${totalFulfilledRequirements}/${totalRequirementsCount} requirements`;
+      return `${dangerouslyFulfilledCount}/${totalRequirementsCount} requirements`;
     },
   },
 });

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -141,7 +141,6 @@
           aria-valuemax="100"
         ></div>
         <div
-          v-if="conflictsEnabled"
           class="progress-bar progress-bar--warning"
           :style="{ width: dangerousProgressWidth }"
           role="progressbar"
@@ -203,7 +202,6 @@ import {
   getGradFullName,
   getReqColor,
 } from '@/utilities';
-import featureFlagCheckers from '@/feature-flags';
 import {
   groupedRequirementDangerouslyFulfilled,
   groupedRequirementTotalDangerousRequirementProgress,
@@ -218,8 +216,14 @@ export default defineComponent({
     displayDetails: { type: Boolean, required: true },
     displayedMajorIndex: { type: Number, required: true },
     displayedMinorIndex: { type: Number, required: true },
-    req: { type: Object as PropType<GroupedRequirementFulfillmentReport>, required: true },
-    onboardingData: { type: Object as PropType<AppOnboardingData>, required: true },
+    req: {
+      type: Object as PropType<GroupedRequirementFulfillmentReport>,
+      required: true,
+    },
+    onboardingData: {
+      type: Object as PropType<AppOnboardingData>,
+      required: true,
+    },
     showMajorOrMinorRequirements: { type: Boolean, required: true },
     numOfColleges: { type: Number, required: true },
   },
@@ -235,9 +239,6 @@ export default defineComponent({
     },
   },
   computed: {
-    conflictsEnabled(): boolean {
-      return featureFlagCheckers.isRequirementConflictsEnabled();
-    },
     requirementDangerouslyFulfilled(): number {
       return groupedRequirementDangerouslyFulfilled(this.req);
     },
@@ -266,9 +267,7 @@ export default defineComponent({
       return ((diff / this.requirementTotalRequired) * 100).toFixed(1);
     },
     numberConflicts(): number {
-      return this.conflictsEnabled
-        ? this.totalDangerousRequirementProgress - this.totalSafeRequirementProgress
-        : 0;
+      return this.totalDangerousRequirementProgress - this.totalSafeRequirementProgress;
     },
     numberConflictsRounded(): number {
       return Math.ceil(this.numberConflicts);

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -10,7 +10,6 @@
   >
     <new-course-modal
       @close-course-modal="closeCourseModal"
-      @select-course="selectCourse"
       v-if="isCourseModalOpen"
       @add-course="addCourse"
     />
@@ -164,7 +163,6 @@ import {
   addCourseToSemester,
   deleteCourseFromSemester,
   deleteAllCoursesFromSemester,
-  addAcknowledgedCheckerWarningOptIn,
 } from '@/global-firestore-data';
 import store, { updateSubjectColorData } from '@/store';
 import { getRelatedUnfulfilledRequirements } from '@/requirements/requirement-frontend-utils';
@@ -370,18 +368,7 @@ export default defineComponent({
     closeConfirmationModal() {
       this.isConfirmationOpen = false;
     },
-    // TODO @willespencer refactor the below methods after gatekeep removed (to only 1 method)
-    addCourse(data: CornellCourseRosterCourse, selectableReqId: string) {
-      const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourseWithGlobalData(data);
-      if (selectableReqId) {
-        addAcknowledgedCheckerWarningOptIn(newCourse.uniqueID, selectableReqId);
-      }
-      addCourseToSemester(this.year, this.season, newCourse, this.$gtag);
-
-      const courseCode = `${data.subject} ${data.catalogNbr}`;
-      this.openConfirmationModal(`Added ${courseCode} to ${this.season} ${this.year}`);
-    },
-    selectCourse(data: CornellCourseRosterCourse) {
+    addCourse(data: CornellCourseRosterCourse) {
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourseWithGlobalData(data);
 
       addCourseToSemester(this.year, this.season, newCourse, this.$gtag);

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -169,8 +169,6 @@ import {
 import store, { updateSubjectColorData } from '@/store';
 import { getRelatedUnfulfilledRequirements } from '@/requirements/requirement-frontend-utils';
 
-import featureFlagCheckers from '@/feature-flags';
-
 type ComponentRef = { $el: HTMLDivElement };
 
 export default defineComponent({
@@ -311,9 +309,6 @@ export default defineComponent({
       }
       return `${credits.toString()} credits`;
     },
-    handleRequirementConflicts(): boolean {
-      return featureFlagCheckers.isRequirementConflictsEnabled();
-    },
   },
   methods: {
     isPlaceholderCourse,
@@ -387,29 +382,26 @@ export default defineComponent({
       this.openConfirmationModal(`Added ${courseCode} to ${this.season} ${this.year}`);
     },
     selectCourse(data: CornellCourseRosterCourse) {
-      // only perform operations if the gatekeep is true
-      if (this.handleRequirementConflicts) {
-        const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourseWithGlobalData(data);
+      const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourseWithGlobalData(data);
 
-        addCourseToSemester(this.year, this.season, newCourse, this.$gtag);
-        this.closeCourseModal();
+      addCourseToSemester(this.year, this.season, newCourse, this.$gtag);
+      this.closeCourseModal();
 
-        const conflicts = store.state.courseToRequirementsInConstraintViolations.get(
-          newCourse.uniqueID
-        );
+      const conflicts = store.state.courseToRequirementsInConstraintViolations.get(
+        newCourse.uniqueID
+      );
 
-        const { selfCheckRequirements } = getRelatedUnfulfilledRequirements(
-          data,
-          store.state.groupedRequirementFulfillmentReport,
-          store.state.toggleableRequirementChoices,
-          store.state.overriddenFulfillmentChoices,
-          store.state.userRequirementsMap
-        );
+      const { selfCheckRequirements } = getRelatedUnfulfilledRequirements(
+        data,
+        store.state.groupedRequirementFulfillmentReport,
+        store.state.toggleableRequirementChoices,
+        store.state.overriddenFulfillmentChoices,
+        store.state.userRequirementsMap
+      );
 
-        // only open conflict modal if conflicts exist
-        if (conflicts && conflicts.size > 0) {
-          this.openConflictModal(newCourse, conflicts, selfCheckRequirements);
-        }
+      // only open conflict modal if conflicts exist
+      if (conflicts && conflicts.size > 0) {
+        this.openConflictModal(newCourse, conflicts, selfCheckRequirements);
       }
     },
     handleConflictsResolved(course: FirestoreSemesterCourse | CourseTaken) {

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -5,7 +5,6 @@ const GateKeeperTogglers: Record<string, () => void> = {};
 type FeatureFlagName =
   | 'APIBFulfillment'
   | 'Case'
-  | 'RequirementConflicts'
   | 'RequirementDebugger'
   | 'ToggleRequirementsBarBtn'
   | 'Profile'
@@ -14,7 +13,6 @@ type FeatureFlagName =
 const featureFlagCheckers: FeatureFlagCheckers = registerFeatureFlagChecker(
   'APIBFulfillment',
   'Case',
-  'RequirementConflicts',
   'RequirementDebugger',
   'ToggleRequirementsBarBtn',
   'Profile',

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -8,7 +8,6 @@ import {
 } from './requirement-frontend-utils';
 import { ReadonlyRequirementFulfillmentGraph } from './graph';
 import buildRequirementFulfillmentGraphFromUserData from './requirement-graph-builder-from-user-data';
-import featureFlagCheckers from '../feature-flags';
 
 /**
  * Used for total academic credit requirements for all colleges except EN and AR
@@ -348,16 +347,7 @@ export function groupedRequirementDangerouslyFulfilled(
   groupedRequirementFulfillmentReport.reqs.forEach(req => {
     [req.fulfillment, ...Object.values(req.fulfillment.additionalRequirements ?? {})].forEach(
       reqOrNestedReq => {
-        if (
-          reqOrNestedReq.dangerousMinCountFulfilled >= reqOrNestedReq.minCountRequired &&
-          !featureFlagCheckers.isRequirementConflictsEnabled()
-        ) {
-          fulfilled += 1;
-        }
-        if (
-          reqOrNestedReq.safeMinCountFulfilled >= reqOrNestedReq.minCountRequired &&
-          featureFlagCheckers.isRequirementConflictsEnabled()
-        ) {
+        if (reqOrNestedReq.safeMinCountFulfilled >= reqOrNestedReq.minCountRequired) {
           fulfilled += 1;
         }
       }

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -2,7 +2,6 @@ import requirementJson from './typed-requirement-json';
 import specialized from './specialize';
 import { examCourseIds } from './requirement-exam-mapping';
 import { getConstraintViolationsForSingleCourse } from './requirement-constraints-utils';
-import featureFlagCheckers from '../feature-flags';
 
 /**
  * A collection of helper functions
@@ -485,16 +484,12 @@ export function computeFulfillmentCoursesAndStatistics(
 }
 
 // display the entire number of fulfillents, including those that are dangerous
-export function fulfillmentProgressString({
+export const fulfillmentProgressString = ({
   fulfilledBy,
   dangerousMinCountFulfilled,
-  safeMinCountFulfilled,
   minCountRequired,
-}: MixedRequirementFulfillmentStatistics) {
-  return featureFlagCheckers.isRequirementConflictsEnabled()
-    ? `${dangerousMinCountFulfilled}/${minCountRequired} ${fulfilledBy}`
-    : `${safeMinCountFulfilled}/${minCountRequired} ${fulfilledBy}`;
-}
+}: MixedRequirementFulfillmentStatistics) =>
+  `${dangerousMinCountFulfilled}/${minCountRequired} ${fulfilledBy}`;
 
 export function getRelatedUnfulfilledRequirements(
   {

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,7 +14,6 @@ import {
   sortedSemesters,
   isPlaceholderCourse,
 } from './utilities';
-import featureFlagCheckers from './feature-flags';
 
 type SimplifiedFirebaseUser = { readonly displayName: string; readonly email: string };
 
@@ -353,7 +352,6 @@ export const updateSubjectColorData = (color: string, code: string): void => {
 };
 
 export const isCourseConflict = (uniqueId: string | number): boolean =>
-  featureFlagCheckers.isRequirementConflictsEnabled() &&
   store.state.doubleCountedCourseUniqueIDSet.has(uniqueId);
 
 fb.auth.onAuthStateChanged(user => {


### PR DESCRIPTION
### Summary <!-- Required -->

Removes the conflicts feature flag so that conflicts are visible by default on `user-choice`. To be consistent with the existing frontend flow (and pass the E2E tests), I also modified the logic of the add course modal so that only closes when the add button is clicked. Previously, the modal would close whenever you selected a course.

### Test Plan <!-- Required -->

- Ensure that you can add a course as usual through the add modal
- Ensure that requirement conflicts are visible when adding a course creating a constraint violation
