### PR TITLE
Refactor semesters to plans

### DIFF
--- a/scripts/track-users.ts
+++ b/scripts/track-users.ts
@@ -135,11 +135,11 @@ async function trackUsers() {
         return;
       }
 
-      const semesters = getFirstPlan(doc.data());
+      const plan = getFirstPlan(doc.data());
 
       let oldSemesterCount = 0;
       let newSemesterCount = 0;
-      semesters.forEach((semester: { year: number; season: string }) => {
+      plan.semesters.forEach((semester: { year: number; season: string }) => {
         if (isOld(semester)) {
           oldSemesterCount += 1;
         } else {
@@ -152,7 +152,7 @@ async function trackUsers() {
         activeUsersCount += 1;
       }
 
-      numSemestersPerUser.push(semesters.length);
+      numSemestersPerUser.push(plan.semesters.length);
       oldSemesters.push(oldSemesterCount);
       newSemesters.push(newSemesterCount);
     });

--- a/src/components/Course/CourseCaution.vue
+++ b/src/components/Course/CourseCaution.vue
@@ -98,7 +98,13 @@ const getCourseCautions = (
     isPlaceholderCourse(course) &&
     ((!store.state.orderByNewest && semesterIndex !== course.startingSemester) ||
       (store.state.orderByNewest &&
-        store.state.semesters.length - semesterIndex + 1 !== course.startingSemester));
+        (
+          store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+          store.state.plans[0].semesters
+        ).length -
+          semesterIndex +
+          1 !==
+          course.startingSemester));
   return {
     noMatchedRequirement,
     typicallyOfferedWarning,

--- a/src/components/Modals/EditSemester.vue
+++ b/src/components/Modals/EditSemester.vue
@@ -46,7 +46,10 @@ export default defineComponent({
   },
   computed: {
     semesters(): readonly FirestoreSemester[] {
-      return store.state.semesters;
+      return (
+        store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+        store.state.plans[0].semesters
+      );
     },
   },
   methods: {

--- a/src/components/Modals/NewSemesterModal.vue
+++ b/src/components/Modals/NewSemesterModal.vue
@@ -37,7 +37,10 @@ export default defineComponent({
   },
   computed: {
     semesters(): readonly FirestoreSemester[] {
-      return store.state.semesters;
+      return (
+        store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+        store.state.plans[0].semesters
+      );
     },
   },
   methods: {

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -124,6 +124,7 @@ import {
 import timeline1Text from '@/assets/images/timeline1text.svg';
 import timeline2Text from '@/assets/images/timeline2text.svg';
 import timeline3Text from '@/assets/images/timeline3text.svg';
+import store from '@/store';
 
 const timelineTexts = [timeline1Text, timeline2Text, timeline3Text];
 
@@ -251,7 +252,7 @@ export default defineComponent({
       this.clearTransferCreditIfGraduate();
       setAppOnboardingData(this.name, revised);
       // indicates first time user onboarding
-      if (!this.isEditingProfile) populateSemesters(revised);
+      if (!this.isEditingProfile) populateSemesters(store.state.currentPlan, revised);
       this.$emit('onboard');
     },
     goBack() {

--- a/src/components/Requirements/CompletedSubReqCourse.vue
+++ b/src/components/Requirements/CompletedSubReqCourse.vue
@@ -68,7 +68,10 @@ export default defineComponent({
   }),
   computed: {
     semesters(): readonly FirestoreSemester[] {
-      return store.state.semesters;
+      return (
+        store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+        store.state.plans[0].semesters
+      );
     },
     isTransferCredit(): boolean {
       const { uniqueId } = this.courseTaken;
@@ -111,7 +114,8 @@ export default defineComponent({
           deleteTransferCredit(this.courseTaken.code);
         } else {
           const { uniqueId } = this.courseTaken;
-          if (typeof uniqueId === 'number') deleteCourseFromSemesters(uniqueId, this.$gtag);
+          if (typeof uniqueId === 'number')
+            deleteCourseFromSemesters(store.state.currentPlan, uniqueId, this.$gtag);
         }
       }
     },

--- a/src/components/Requirements/IncompleteSelfCheck.vue
+++ b/src/components/Requirements/IncompleteSelfCheck.vue
@@ -77,7 +77,10 @@ export default defineComponent({
     // and courses that do not fulfill the requirement checker
     selfCheckCourses(): Record<string, FirestoreSemesterCourse> {
       const courses: Record<string, FirestoreSemesterCourse> = {};
-      store.state.semesters
+      (
+        store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+        store.state.plans[0].semesters
+      )
         .flatMap(it => it.courses)
         .forEach(course => {
           if (
@@ -165,6 +168,7 @@ export default defineComponent({
       this.showDropdown = false;
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourseWithGlobalData(course);
       addCourseToSemester(
+        store.state.currentPlan,
         year,
         season,
         newCourse,

--- a/src/components/Requirements/RequirementSideBar.vue
+++ b/src/components/Requirements/RequirementSideBar.vue
@@ -224,7 +224,10 @@ export default defineComponent({
       return featureFlagCheckers.isRequirementDebuggerEnabled();
     },
     semesters(): readonly FirestoreSemester[] {
-      return store.state.semesters;
+      return (
+        store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+        store.state.plans[0].semesters
+      );
     },
     onboardingData(): AppOnboardingData {
       return store.state.onboardingData;

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -278,6 +278,7 @@ export default defineComponent({
       set(newCourses: readonly AppFirestoreSemesterCourseWithRequirementID[]) {
         const courses = newCourses.map(({ requirementID: _, ...rest }) => rest);
         editSemester(
+          store.state.currentPlan,
           this.year,
           this.season,
           (semester: FirestoreSemester): FirestoreSemester => ({
@@ -411,7 +412,14 @@ export default defineComponent({
     addCourse(data: CornellCourseRosterCourse, choice: FirestoreCourseOptInOptOutChoices) {
       const newCourse = cornellCourseRosterCourseToFirebaseSemesterCourseWithGlobalData(data);
       // Since the course is new, we know the old choice does not exist.
-      addCourseToSemester(this.year, this.season, newCourse, () => choice, this.$gtag);
+      addCourseToSemester(
+        store.state.currentPlan,
+        this.year,
+        this.season,
+        newCourse,
+        () => choice,
+        this.$gtag
+      );
 
       const courseCode = `${data.subject} ${data.catalogNbr}`;
       this.openConfirmationModal(`Added ${courseCode} to ${this.season} ${this.year}`);
@@ -429,7 +437,14 @@ export default defineComponent({
         };
 
         // add the course to the semeser (with no choice made)
-        addCourseToSemester(this.year, this.season, newCourse, () => choice, this.$gtag);
+        addCourseToSemester(
+          store.state.currentPlan,
+          this.year,
+          this.season,
+          newCourse,
+          () => choice,
+          this.$gtag
+        );
         this.closeCourseModal();
 
         const conflicts = store.state.courseToRequirementsInConstraintViolations.get(
@@ -455,15 +470,28 @@ export default defineComponent({
       this.openConfirmationModal(`Added ${course.code} to ${this.season} ${this.year}`);
     },
     deleteCourseWithoutModal(uniqueID: number) {
-      deleteCourseFromSemester(this.year, this.season, uniqueID, this.$gtag);
+      deleteCourseFromSemester(
+        store.state.currentPlan,
+        this.year,
+        this.season,
+        uniqueID,
+        this.$gtag
+      );
     },
     deleteCourse(courseCode: string, uniqueID: number) {
-      deleteCourseFromSemester(this.year, this.season, uniqueID, this.$gtag);
+      deleteCourseFromSemester(
+        store.state.currentPlan,
+        this.year,
+        this.season,
+        uniqueID,
+        this.$gtag
+      );
       // Update requirements menu
       this.openConfirmationModal(`Removed ${courseCode} from ${this.season} ${this.year}`);
     },
     colorCourse(color: string, uniqueID: number, courseCode: string) {
       editSemester(
+        store.state.currentPlan,
         this.year,
         this.season,
         (semester: FirestoreSemester): FirestoreSemester => ({
@@ -485,7 +513,7 @@ export default defineComponent({
             : course
         ),
       });
-      editSemesters(oldSemesters => oldSemesters.map(sem => updater(sem)));
+      editSemesters(store.state.currentPlan, oldSemesters => oldSemesters.map(sem => updater(sem)));
       updateSubjectColorData(color, subject);
       this.openConfirmationModal(`Changed color for ${subject}`);
     },
@@ -494,6 +522,7 @@ export default defineComponent({
     },
     editCourseCredit(credit: number, uniqueID: number) {
       editSemester(
+        store.state.currentPlan,
         this.year,
         this.season,
         (semester: FirestoreSemester): FirestoreSemester => ({
@@ -543,6 +572,7 @@ export default defineComponent({
     },
     editSemester(seasonInput: string, yearInput: number) {
       editSemester(
+        store.state.currentPlan,
         this.year,
         this.season,
         (oldSemester: FirestoreSemester): FirestoreSemester => ({
@@ -559,7 +589,7 @@ export default defineComponent({
       this.isClearSemesterOpen = false;
     },
     clearSemester() {
-      deleteAllCoursesFromSemester(this.year, this.season, this.$gtag);
+      deleteAllCoursesFromSemester(store.state.currentPlan, this.year, this.season, this.$gtag);
       this.openConfirmationModal(`Cleared ${this.season} ${this.year} in plan`);
     },
     walkthroughText() {

--- a/src/components/Semester/SemesterView.vue
+++ b/src/components/Semester/SemesterView.vue
@@ -107,7 +107,14 @@ export default defineComponent({
   },
   computed: {
     semesters(): readonly FirestoreSemester[] {
-      return store.state.semesters;
+      console.log(store.state.plans);
+      if (store.state.plans.length === 0) {
+        return [];
+      }
+      return (
+        store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+        store.state.plans[0].semesters
+      );
     },
     noSemesters(): boolean {
       return this.semesters.length === 0;
@@ -145,11 +152,11 @@ export default defineComponent({
       this.isSemesterModalOpen = false;
     },
     addSemester(season: string, year: number) {
-      addSemester(year, season as FirestoreSemesterSeason, this.$gtag);
+      addSemester(store.state.currentPlan, year, season as FirestoreSemesterSeason, this.$gtag);
       this.openSemesterConfirmationModal(season as FirestoreSemesterSeason, year, true);
     },
     deleteSemester(season: string, year: number) {
-      deleteSemester(year, season as FirestoreSemesterSeason, this.$gtag);
+      deleteSemester(store.state.currentPlan, year, season as FirestoreSemesterSeason, this.$gtag);
       this.openSemesterConfirmationModal(season as FirestoreSemesterSeason, year, false);
     },
     courseOnClick(course: FirestoreSemesterCourse) {

--- a/src/containers/Dashboard.vue
+++ b/src/containers/Dashboard.vue
@@ -169,7 +169,10 @@ export default defineComponent({
       return store.state.onboardingData;
     },
     semesters(): readonly FirestoreSemester[] {
-      return store.state.semesters;
+      return (
+        store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+        store.state.plans[0].semesters
+      );
     },
     hasBottomCourses(): boolean {
       return immutableBottomBarState.bottomCourses.length > 0;

--- a/src/global-firestore-data/user-semesters.ts
+++ b/src/global-firestore-data/user-semesters.ts
@@ -13,17 +13,22 @@ import {
 } from './user-overridden-fulfillment-choices';
 
 export const editSemesters = (
+  plan: Plan,
   updater: (oldSemesters: readonly FirestoreSemester[]) => readonly FirestoreSemester[]
 ): void => {
-  const semesters = updater(store.state.semesters);
-  store.commit('setSemesters', semesters);
-  // TODO: update when multiple plans frontend implemented
-  updateDoc(doc(semestersCollection, store.state.currentFirebaseUser.email), {
-    semesters,
-    plans: [{ semesters }],
-  });
+  const editedPlan = (p: Plan): Plan => ({ name: p.name, semesters: updater(p.semesters) });
+  editPlan(plan.name, editedPlan);
 };
 
+export const editPlans = async (
+  updater: (oldPlans: readonly Plan[]) => readonly Plan[]
+): Promise<void> => {
+  const plans = updater(store.state.plans);
+  store.commit('setPlans', plans);
+  await updateDoc(doc(semestersCollection, store.state.currentFirebaseUser.email), {
+    plans,
+  });
+};
 /**
  * Sets whether semesters are ordered by newest/oldest
  */
@@ -36,11 +41,12 @@ export const setOrderByNewest = (orderByNewest: boolean): void => {
 };
 
 export const editSemester = (
+  plan: Plan,
   year: number,
   season: FirestoreSemesterSeason,
   updater: (oldSemester: FirestoreSemester) => FirestoreSemester
 ): void => {
-  editSemesters(oldSemesters =>
+  editSemesters(plan, oldSemesters =>
     oldSemesters.map(sem => (semesterEquals(sem, year, season) ? updater(sem) : sem))
   );
 };
@@ -67,6 +73,7 @@ export const semesterEquals = (
 ): boolean => semester.year === year && semester.season === season;
 
 export const addSemester = (
+  plan: Plan,
   year: number,
   season: FirestoreSemesterSeason,
   gtag?: VueGtag,
@@ -76,20 +83,41 @@ export const addSemester = (
   editSemesters(oldSemesters => [...oldSemesters, createSemester(year, season, courses)]);
 };
 
+export const addPlan = async (
+  name: string,
+  semesters: FirestoreSemester[],
+  gtag?: GTag
+): Promise<void> => {
+  GTagEvent(gtag, 'add-plan');
+  await editPlans(oldPlans => [...oldPlans, createPlan(name, semesters)]);
+};
+
 export const deleteSemester = (
+  plan: Plan,
   year: number,
   season: FirestoreSemesterSeason,
   gtag?: VueGtag
 ): void => {
   GTagEvent(gtag, 'delete-semester');
-  const semester = store.state.semesters.find(sem => semesterEquals(sem, year, season));
+  const semester = (
+    store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+    store.state.plans[0].semesters
+  ).find(sem => semesterEquals(sem, year, season));
   if (semester) {
     deleteCoursesFromRequirementChoices(semester.courses.map(course => course.uniqueID));
     editSemesters(oldSemesters => oldSemesters.filter(sem => !semesterEquals(sem, year, season)));
   }
 };
 
+export const deletePlan = async (name: string, gtag?: GTag): Promise<void> => {
+  GTagEvent(gtag, 'delete-plan');
+  if (store.state.plans.some(p => p.name === name)) {
+    await editPlans(oldPlans => oldPlans.filter(p => p.name !== name));
+  }
+};
+
 export const addCourseToSemester = (
+  plan: Plan,
   year: number,
   season: FirestoreSemesterSeason,
   newCourse: FirestoreSemesterCourse,
@@ -97,7 +125,7 @@ export const addCourseToSemester = (
   gtag?: VueGtag
 ): void => {
   GTagEvent(gtag, 'add-course');
-  editSemesters(oldSemesters => {
+  editSemesters(plan, oldSemesters => {
     let semesterFound = false;
     const newSemestersWithCourse = oldSemesters.map(sem => {
       if (semesterEquals(sem, year, season)) {
@@ -113,16 +141,20 @@ export const addCourseToSemester = (
 };
 
 export const deleteCourseFromSemester = (
+  plan: Plan,
   year: number,
   season: FirestoreSemesterSeason,
   courseUniqueID: number,
   gtag?: VueGtag
 ): void => {
   GTagEvent(gtag, 'delete-course');
-  const semester = store.state.semesters.find(sem => semesterEquals(sem, year, season));
+  const semester = (
+    store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+    store.state.plans[0].semesters
+  ).find(sem => semesterEquals(sem, year, season));
   if (semester) {
     deleteCourseFromRequirementChoices(courseUniqueID);
-    editSemesters(oldSemesters =>
+    editSemesters(plan, oldSemesters =>
       oldSemesters.map(sem => ({
         ...sem,
         courses: semesterEquals(sem, year, season)
@@ -134,15 +166,19 @@ export const deleteCourseFromSemester = (
 };
 
 export const deleteAllCoursesFromSemester = (
+  plan: Plan,
   year: number,
   season: FirestoreSemesterSeason,
   gtag?: VueGtag
 ): void => {
   GTagEvent(gtag, 'delete-semester-courses');
-  const semester = store.state.semesters.find(sem => semesterEquals(sem, year, season));
+  const semester = (
+    store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+    store.state.plans[0].semesters
+  ).find(sem => semesterEquals(sem, year, season));
   if (semester) {
     deleteCoursesFromRequirementChoices(semester.courses.map(course => course.uniqueID));
-    editSemesters(oldSemesters =>
+    editSemesters(plan, oldSemesters =>
       oldSemesters.map(sem => ({
         ...sem,
         courses: semesterEquals(sem, year, season) ? [] : sem.courses,
@@ -151,9 +187,13 @@ export const deleteAllCoursesFromSemester = (
   }
 };
 
-export const deleteCourseFromSemesters = (courseUniqueID: number, gtag?: VueGtag): void => {
+export const deleteCourseFromSemesters = (
+  plan: Plan,
+  courseUniqueID: number,
+  gtag?: GTag
+): void => {
   GTagEvent(gtag, 'delete-course');
-  editSemesters(oldSemesters =>
+  editSemesters(plan, oldSemesters =>
     oldSemesters.map(semester => {
       const coursesWithoutDeleted = semester.courses.filter(
         course => course.uniqueID !== courseUniqueID
@@ -185,7 +225,7 @@ export const getActiveSemesters = (
 };
 
 // add empty semesters based on entrance and graduation time
-export const populateSemesters = (onboarding: AppOnboardingData): void => {
+export const populateSemesters = (plan: Plan, onboarding: AppOnboardingData): void => {
   const entranceYear = parseInt(onboarding.entranceYear, 10);
   const gradYear = parseInt(onboarding.gradYear, 10);
 
@@ -194,5 +234,5 @@ export const populateSemesters = (onboarding: AppOnboardingData): void => {
     : 'Fall';
   const gradSem: FirestoreSemesterSeason = onboarding.gradSem ? onboarding.gradSem : 'Spring';
 
-  editSemesters(() => getActiveSemesters(entranceYear, entranceSem, gradYear, gradSem));
+  editSemesters(plan, () => getActiveSemesters(entranceYear, entranceSem, gradYear, gradSem));
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -50,6 +50,8 @@ export type VuexStoreState = {
   subjectColors: Readonly<Record<string, string>>;
   uniqueIncrementer: number;
   isTeleportModalOpen: boolean;
+  plans: readonly Plan[];
+  currentPlan: Plan;
 };
 
 export class TypedVuexStore extends Store<VuexStoreState> {}
@@ -96,6 +98,8 @@ const store: TypedVuexStore = new TypedVuexStore({
     subjectColors: {},
     uniqueIncrementer: 0,
     isTeleportModalOpen: false,
+    plans: [],
+    currentPlan: { name: '', semesters: [] },
   },
   actions: {},
   mutations: {
@@ -333,7 +337,7 @@ export const initializeFirestoreListeners = (onLoad: () => void): (() => void) =
       store.commit('setSemesters', [newSemester]);
       setDoc(doc(fb.semestersCollection, simplifiedUser.email), {
         orderByNewest: true,
-        plans: [{ semesters: [newSemester] }], // TODO: andxu282 update later
+        plans: [{ name: 'Plan 1', semesters: [newSemester] }], // TODO: andxu282 update later
         semesters: [newSemester],
       });
     }

--- a/src/tools/export-plan/pdf-generator.ts
+++ b/src/tools/export-plan/pdf-generator.ts
@@ -135,7 +135,13 @@ const generatePDF = async (): Promise<void> => {
   doc.setTextColor('#000000');
 
   // Rendering tables now
-  const sems = trimEmptySems(sortedSemesters(store.state.semesters, false));
+  const sems = trimEmptySems(
+    sortedSemesters(
+      store.state.plans.find(p => p === store.state.currentPlan)?.semesters ??
+        store.state.plans[0].semesters,
+      false
+    )
+  );
   let startct = Math.max(firstTableY, programY + 20);
 
   const emojiMap = {

--- a/src/user-data.d.ts
+++ b/src/user-data.d.ts
@@ -36,7 +36,7 @@ type FirestoreSemester = {
 };
 
 type FirestoreSemestersData = {
-  readonly plans?: readonly { semesters: readonly FirestoreSemester[] }[];
+  readonly plans: readonly Plan[];
   readonly semesters: readonly FirestoreSemester[];
   readonly orderByNewest: boolean;
 };
@@ -85,7 +85,7 @@ type FirestoreOverriddenFulfillmentChoices = {
 
 type FirestoreUserData = {
   readonly name: FirestoreUserName;
-  readonly semesters: FirestoreSemester[];
+  // readonly semesters: readonlyFirestoreSemester[];
   readonly orderByNewest: boolean;
   readonly toggleableRequirementChoices: AppToggleableRequirementChoices;
   readonly subjectColors: { readonly [subject: string]: string };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -16,11 +16,8 @@ export const SeasonOrdinal = {
  * @param semestersDoc A document in the `user-semesters` collection
  * @returns The user's first plan
  */
-export const getFirstPlan = ({
-  semesters,
-  plans,
-}: FirestoreSemestersData): readonly FirestoreSemester[] =>
-  plans && plans.length > 0 ? plans[0].semesters : semesters;
+export const getFirstPlan = ({ semesters, plans }: FirestoreSemestersData): Plan =>
+  plans && plans.length > 0 ? plans[0] : { name: 'Plan 1', semesters };
 
 /**
  * Returns given semesters sorted in either increasing or decreasing order of date


### PR DESCRIPTION
**Summary**
Remove all uses of semesters in Vuex store and in Firebase data
- Replace references to semesters field in VuexStoreState with new schema using the new plan data type.
- Address edge case with rendering before Vuex store is set.

**Remaining TODOs:**

- Stub in rest of multiple plans functionality
**Test Plan**
- After running migration script on all users/just your username if testing, does the app load with 1 plan?
- Does adding a new plan show up for you on Firebase?
- Does adding a new semester or classes to a semester update the correct plan on Firebase?