### PR TITLE
Course color and credits dropdown

### DIFF
--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -16,15 +16,11 @@
         </div>
         <img
           class="courseMenu-arrow"
-          src="@/assets/images/sidearrow.svg"
+          src="@/assets/images/downarrow.svg"
           alt="arrow to expand edit course color"
         />
 
-        <div
-          v-if="displayColors"
-          class="courseMenu-content courseMenu-colors"
-          :class="{ 'courseMenu-colors--left': isLeft }"
-        >
+        <div v-if="displayColors" class="courseMenu-content courseMenu-colors">
           <button
             v-for="(color, index) in colors"
             :key="index"
@@ -69,13 +65,12 @@
         </div>
         <img
           class="courseMenu-arrow"
-          src="@/assets/images/sidearrow.svg"
+          src="@/assets/images/downarrow.svg"
           alt="arrow to expand edit course credits"
         />
         <div
           v-if="displayEditCourseCredits"
           class="courseMenu-content courseMenu-editCredits courseMenu-centerCredits"
-          :class="{ 'courseMenu-editCredits--left': isLeft }"
         >
           <div
             v-for="credit in makeCreditArary()"
@@ -296,26 +291,20 @@ export default defineComponent({
   &-colors {
     position: absolute;
     padding: 10px 5px 0px 5px;
-    right: -9rem;
-
-    &--left {
-      right: 8.87rem;
-    }
+    top: 100%;
+    right: 0;
   }
 
   &-editCredits {
     position: absolute;
-    width: 2.75rem;
-    right: -2.75rem;
+    top: 100%;
+    right: 0;
+    width: 100%;
     padding: auto;
     display: flex;
     justify-content: center;
     align-items: center;
     flex-direction: column;
-
-    &--left {
-      right: 8.87rem;
-    }
   }
 }
 

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -20,7 +20,11 @@
           alt="arrow to expand edit course color"
         />
 
-        <div v-if="displayColors" class="courseMenu-content courseMenu-colors">
+        <div
+          v-if="displayColors"
+          class="courseMenu-content courseMenu-colors"
+          :style="{ zIndex: zIndexColors }"
+        >
           <button
             v-for="(color, index) in colors"
             :key="index"
@@ -71,6 +75,7 @@
         <div
           v-if="displayEditCourseCredits"
           class="courseMenu-content courseMenu-editCredits courseMenu-centerCredits"
+          :style="{ zIndex: zIndexEditCredits }"
         >
           <div
             v-for="credit in makeCreditArary()"
@@ -124,6 +129,8 @@ export default defineComponent({
       displayColors: false,
       displayEditCourseCredits: false,
       tooltipColor: '',
+      zIndexColors: 1,
+      zIndexEditCredits: 1,
     };
   },
   computed: {
@@ -160,6 +167,12 @@ export default defineComponent({
     },
     setDisplayColors(bool: boolean) {
       this.displayColors = bool;
+      if (bool) {
+        this.zIndexColors = 3;
+        this.zIndexEditCredits = 1;
+      } else {
+        this.zIndexColors = 1;
+      }
     },
     setDisplayColorTooltip(bool: boolean, color: string) {
       if (bool) {
@@ -170,6 +183,12 @@ export default defineComponent({
     },
     setDisplayEditCourseCredits(bool: boolean) {
       this.displayEditCourseCredits = bool;
+      if (bool) {
+        this.zIndexEditCredits = 3;
+        this.zIndexColors = 1;
+      } else {
+        this.zIndexEditCredits = 1;
+      }
     },
     editCourseCredit(credit: number) {
       this.$emit('edit-course-credit', credit);
@@ -293,6 +312,7 @@ export default defineComponent({
     padding: 10px 5px 0px 5px;
     top: 100%;
     right: 0;
+    z-index: 1;
   }
 
   &-editCredits {
@@ -305,6 +325,7 @@ export default defineComponent({
     justify-content: center;
     align-items: center;
     flex-direction: column;
+    z-index: 1;
   }
 }
 

--- a/src/components/Modals/CourseMenu.vue
+++ b/src/components/Modals/CourseMenu.vue
@@ -246,7 +246,8 @@ export default defineComponent({
       background-color: rgba(50, 160, 242, 0.15);
     }
 
-    &:first-child {
+    &:first-child:not(.courseMenu-editCredits > &),
+    &:only-child {
       border-top-left-radius: 9px;
       border-top-right-radius: 9px;
     }
@@ -311,21 +312,28 @@ export default defineComponent({
     position: absolute;
     padding: 10px 5px 0px 5px;
     top: 100%;
-    right: 0;
     z-index: 1;
+    width: calc(100% + 0.081rem);
+    left: -0.031rem;
+    border-radius: 0 0 9px 9px;
+    border-top: none;
+    box-sizing: border-box;
   }
 
   &-editCredits {
     position: absolute;
     top: 100%;
-    right: 0;
-    width: 100%;
+    width: calc(100% + 0.081rem);
+    left: -0.031rem;
     padding: auto;
     display: flex;
     justify-content: center;
     align-items: center;
     flex-direction: column;
     z-index: 1;
+    border-radius: 0 0 9px 9px;
+    border-top: none;
+    box-sizing: border-box;
   }
 }
 
@@ -338,7 +346,7 @@ export default defineComponent({
     }
     &-colors {
       right: 0rem;
-      left: -9rem;
+      left: 0rem;
     }
   }
 }


### PR DESCRIPTION
### Summary 

This PR changes the Course Menu Edit Color and Edit Credits sections to drop downwards. It addresses this issue: https://github.com/cornell-dti/course-plan/issues/704

_Before:_ 
When you hover over the edit color button, the color modal will sometimes go to the right, sometimes to the left, and sometimes off screen. The same occurs with the credits modal on courses like CS 4999 where you can edit the number of credits. 

_After:_ 
Now, both the color and credits modals drop downwards so that they will never go offscreen and there is more consistency in the user experience. 

### Test Plan <!-- Required -->
- On any course, hover over Edit Color and see if the color modal opens downwards, directly under. Click on various colors to test if the functionality remains. 
<img width="344" alt="image" src="https://user-images.githubusercontent.com/116850705/228936101-b6419f1a-5733-4394-a0c5-d2ee37b819fd.png">

- On a course like ORIE 4999 or CS 4999, hover over Edit Course and see if the credits modal opens downwards. Click on various credits to test if the functionality remains. 
<img width="380" alt="image" src="https://user-images.githubusercontent.com/116850705/228935968-a8d6e458-c737-432c-bd8d-df8b7c0fa772.png">

- Experiment with different screen sizes, default vs. compact view, zooming in and out to see if the dropdown is still downward aligned. 


