### PR TITLE
migration script for multiple plans in firebase

### DIFF
--- a/scripts/migration/plans-migration.ts
+++ b/scripts/migration/plans-migration.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+
+import { usernameCollection, semestersCollection } from '../firebase-config';
+
+/**
+ * Perform migration of semester to plans with a list of semesters
+ */
+async function runOnUser(userEmail: string) {
+  const semestersDoc = await semestersCollection.doc(userEmail).get();
+  const semesters = semestersDoc.data()?.semesters ?? [];
+  await semestersCollection.doc(userEmail).update({
+    plans: [{ name: 'Plan 1', semesters }],
+  });
+}
+
+async function main() {
+  const userEmail = process.argv[2];
+  if (userEmail != null) {
+    await runOnUser(userEmail);
+    return;
+  }
+  const collection = await usernameCollection.get();
+  for (const { id } of collection.docs) {
+    console.group(`Running on ${id}...`);
+    // Intentionally await in a loop to have no interleaved console logs.
+    // eslint-disable-next-line no-await-in-loop
+    await runOnUser(id);
+    console.groupEnd();
+  }
+}
+
+main();

--- a/src/store.ts
+++ b/src/store.ts
@@ -291,7 +291,7 @@ export const initializeFirestoreListeners = (onLoad: () => void): (() => void) =
       store.commit('setSemesters', [newSemester]);
       setDoc(doc(fb.semestersCollection, simplifiedUser.email), {
         orderByNewest: true,
-        plans: [{ semesters: [newSemester] }], // TODO: andxu282 update later
+        plans: [{ name: 'Plan 1', semesters: [newSemester] }], // TODO: andxu282 update later
         semesters: [newSemester],
       });
     }

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -36,7 +36,7 @@ type FirestoreSemester = {
 };
 
 type FirestoreSemestersData = {
-  readonly plans?: readonly { semesters: readonly FirestoreSemester[] }[];
+  readonly plans?: readonly Plan[];
   readonly semesters: readonly FirestoreSemester[];
   readonly orderByNewest: boolean;
 };
@@ -172,6 +172,11 @@ interface CornellCourseRosterCourseFullDetail extends CornellCourseRosterCourse 
   readonly catalogPrereqCoreq?: string;
   readonly catalogDistr?: string;
 }
+
+type Plan = {
+  readonly name: string;
+  readonly semesters: readonly FirestoreSemester[];
+};
 
 // college and grad are optional fields: grad can be undefined if the user hasn't selected a grad program, and college can be undefined if the user has only selected a grad program.
 type AppOnboardingData = {


### PR DESCRIPTION
### Summary <!-- Required -->

- Wrote a migration script to support new data type Plan
- Associates all current plans with default name "Plan 1"

### Test Plan <!-- Required -->

- Test with dev courseplan firebase to see if in user-semesters, plans:
     -  is an array with one plan
     -  the plan has name "Plan 1"
     -  the plan has all old semesters in the semesters field.
