### PR TITLE
WIP: Implement frontend for all modals to add, delete and edit plans.

### DIFF
--- a/src/components/Modals/AddPlanModal.vue
+++ b/src/components/Modals/AddPlanModal.vue
@@ -1,0 +1,54 @@
+<template>
+  <teleport-modal
+    title="Copy Plan?"
+    content-class="content-plan"
+    left-button-text="Create Blank"
+    right-button-text="Make a Copy"
+    @modal-closed="closeCurrentModal"
+    @left-button-clicked="closeCurrentModal"
+    @right-button-clicked="copyPlan"
+    :isPlanModal="true"
+  >
+    Would you like to copy an existing plan or create a blank one?
+  </teleport-modal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TeleportModal from '@/components/Modals/TeleportModal.vue';
+
+export default defineComponent({
+  components: { TeleportModal },
+  emits: {
+    'close-plan-modal': () => true,
+    'open-copy-modal': () => true,
+  },
+  data() {
+    return { isDisabled: false, isCopyPlanOpen: false };
+  },
+  methods: {
+    closeCurrentModal() {
+      this.$emit('close-plan-modal');
+    },
+    copyPlan() {
+      this.$emit('open-copy-modal');
+      this.$emit('close-plan-modal');
+    },
+  },
+});
+</script>
+
+<style lang="scss">
+.content-plan {
+  width: 20rem;
+}
+
+.modal {
+  &--block {
+    display: block;
+  }
+  &--flex {
+    display: flex;
+  }
+}
+</style>

