### PR TITLE
Implemented multiple plans feature flag and added add plan button

### DIFF
--- a/src/components/Requirements/RequirementSideBar.vue
+++ b/src/components/Requirements/RequirementSideBar.vue
@@ -7,6 +7,7 @@
     >
       →
     </button>
+
     <aside v-if="isMobile ? isDisplayingMobile : !isMinimized" class="requirements">
       <div
         class="requirements-wrapper"
@@ -35,6 +36,9 @@
           >
             Open Requirement Debugger
           </button>
+          <div class="multiple-plans" v-if="multiplePlansAllowed">
+            <button class="add-plan-button" @click="addPlan()">+ Add Plan</button>
+          </div>
           <teleport-modal
             content-class="requirement-debugger-modal-content"
             :isSimpleModal="true"
@@ -220,6 +224,9 @@ export default defineComponent({
     },
   },
   computed: {
+    multiplePlansAllowed(): boolean {
+      return featureFlagCheckers.isMultiplePlansEnabled();
+    },
     debuggerAllowed(): boolean {
       return featureFlagCheckers.isRequirementDebuggerEnabled();
     },
@@ -252,6 +259,9 @@ export default defineComponent({
     },
   },
   methods: {
+    addPlan() {
+      console.log('add plan clicked!');
+    },
     toggleDebugger(): void {
       this.displayDebugger = !this.displayDebugger;
     },
@@ -364,6 +374,21 @@ export default defineComponent({
     color: $yuxuanBlue;
     opacity: 1;
   }
+}
+
+.multiple-plans {
+  height: 2.5rem;
+}
+
+.add-plan-button {
+  float: right;
+  background: $sangBlue;
+  border-radius: 8px;
+  min-height: 2.5rem;
+  min-width: 6.5rem;
+  color: $white;
+  border: none;
+  font-size: 16px;
 }
 
 .requirement-sidebar-btn-open {

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -8,7 +8,8 @@ type FeatureFlagName =
   | 'RequirementConflicts'
   | 'RequirementDebugger'
   | 'ToggleRequirementsBarBtn'
-  | 'Profile';
+  | 'Profile'
+  | 'MultiplePlans';
 /* | 'AddYourFeatureFlagNameHere' */
 const featureFlagCheckers: FeatureFlagCheckers = registerFeatureFlagChecker(
   'APIBFulfillment',
@@ -16,7 +17,8 @@ const featureFlagCheckers: FeatureFlagCheckers = registerFeatureFlagChecker(
   'RequirementConflicts',
   'RequirementDebugger',
   'ToggleRequirementsBarBtn',
-  'Profile'
+  'Profile',
+  'MultiplePlans'
   /* 'AddYourFeatureFlagNameHere' */
 );
 export default featureFlagCheckers;


### PR DESCRIPTION
**Implemented multiple plans feature flag and added add plan button**

- Added multiple feature flag to featureflag.ts
- Added add plan button that currently logs "Add plan button clicked!" to console when clicked

**Test Plan** 
- Is button initially hidden?
- Does button appear when multiple plans feature flag is enabled?
- Does button log to console when clicked?
