### PR TITLE
Implement 'serve:prod' Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vite",
+    "serve:prod": "vite --mode production",
     "build": "vite build --mode production",
     "build:dev": "vite build --mode development",
     "serve:build": "serve --listen 8080 --single dist",


### PR DESCRIPTION
### Summary <!-- Required -->

Implements a 'serve:prod' script, allowing devs to build and test CoursePlan locally for production.

### Test Plan <!-- Required -->

Run `npm run serve:prod` and check that you can view your production data on CoursePlan.
