### PR TITLE
Course retrieval function and New course interface

### DIFF
--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -7,7 +7,6 @@ import {
   cornellCourseRosterCourseDetailedInformationToPartialBottomCourseInformation,
   firestoreSemesterCourseToBottomBarCourse,
 } from '../../user-data-converter';
-import getCourse from '@/global-firestore-data/courses';
 
 export type BottomBarState = {
   bottomCourses: readonly AppBottomBarCourse[];
@@ -40,7 +39,6 @@ const getDetailedInformationForBottomBar = async (
   subject: string,
   number: string
 ) => {
-  console.log(await getCourse(roster, subject, number));
   const courses: readonly CornellCourseRosterCourseFullDetail[] = (
     await fetch(
       `https://classes.cornell.edu/api/2.0/search/classes.json?roster=${roster}&subject=${subject}`

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -7,6 +7,7 @@ import {
   cornellCourseRosterCourseDetailedInformationToPartialBottomCourseInformation,
   firestoreSemesterCourseToBottomBarCourse,
 } from '../../user-data-converter';
+import getCourse from '@/global-firestore-data/courses';
 
 export type BottomBarState = {
   bottomCourses: readonly AppBottomBarCourse[];
@@ -39,6 +40,7 @@ const getDetailedInformationForBottomBar = async (
   subject: string,
   number: string
 ) => {
+  console.log(await getCourse(roster, subject, number));
   const courses: readonly CornellCourseRosterCourseFullDetail[] = (
     await fetch(
       `https://classes.cornell.edu/api/2.0/search/classes.json?roster=${roster}&subject=${subject}`

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -2,6 +2,7 @@ import { reactive } from 'vue';
 import { VueGtag } from 'vue-gtag-next';
 import { GTagEvent } from '../../gtag';
 import { checkNotNull } from '../../utilities';
+import { getCourse } from '../../global-firestore-data/courses';
 
 import {
   cornellCourseRosterCourseDetailedInformationToPartialBottomCourseInformation,

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -2,7 +2,6 @@ import { reactive } from 'vue';
 import { VueGtag } from 'vue-gtag-next';
 import { GTagEvent } from '../../gtag';
 import { checkNotNull } from '../../utilities';
-import { getCourse } from '../../global-firestore-data/courses';
 
 import {
   cornellCourseRosterCourseDetailedInformationToPartialBottomCourseInformation,

--- a/src/firebase-config.ts
+++ b/src/firebase-config.ts
@@ -58,6 +58,10 @@ export const semestersCollection = collection(db, 'user-semesters').withConverte
   getTypedFirestoreDataConverter<FirestoreSemestersData>()
 );
 
+export const coursesCollection = collection(db, 'courses');
+
+export const availableRostersForCoursesCollection = collection(db, 'available-rosters-for-course');
+
 export const toggleableRequirementChoicesCollection = collection(
   db,
   'user-toggleable-requirement-choices'

--- a/src/firebase-config.ts
+++ b/src/firebase-config.ts
@@ -62,8 +62,6 @@ export const coursesCollection = collection(db, 'courses');
 
 export const availableRostersForCoursesCollection = collection(db, 'available-rosters-for-course');
 
-export const crseIdToCatalogNbrCollection = collection(db, 'crseid-to-catalognbr');
-
 export const toggleableRequirementChoicesCollection = collection(
   db,
   'user-toggleable-requirement-choices'

--- a/src/firebase-config.ts
+++ b/src/firebase-config.ts
@@ -62,6 +62,8 @@ export const coursesCollection = collection(db, 'courses');
 
 export const availableRostersForCoursesCollection = collection(db, 'available-rosters-for-course');
 
+export const crseIdToCatalogNbrCollection = collection(db, 'crseid-to-catalognbr');
+
 export const toggleableRequirementChoicesCollection = collection(
   db,
   'user-toggleable-requirement-choices'

--- a/src/global-firestore-data/courses.ts
+++ b/src/global-firestore-data/courses.ts
@@ -18,19 +18,20 @@ export const getCourseWithSeasonAndYear = async (
   const roster = seasonAndYearToRosterIdentifier(season, year);
   const course = await getDoc(doc(coursesCollection, `${roster}/${subject}/${number}`));
   if (!course.exists()) {
-    const availableRostersForCourse = (
-      await getDoc(doc(availableRostersForCoursesCollection, `${subject} ${number}`))
-    ).data() as { rosters: string[] };
-    const lastRoster = availableRostersForCourse.rosters.length - 1;
-    const latestCourse = await getDoc(
-      doc(
-        coursesCollection,
-        `${availableRostersForCourse.rosters[lastRoster]}/${subject}/${number}`
-      )
-    );
-    return latestCourse.data()?.course as CornellCourseRosterCourseFullDetail;
+    return getLastOffering(subject, number);
   }
   return course.data()?.course as CornellCourseRosterCourseFullDetail;
+};
+
+const getLastOffering = async (subject: string, number: string) => {
+  const availableRostersForCourse = (
+    await getDoc(doc(availableRostersForCoursesCollection, `${subject} ${number}`))
+  ).data() as { rosters: string[] };
+  const lastRoster = availableRostersForCourse.rosters.length - 1;
+  const latestCourse = await getDoc(
+    doc(coursesCollection, `${availableRostersForCourse.rosters[lastRoster]}/${subject}/${number}`)
+  );
+  return latestCourse.data()?.course as CornellCourseRosterCourseFullDetail;
 };
 
 /**

--- a/src/global-firestore-data/courses.ts
+++ b/src/global-firestore-data/courses.ts
@@ -41,7 +41,7 @@ const seasonAndYearToRosterIdentifier = (season: FirestoreSemesterSeason, year: 
     Fall: 'FA',
     Spring: 'SP',
     Winter: 'WI',
-    Summer: 'SU'
+    Summer: 'SU',
   } as const;
 
   return `${seasonToSemesterMap[season]}${year - 2000}`;

--- a/src/global-firestore-data/courses.ts
+++ b/src/global-firestore-data/courses.ts
@@ -24,7 +24,7 @@ export const getCourseWithSeasonAndYear = async (
   if (!course.exists()) {
     return getLastOffering(subject, number);
   }
-  return course.data()?.course as CornellCourseRosterCourseFullDetail;
+  return course.data()?.course;
 };
 
 /**
@@ -50,7 +50,7 @@ export const getCourseWithCrseIdAndRoster = async (
   if (!course.exists()) {
     return getLastOffering(subject, number);
   }
-  return course.data()?.course as CornellCourseRosterCourseFullDetail;
+  return course.data()?.course;
 };
 
 /**
@@ -67,7 +67,7 @@ const getLastOffering = async (subject: string, number: string) => {
   const latestCourse = await getDoc(
     doc(coursesCollection, `${availableRostersForCourse.rosters[lastRoster]}/${subject}/${number}`)
   );
-  return latestCourse.data()?.course as CornellCourseRosterCourseFullDetail;
+  return latestCourse.data()?.course;
 };
 
 /**

--- a/src/global-firestore-data/courses.ts
+++ b/src/global-firestore-data/courses.ts
@@ -1,9 +1,5 @@
 import { doc, getDoc } from 'firebase/firestore';
-import {
-  coursesCollection,
-  availableRostersForCoursesCollection,
-  crseIdToCatalogNbrCollection,
-} from '../firebase-config';
+import { coursesCollection, availableRostersForCoursesCollection } from '../firebase-config';
 
 /**
  * This function uses the subject and number of a course to retrieve the course information from 'courses' collection
@@ -38,37 +34,6 @@ export const getCourseWithSeasonAndYear = async (
 };
 
 /**
- * This function uses the crseId and desired roster of a course to retrieve the course information from 'courses' collection
- * @param roster The roster from which we want to fetch the course
- * @param crseId  The course id of the course
- * @returns `Promise<CornellCourseRosterCourseFullDetail>`
- */
-export const getCourseWithCrseIdAndRoster = async (
-  roster: string,
-  crseId: number
-): Promise<CornellCourseRosterCourseFullDetail> => {
-  // use crseId to retrieve course subject and code
-  const courseSubjectAndNumber = await getDoc(doc(crseIdToCatalogNbrCollection, `${crseId}`));
-  const subject = courseSubjectAndNumber.data()?.split(' ')[0];
-  const number = courseSubjectAndNumber.data()?.split(' ')[1];
-
-  const course = await getDoc(doc(coursesCollection, `${roster}/${subject}/${number}`));
-  if (!course.exists()) {
-    const availableRostersForCourse = (
-      await getDoc(doc(availableRostersForCoursesCollection, `${subject} ${number}`))
-    ).data() as { rosters: string[] };
-    const lastRoster = availableRostersForCourse.rosters.length - 1;
-    const latestCourse = await getDoc(
-      doc(
-        coursesCollection,
-        `${availableRostersForCourse.rosters[lastRoster]}/${subject}/${number}`
-      )
-    );
-    return latestCourse.data()?.course as CornellCourseRosterCourseFullDetail;
-  }
-  return course.data()?.course as CornellCourseRosterCourseFullDetail;
-};
-/**
  * This function transforms semester and year to a roster ID. EX: Spring 2023 -> SP23
  * */
 const seasonAndYearToRosterIdentifier = (season: string, year: number): string => {
@@ -81,3 +46,5 @@ const seasonAndYearToRosterIdentifier = (season: string, year: number): string =
 
   return `${seasonToSemesterMap.get(season)}${year - 2000}`;
 };
+
+export default getCourseWithSeasonAndYear;

--- a/src/global-firestore-data/courses.ts
+++ b/src/global-firestore-data/courses.ts
@@ -1,0 +1,22 @@
+import { doc, getDoc } from 'firebase/firestore';
+import { coursesCollection, availableRostersForCoursesCollection } from '../firebase-config';
+
+export const getCourse = async (roster: string, subject: string, number: string) => {
+  const course = await getDoc(doc(coursesCollection, `${roster}/${subject}/${number}`));
+  if (!course.exists()) {
+    const availableRostersForCourse = (
+      await getDoc(doc(availableRostersForCoursesCollection, `${subject} ${number}`))
+    ).data() as { rosters: string[] };
+    const lastRoster = availableRostersForCourse.rosters.length - 1;
+    const latestCourse = await getDoc(
+      doc(
+        coursesCollection,
+        `${availableRostersForCourse.rosters[lastRoster]}/${subject}/${number}`
+      )
+    );
+    return latestCourse.data()?.course;
+  }
+  return course.data()?.course;
+};
+
+export default getCourse;

--- a/src/global-firestore-data/courses.ts
+++ b/src/global-firestore-data/courses.ts
@@ -81,5 +81,3 @@ const seasonAndYearToRosterIdentifier = (season: string, year: number): string =
 
   return `${seasonToSemesterMap.get(season)}${year - 2000}`;
 };
-
-export default getCourseWithSeasonAndYear;

--- a/src/global-firestore-data/courses.ts
+++ b/src/global-firestore-data/courses.ts
@@ -42,8 +42,9 @@ export const getCourseWithCrseIdAndRoster = async (
     await getDoc(doc(crseIdToCatalogNbrCollection, `${crseId}`))
   ).data()?.catalogNbr as string;
 
-  const subject = extractSubjectAndNumber(courseSubjectAndNumber)[0];
-  const number = extractSubjectAndNumber(courseSubjectAndNumber)[1];
+  const subjectAndNumberList = extractSubjectAndNumber(courseSubjectAndNumber);
+  const subject = subjectAndNumberList[0];
+  const number = subjectAndNumberList[1];
 
   const course = await getDoc(doc(coursesCollection, `${roster}/${subject}/${number}`));
   if (!course.exists()) {

--- a/src/global-firestore-data/courses.ts
+++ b/src/global-firestore-data/courses.ts
@@ -1,7 +1,25 @@
 import { doc, getDoc } from 'firebase/firestore';
-import { coursesCollection, availableRostersForCoursesCollection } from '../firebase-config';
+import {
+  coursesCollection,
+  availableRostersForCoursesCollection,
+  crseIdToCatalogNbrCollection,
+} from '../firebase-config';
 
-export const getCourse = async (roster: string, subject: string, number: string) => {
+/**
+ * This function uses the subject and number of a course to retrieve the course information from 'courses' collection
+ * @param season The season that the course is under in the user's semester view
+ * @param year The year the course is under in the user's semester view
+ * @param subject The subject of the course
+ * @param number The number of the course
+ * @returns `Promise<CornellCourseRosterCourseFullDetail>`
+ */
+export const getCourseWithSeasonAndYear = async (
+  season: FirestoreSemesterSeason,
+  year: number,
+  subject: string,
+  number: string
+): Promise<CornellCourseRosterCourseFullDetail> => {
+  const roster = seasonAndYearToRosterIdentifier(season, year);
   const course = await getDoc(doc(coursesCollection, `${roster}/${subject}/${number}`));
   if (!course.exists()) {
     const availableRostersForCourse = (
@@ -14,9 +32,54 @@ export const getCourse = async (roster: string, subject: string, number: string)
         `${availableRostersForCourse.rosters[lastRoster]}/${subject}/${number}`
       )
     );
-    return latestCourse.data()?.course;
+    return latestCourse.data()?.course as CornellCourseRosterCourseFullDetail;
   }
-  return course.data()?.course;
+  return course.data()?.course as CornellCourseRosterCourseFullDetail;
 };
 
-export default getCourse;
+/**
+ * This function uses the crseId and desired roster of a course to retrieve the course information from 'courses' collection
+ * @param roster The roster from which we want to fetch the course
+ * @param crseId  The course id of the course
+ * @returns `Promise<CornellCourseRosterCourseFullDetail>`
+ */
+export const getCourseWithCrseIdAndRoster = async (
+  roster: string,
+  crseId: number
+): Promise<CornellCourseRosterCourseFullDetail> => {
+  // use crseId to retrieve course subject and code
+  const courseSubjectAndNumber = await getDoc(doc(crseIdToCatalogNbrCollection, `${crseId}`));
+  const subject = courseSubjectAndNumber.data()?.split(' ')[0];
+  const number = courseSubjectAndNumber.data()?.split(' ')[1];
+
+  const course = await getDoc(doc(coursesCollection, `${roster}/${subject}/${number}`));
+  if (!course.exists()) {
+    const availableRostersForCourse = (
+      await getDoc(doc(availableRostersForCoursesCollection, `${subject} ${number}`))
+    ).data() as { rosters: string[] };
+    const lastRoster = availableRostersForCourse.rosters.length - 1;
+    const latestCourse = await getDoc(
+      doc(
+        coursesCollection,
+        `${availableRostersForCourse.rosters[lastRoster]}/${subject}/${number}`
+      )
+    );
+    return latestCourse.data()?.course as CornellCourseRosterCourseFullDetail;
+  }
+  return course.data()?.course as CornellCourseRosterCourseFullDetail;
+};
+/**
+ * This function transforms semester and year to a roster ID. EX: Spring 2023 -> SP23
+ * */
+const seasonAndYearToRosterIdentifier = (season: string, year: number): string => {
+  const seasonToSemesterMap = new Map([
+    ['Fall', 'FA'],
+    ['Spring', 'SP'],
+    ['Winter', 'WI'],
+    ['Summer', 'SU'],
+  ]);
+
+  return `${seasonToSemesterMap.get(season)}${year - 2000}`;
+};
+
+export default getCourseWithSeasonAndYear;

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -173,6 +173,11 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
   readonly catalogDistr?: string;
 }
 
+interface FullClassRosterCourseWithUniqueID extends CornellCourseRosterCourseFullDetail {
+  readonly userChosenCredits: number;
+  readonly uniqueID: number;
+}
+
 // college and grad are optional fields: grad can be undefined if the user hasn't selected a grad program, and college can be undefined if the user has only selected a grad program.
 type AppOnboardingData = {
   readonly gradYear: string;


### PR DESCRIPTION
### Summary <!-- Required -->

In this PR, we create a global course retrieval function that takes in a roster, subject, and number and retrieves the desired course. If the course is not offered in that roster, we find the latest roster that it is offered in and retrieve that version of the course.  

We also define the new courses interface that will be used to populate the VuexStoreState. 


### Test Plan <!-- Required -->

Tested the function by importing into BottomBarState.ts and calling it in `getDetailedInformationForBottomBar()`. I logged the output into the console to ensure that the course information that was retrieved when a user clicks on a course card is the same as the current implementation of course information (which is via the class roster API). 

<img width="1680" alt="Screen Shot 2023-03-25 at 3 49 29 PM" src="https://user-images.githubusercontent.com/46412997/227738498-be9510e0-d70e-42b5-bb5b-f554814068e8.png">

Line 43 is where we make the call to the new `getCourse` function.
<img width="870" alt="Screen Shot 2023-03-25 at 3 50 08 PM" src="https://user-images.githubusercontent.com/46412997/227738514-7f10fa28-41fd-4a32-a0f1-14fd057f87ec.png">