--- a/src/components/Modals/CopyPlanModal.vue
+++ b/src/components/Modals/CopyPlanModal.vue
@@ -1,0 +1,125 @@
+<template>
+  <teleport-modal
+    title="Copy a Plan"
+    content-class="content-plan"
+    left-button-text="Back"
+    right-button-text="Copy Plan"
+    @modal-closed="closeCurrentModal"
+    @left-button-clicked="backAddPlan"
+    @right-button-clicked="namePlan"
+  >
+    <div class="selectPlan">
+      <label class="selectPlan-label">Copy Plan</label>
+      <div class="selectPlan-dropdown">
+        <div class="multiplePlansModal-dropdown">
+          <div
+            class="multiplePlansModal-dropdown-placeholder wrapper"
+            @click="closeDropdownIfOpen()"
+          >
+            <div class="multiplePlansModal-dropdown-placeholder plan">{{ currPlan }}</div>
+            <img
+              class="multiplePlansModal-dropdown-placeholder up-arrow"
+              v-if="shown"
+              alt="close dropdown"
+            />
+            <img
+              class="multiplePlansModal-dropdown-placeholder down-arrow"
+              v-else
+              alt="open dropdown"
+            />
+          </div>
+          <div class="multiplePlansModal-dropdown-content" v-if="shown" :class="shown">
+            <div
+              v-for="otherPlan in otherPlans"
+              class="multiplePlansModal-dropdown-content item"
+              :key="otherPlan"
+              @click="planClicked(otherPlan)"
+            >
+              {{ otherPlan }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </teleport-modal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TeleportModal from '@/components/Modals/TeleportModal.vue';
+import store from '@/store';
+
+export default defineComponent({
+  props: {
+    plan: { type: String, default: 'No additional plans yet' },
+  },
+  components: { TeleportModal },
+  emits: {
+    'close-copy-modal': () => true,
+    'open-plan-modal': () => true,
+    'open-name-modal': () => true,
+  },
+  data() {
+    return { isDisabled: false, shown: false };
+  },
+  methods: {
+    closeCurrentModal() {
+      this.$emit('close-copy-modal');
+    },
+    closeDropdownIfOpen() {
+      this.shown = !this.shown;
+    },
+    planClicked(plan: string) {
+      if (this.plans.length !== 1) this.currPlan = plan;
+    },
+    backAddPlan() {
+      this.$emit('open-plan-modal');
+      this.$emit('close-copy-modal');
+    },
+    namePlan() {
+      this.$emit('open-name-modal');
+      this.$emit('close-copy-modal');
+    },
+  },
+  computed: {
+    otherPlans() {
+      const filtered = this.plans.filter(plan => plan !== this.currPlan);
+      return filtered.length === 0 ? ['No additional plans yet'] : filtered;
+    },
+    plans() {
+      return store.state.plans.map(plan => plan.name);
+    },
+    currPlan() {
+      return store.state.currentPlan.name;
+    },
+  },
+});
+</script>
+
+<style lang="scss">
+@import '@/components/Modals/PlanModalDropdown.scss';
+.selectPlan {
+  height: 6rem;
+  &-label {
+    position: relative;
+    top: 0.5rem;
+  }
+  &-dropdown {
+    top: 0.5rem;
+    position: relative;
+  }
+}
+
+.content-plan {
+  width: 20rem;
+}
+
+.modal {
+  &--block {
+    display: block;
+  }
+  &--flex {
+    display: flex;
+  }
+}
+</style>

--- a/src/components/Modals/EditPlanModal.vue
+++ b/src/components/Modals/EditPlanModal.vue
@@ -1,0 +1,91 @@
+<template>
+  <text-input-modal
+    title="Edit Plan"
+    content-class="content-plan"
+    left-button-text="Cancel"
+    right-button-text="Save Changes"
+    @modal-closed="closeCurrentModal"
+    @left-button-clicked="closeCurrentModal"
+    @right-button-clicked="addPlan"
+    :isPlanModal="true"
+    label="Name"
+  >
+    <button class="editPlan-delete">DELETE PLAN</button>
+  </text-input-modal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import store from '@/store';
+import TextInputModal from './TextInputModal.vue';
+
+export default defineComponent({
+  props: {
+    plan: { type: String, default: 'No additional plans yet' },
+  },
+  components: { TextInputModal },
+  emits: {
+    'close-edit-modal': () => true,
+    'open-copy-modal': () => true,
+  },
+  data() {
+    return { isDisabled: false, shown: false };
+  },
+  methods: {
+    closeCurrentModal() {
+      this.$emit('close-edit-modal');
+    },
+    closeDropdownIfOpen() {
+      this.shown = !this.shown;
+    },
+    planClicked(plan: string) {
+      if (this.plans.length !== 1) this.currPlan = plan;
+    },
+    backCopyPlan() {
+      this.$emit('open-copy-modal');
+      this.$emit('close-edit-modal');
+    },
+    addPlan() {
+      this.$emit('close-edit-modal');
+    },
+  },
+  computed: {
+    otherPlans() {
+      const filtered = this.plans.filter(plan => plan !== this.currPlan);
+      return filtered.length === 0 ? ['No additional plans yet'] : filtered;
+    },
+    plans() {
+      return store.state.plans.map(plan => plan.name);
+    },
+    currPlan() {
+      return store.state.currentPlan.name;
+    },
+  },
+});
+</script>
+
+<style lang="scss">
+@import '@/components/Modals/PlanModalDropdown.scss';
+
+.editPlan {
+  &-delete {
+    position: relative;
+    bottom: 0.5rem;
+    width: 100%;
+    color: $primary;
+  }
+}
+
+.content-plan {
+  width: 20rem;
+}
+
+.modal {
+  &--block {
+    display: block;
+  }
+  &--flex {
+    display: flex;
+  }
+}
+</style>

--- a/src/components/Modals/NamePlanModal.vue
+++ b/src/components/Modals/NamePlanModal.vue
@@ -1,0 +1,80 @@
+<template>
+  <text-input-modal
+    title="Name Plan"
+    content-class="content-plan"
+    left-button-text="Back"
+    right-button-text="Add Plan"
+    label="Name"
+    @modal-closed="closeCurrentModal"
+    @left-button-clicked="backCopyPlan"
+    @right-button-clicked="addPlan"
+  >
+  </text-input-modal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import store from '@/store';
+import TextInputModal from './TextInputModal.vue';
+
+export default defineComponent({
+  props: {
+    plan: { type: String, default: 'No additional plans yet' },
+  },
+  components: { TextInputModal },
+  emits: {
+    'close-name-modal': () => true,
+    'open-copy-modal': () => true,
+  },
+  data() {
+    return { isDisabled: false, shown: false };
+  },
+  methods: {
+    closeCurrentModal() {
+      this.$emit('close-name-modal');
+    },
+    closeDropdownIfOpen() {
+      this.shown = !this.shown;
+    },
+    planClicked(plan: string) {
+      if (this.plans.length !== 1) this.currPlan = plan;
+    },
+    backCopyPlan() {
+      this.$emit('open-copy-modal');
+      this.$emit('close-name-modal');
+    },
+    addPlan() {
+      this.$emit('close-name-modal');
+    },
+  },
+  computed: {
+    otherPlans() {
+      const filtered = this.plans.filter(plan => plan !== this.currPlan);
+      return filtered.length === 0 ? ['No additional plans yet'] : filtered;
+    },
+    plans() {
+      return store.state.plans.map(plan => plan.name);
+    },
+    currPlan() {
+      return store.state.currentPlan.name;
+    },
+  },
+});
+</script>
+
+<style lang="scss">
+@import '@/components/Modals/PlanModalDropdown.scss';
+
+.content-plan {
+  width: 20rem;
+}
+
+.modal {
+  &--block {
+    display: block;
+  }
+  &--flex {
+    display: flex;
+  }
+}
+</style>

--- a/src/components/Modals/PlanModalDropdown.scss
+++ b/src/components/Modals/PlanModalDropdown.scss
@@ -1,0 +1,74 @@
+@import '@/assets/scss/_variables.scss';
+
+.multiplePlansModal-dropdown {
+
+  &-placeholder {
+    width: 100%;
+    height: 100%;
+    font-size: 14px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+
+    color: $darkPlaceholderGray;
+
+    background: transparent;
+
+    &.wrapper {
+      position: relative;
+      height: 2rem;
+      border-radius: 2px;
+      border: 1px solid $darkPlaceholderGray;
+      cursor: pointer;
+    }
+
+    &.plan {
+      width: 100%;
+    }
+
+    &.down-arrow {
+      position: relative;
+      right: 7%;
+      width: 6.24px;
+      height: 6.24px;
+      border-left: 6.24px solid transparent;
+      border-right: 6.24px solid transparent;
+      border-top: 6.24px solid $darkPlaceholderGray;
+    }
+
+    &.up-arrow {
+      position: relative;
+      right: 7%;
+      width: 6.24px;
+      height: 6.24px;
+      border-left: 6.24px solid transparent;
+      border-right: 6.24px solid transparent;
+      border-top: 6.24px solid $darkPlaceholderGray;
+      transform: rotate(180deg);
+    }
+  }
+
+  &-content {
+    width: 100%;
+    z-index: 100;
+    max-height: 8rem;
+    border-radius: 2px;
+    &.item {
+      border: 1px solid $darkPlaceholderGray;
+      z-index: 150;
+      background-color: white;
+      height: 2rem;
+      font-size: 14px;
+      line-height: 16px;
+      display: flex;
+      align-items: center;
+      color: $darkPlaceholderGray;
+      padding-left: 10px;
+    }
+    &.item:hover {
+      background-color: $searchBoxHoverGray;
+      opacity: 1;
+      cursor: pointer;
+    }
+  }
+}

--- a/src/components/Modals/TeleportModal.vue
+++ b/src/components/Modals/TeleportModal.vue
@@ -23,7 +23,12 @@
         </div>
         <slot class="modal-body"></slot>
         <div v-if="!isSimpleModal" class="modal-buttonWrapper">
-          <button v-if="leftButtonText" class="modal-button" @click="leftButtonClicked">
+          <button
+            :class="{ 'modal-button--big': isPlanModal }"
+            v-if="leftButtonText"
+            class="modal-button"
+            @click="leftButtonClicked"
+          >
             {{ leftButtonText }}
           </button>
           <button
@@ -31,6 +36,7 @@
             :class="{
               'modal-button--disabled': rightButtonIsDisabled,
               'modal-button--highlighted': rightButtonIsHighlighted,
+              'modal-button--big': isPlanModal,
             }"
             @click="rightButtonClicked"
             data-cyId="modal-button"
