### PR TITLE
Update BottomBarCourseInfo.vue

### DIFF
--- a/src/components/BottomBar/BottomBarCourseInfo.vue
+++ b/src/components/BottomBar/BottomBarCourseInfo.vue
@@ -107,7 +107,7 @@ export default defineComponent({
     },
     rosterLink(): string {
       const [subject, number] = this.courseObj.code.split(' ');
-      return `https://classes.cornell.edu/browse/roster/${this.courseObj.lastRoster}/class/${subject}/${number}`;
+      return `https://classes.cornell.edu/browse/roster/${this.courseObj.currRoster}/class/${subject}/${number}`;
     },
   },
 


### PR DESCRIPTION
### Summary <!-- Required -->

Fix the class roster URL when a user clicks the "View Course Information on Roster" link in BottomBar. 

### Test Plan <!-- Required -->

Visited the updated link for courses in two scenarios: 

1. Course is offered in the chosen semester, and the link takes user to the correct roster link.
2. Course is not offered in the chosen semester, and the link takes the user to the latest roster link. 


