### PR TITLE
Populate VuexStore from Course Data

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -355,7 +355,6 @@ export const initializeFirestoreListeners = (onLoad: () => void): (() => void) =
     if (data) {
       const semesters = getFirstPlan(data);
       const { orderByNewest } = data;
-      console.log('here');
       store.commit('setSemesters', semesters);
       updateDoc(doc(fb.semestersCollection, simplifiedUser.email), {
         plans: [{ semesters }], // TODO: andxu282 update later


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request handles added a function `popSemCourseData ` which repopulates courses with information from course data. In addition, I added function for a VuexAction to handle modify the VuexStore

- [x] Implemented functionality for handling VuexStore repopulation given list of `FirestoreSemester`

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] Need to add functionality to replace old state modification of the VuexStore to new VuexAction

<!--- Note dependencies on other PRs if any. -->

Depends on #805


### Test Plan <!-- Required -->

- Unit tests is making sure the VuexStore is being repopulated correctly once replacing previous mutation calls with the VuexAction calls
- Creating a `FirestoreSemester` and making sure the courses within it are repopulated correctly with information from course data.