@@ -67,6 +73,7 @@ export default defineComponent({
     hasNoBackground: { type: Boolean, default: false }, // true for modals without the gray overlay behind them
     hasClickableTransparentBackground: { type: Boolean, default: false }, // modals without a gray overlay behind them AND clicking on the background closes the modal
     hasCustomPosition: { type: Boolean, default: false }, // true if you want to set custom position for modal
+    isPlanModal: { type: Boolean, default: false },
     position: {
       type: Object as PropType<{ x: number; y: number }>,
       default: () => ({ x: 0, y: 0 }),
@@ -210,6 +217,10 @@ export default defineComponent({
 
     &--highlighted {
       border: 2px solid $error;
+    }
+
+    &--big {
+      width: 7rem;
     }
   }
 }

--- a/src/components/Modals/TextInputModal.vue
+++ b/src/components/Modals/TextInputModal.vue
@@ -1,0 +1,74 @@
+<template>
+  <teleport-modal>
+    <div class="textInput">
+      <label class="textInput-label">{{ label }}</label>
+      <div class="textInput-wrapper">
+        <input
+          class="textInput-userinput"
+          maxlength="charLimit"
+          :value="planName"
+          @input="rightPlanClicked"
+        />
+      </div>
+      <slot />
+    </div>
+  </teleport-modal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TeleportModal from '@/components/Modals/TeleportModal.vue';
+
+export default defineComponent({
+  props: {
+    charLimit: { type: Number, default: 100 },
+    label: { type: String, default: '' },
+    planName: { type: String, default: 'Plan Name' },
+  },
+  components: { TeleportModal },
+  emits: ['update:planName'],
+  methods: {
+    rightPlanClicked(): void {
+      this.$emit('update:planName');
+    },
+  },
+  data() {
+    return { isDisabled: false, shown: false };
+  },
+});
+</script>
+
+<style lang="scss">
+@import '@/components/Modals/PlanModalDropdown.scss';
+
+.textInput {
+  &-label {
+    font-weight: bold;
+    top: 0.5rem;
+    position: relative;
+  }
+  &-wrapper {
+    height: 4.2rem;
+  }
+  &-userinput {
+    border: 1px solid $darkPlaceholderGray;
+    top: 0.5rem;
+    position: relative;
+    width: 100%;
+    height: 2rem;
+  }
+}
+
+.content-plan {
+  width: 20rem;
+}
+
+.modal {
+  &--block {
+    display: block;
+  }
+  &--flex {
+    display: flex;
+  }
+}
+</style>

--- a/src/components/Requirements/MultiplePlansDropdown.vue
+++ b/src/components/Requirements/MultiplePlansDropdown.vue
@@ -1,19 +1,28 @@
 <template>
   <div>
     <div class="multiplePlans-dropdown">
-      <div
-        class="multiplePlans-dropdown-placeholder wrapper"
-        @click="closeDropdownIfOpen()"
-        data-cyId="multiplePlans-dropdown"
-      >
-        <img :src="editPlan" class="multiplePlans-dropdown-placeholder editimg" alt="edit plans" />
+      <div class="multiplePlans-dropdown-placeholder wrapper" data-cyId="multiplePlans-dropdown">
+        <button>
+          <img
+            :src="editPlan"
+            class="multiplePlans-dropdown-placeholder editimg"
+            alt="edit plans"
+            @click="toggleEditPlan()"
+          />
+        </button>
         <div class="multiplePlans-dropdown-placeholder plan">{{ currPlan }}</div>
         <img
           class="multiplePlans-dropdown-placeholder up-arrow"
           v-if="shown"
           alt="close dropdown"
+          @click="closeDropdownIfOpen()"
         />
-        <img class="multiplePlans-dropdown-placeholder down-arrow" v-else alt="open dropdown" />
+        <img
+          class="multiplePlans-dropdown-placeholder down-arrow"
+          v-else
+          alt="open dropdown"
+          @click="closeDropdownIfOpen()"
+        />
       </div>
       <div
         class="multiplePlans-dropdown-content"
@@ -43,6 +52,9 @@ export default defineComponent({
   props: {
     plan: { type: String, default: 'No additional plans yet' },
   },
+  emits: {
+    'open-edit-modal': () => true,
+  },
   data() {
     return {
       shown: false,
@@ -67,6 +79,9 @@ export default defineComponent({
     },
     planClicked(plan: string) {
       if (this.plans.length !== 1) this.currPlan = plan;
+    },
+    toggleEditPlan() {
+      this.$emit('open-edit-modal');
     },
   },
 });

--- a/src/global-firestore-data/index.ts
+++ b/src/global-firestore-data/index.ts
@@ -13,9 +13,13 @@ export const cornellCourseRosterCourseToFirebaseSemesterCourseWithGlobalData = (
 
 export { setAppOnboardingData, deleteTransferCredit } from './user-onboarding-data';
 export {
+  editPlans,
+  editPlan,
   editSemesters,
   editSemester,
   addSemester,
+  addPlan,
+  deletePlan,
   deleteSemester,
   addCourseToSemester,
   deleteCourseFromSemester,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Work in progress!!
Finish implementing frontend for all modals for add, delete and edit plans. 
- Format modals according to Figma
- Add TextInputModal.vue that saves a text input. Component of CopyPlanModal.vue, and EditPlanModal.vue
- Write methods that will be used to call firestore functions


<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- Call firestore functions after closing modals.
- Write Cypress e2e frontend tests 


### Test Plan <!-- Required -->

- Will write Cypress frontend tests for open and close states for the modal.

