### PR TITLE
Migrate Other Yes Categories

### DIFF
--- a/scripts/other-yes-list/fetch-courses.ts
+++ b/scripts/other-yes-list/fetch-courses.ts
@@ -21,4 +21,4 @@ export async function writeOtherLiberalStudiesCourses(path) {
   await writeFile(`${path}otherYesCourses.json`, courses);
 }
 
-writeOtherLiberalStudiesCoursesJSON('../../src/assets/courses/');
+writeOtherLiberalStudiesCourses('./scripts/other-yes-list/');

--- a/scripts/other-yes-list/migrate-yes-categories.ts
+++ b/scripts/other-yes-list/migrate-yes-categories.ts
@@ -1,0 +1,27 @@
+import { fetchOtherLiberalStudiesCourses } from './fetch-courses';
+import { coursesCollection, availableRostersForCourseCollection } from '../firebase-config';
+import { CourseWithId } from './parse';
+
+export default async function populateYesCategories() {
+  const yesCourses: CourseWithId[] = await fetchOtherLiberalStudiesCourses();
+
+  Promise.all(
+    yesCourses.map(async course => {
+      /* Computing a mapping that maps a course to a list of semesters it is offered in */
+      const courseAndRostersDoc = await availableRostersForCourseCollection
+        .doc(`${course.subject} ${course.catalogNbr.toString()}`)
+        .get();
+
+      if (courseAndRostersDoc.exists) {
+        const roster = courseAndRostersDoc.data()?.rosters;
+        await coursesCollection
+          .doc(roster)
+          .collection(course.subject)
+          .doc(course.catalogNbr.toString())
+          .update({ yesCategories: course.categories });
+      }
+    })
+  );
+}
+
+populateYesCategories();

--- a/scripts/other-yes-list/parse.ts
+++ b/scripts/other-yes-list/parse.ts
@@ -8,11 +8,9 @@ export type Course = {
   /** The liberal studies categories satisfied by the course */
   categories: readonly string[];
 };
-
 export type CourseWithId = Course & {
   crseId: number;
 };
-
 enum Col {
   CoursePrefix,
   CourseNumber,


### PR DESCRIPTION
The task is to add the categories for every course on the liberal studies other yes list to the course data collection. Currently, the type CornellCourseRosterCourseFullDetail records all of the information we maintain about a course in the course data collection. I added an optional property otherYesCategories, a string array that contains the categories associated with a course in the other yes list.

Test Plan

Need to use Firestore Jest
