### PR TITLE
Rebranch DTI as 'Digital Tech & Innovation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Access CoursePlan at [courseplan.io](https://courseplan.io)!
 
-CoursePlan is a four-year academic planner for Cornell undergraduates developed by the Design & Tech Initiative. CoursePlan helps undergraduates track their courses and their requirements automatically depending on their college, major, and minor. It aims to allow students view the big picture of their time at Cornell.
+CoursePlan is a four-year academic planner for Cornell undergraduates developed by the Digital Tech & Innovation. CoursePlan helps undergraduates track their courses and their requirements automatically depending on their college, major, and minor. It aims to allow students view the big picture of their time at Cornell.
 
 View documentation in our [wiki](https://github.com/cornell-dti/course-plan/wiki).
 

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -64,7 +64,7 @@
         <img class="semesterView-heart" src="@/assets/images/redHeart.svg" alt="heart" />
         by
         <a target="_blank" href="https://www.cornelldti.org/projects/courseplan/">
-          Cornell Design &amp; Tech Initiative
+          Cornell Digital Tech &amp; Innovation
         </a>
       </div>
     </div>
@@ -211,6 +211,7 @@ export default defineComponent({
     margin-bottom: 1rem;
     min-height: 2.25rem;
     align-items: center;
+
     &--two {
       justify-content: space-between;
     }
@@ -280,6 +281,7 @@ export default defineComponent({
 
     a {
       color: $medGray;
+
       &:hover {
         text-decoration: underline $medGray;
       }
@@ -308,9 +310,11 @@ export default defineComponent({
     margin-top: 5.5rem;
     margin-left: 2.5rem;
     margin-right: 1rem;
+
     &-switch {
       padding-right: 0.75rem;
     }
+
     &-content {
       width: 100%;
       justify-content: center;

--- a/src/containers/Policy.vue
+++ b/src/containers/Policy.vue
@@ -4,7 +4,7 @@
     <div class="content">
       <h2>Privacy Policy</h2>
       <p>
-        Your privacy is important to us. It is Cornell Design Tech Initiative&#39;s policy to
+        Your privacy is important to us. It is Cornell Digital Tech & Innovation&#39;s policy to
         respect your privacy and comply with any applicable law and regulation regarding any
         personal information we may collect about you, including across our website,
         <a href="https://courseplan.io/">https://courseplan.io/</a>, and other sites we own and


### PR DESCRIPTION
### Summary <!-- Required -->

Replaces instances of 'Design & Tech Initiative' with 'Digital Tech & Innovation.'
