### PR TITLE
Modify Workflows to Reference `main` as Default Branch

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -2,7 +2,7 @@ name: Deploy to Staging
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/ci-policies.yml
+++ b/.github/workflows/ci-policies.yml
@@ -10,10 +10,10 @@ jobs:
         run: |
           echo "Your head ref is ${{ github.head_ref }}."
           echo "Your base ref is ${{ github.base_ref }}."
-      - name: Fail if try to push release from non-master branch
-        if: ((github.base_ref == 'beta-release' || github.base_ref == 'release') && github.head_ref != 'master') && (github.event.pull_request.user.login != 'noschiff')
+      - name: Fail if try to push release from non-main branch
+        if: ((github.base_ref == 'beta-release' || github.base_ref == 'release') && github.head_ref != 'main')
         run: |
-          echo "Head ref must be master for release. Everything should go through staging first!"
+          echo "Head ref must be main for release. Everything should go through staging first!"
           exit 1
   warn-big-diff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary <!-- Required -->

Updates workflows to refer to the default branch as `main`; after this is merged I will update the default branch in settings and delete `master`.