### PR TITLE
Parse GPT Output

### DIFF
--- a/python/prereq_parse.py
+++ b/python/prereq_parse.py
@@ -7,20 +7,13 @@ from typing import Dict, Tuple
 from parsy import (
     regex,
     string,
-    generate,
-    match_item,
     forward_declaration,
-    decimal_digit,
-    seq,
 )
-import parsy
 
 try:
     from secret_api_keys import OPEN_AI_API_KEY
 except ImportError:
     OPEN_AI_API_KEY = "<key>"
-
-# import parsy
 
 MODEL = "gpt-3.5-turbo"
 verbose = False
@@ -224,11 +217,3 @@ def parse_boolean_string(raw_output: str):
     except:
         output = expr.parse(f"({raw_output})")
     return output
-
-
-if __name__ == "__main__":
-    # ((PHYS 2208 AND CHEM 2080) OR (MATH 2130 OR MATH 2310 OR MATH 2220))
-    result = parse_boolean_string(
-        "((PHYS 2208 AND (CHEM 2080 OR MATH 2090)) OR (MATH 2130 OR MATH 2310 OR MATH 2220))"
-    )
-    print(result)

--- a/python/prereq_parse.py
+++ b/python/prereq_parse.py
@@ -4,6 +4,16 @@ from langchain.output_parsers import ResponseSchema
 from langchain.output_parsers import StructuredOutputParser
 from langchain.chains import SequentialChain, TransformChain, LLMChain
 from typing import Dict, Tuple
+from parsy import (
+    regex,
+    string,
+    generate,
+    match_item,
+    forward_declaration,
+    decimal_digit,
+    seq,
+)
+import parsy
 
 try:
     from secret_api_keys import OPEN_AI_API_KEY
@@ -192,13 +202,69 @@ def get_prereqs_coreqs(course_desc: str, verbose=False) -> Tuple[str]:
     # get final prereqs str and coreqs str
     prereqs_response = response["parsed_prerequisites"]
     coreqs_response = response["parsed_corequisites"]
-    # prereqs, coreqs = parse_prereqs_coreqs(prereqs_response, coreqs_response)
     return (prereqs_response, coreqs_response)
 
 
-if __name__ == "__main__":
-    print(
-        get_prereqs_coreqs(
-            "Prerequisite: PHYS 2208 and CHEM 2080, or MATH 2130 or MATH 2310 or MATH 2220, or permission of instructor."
-        )
+def parse_boolean_string(raw_output: str):
+    course = regex("[A-Z]{2,6} \d{4}")
+    expr = forward_declaration()
+    clause = expr.sep_by(sep=string(" AND ") | string(" OR "), min=2).map(
+        lambda x: {"type": "AND", "exprs": x}
     )
+    clause_wrapped = string("(") >> clause << string(")")
+    expr.become(course | clause_wrapped | clause)
+    output = clause.parse(raw_output)
+    return output
+
+
+if __name__ == "__main__":
+    # ((PHYS 2208 AND CHEM 2080) OR (MATH 2130 OR MATH 2310 OR MATH 2220))
+    result = parse_boolean_string(
+        "(PHYS 2208 AND (CHEM 2080 OR MATH 2090)) OR (MATH 2130 OR MATH 2310 OR MATH 2220)"
+    )
+    print(result)
+
+
+# def test_fun(input):
+#     lparen = string('(')
+#     rparen = string(')')
+#     expr = forward_declaration()
+#     simple = regex('[0-9]+')
+#     and_clause = simple.sep_by(string(' AND '))
+#     or_clause = expr.sep_by(string(' OR '))
+#     # group_a = lparen >> and_clause << rparen
+#     # group_b = lparen >> or_clause  << rparen
+#     expr.become(and_clause | or_clause | simple)
+#     return expr.parse(input)
+
+
+# def s_expression(input):
+#     expr = forward_declaration()
+#     simple = regex('[0-9]+').map(int)
+#     grp = expr.sep_by(string(' '))
+#     group = string('(') >> expr.sep_by(string(' ')) << string(')')
+#     expr.become(simple | grp | group)
+#     return expr.parse(input)
+
+# def gpt_fun():
+#     # Define parsers for the logical operators (AND, OR, etc.) and variable names.
+#     operator = parsy.string(" AND ") | parsy.string(" OR ")  # You can add more operators as needed
+#     variable_name = parsy.letter
+
+#     # Define a parser for expressions.
+#     expression = variable_name.sep_by(operator)
+
+#     # Define a function to convert the parsed result into the desired dictionary format.
+#     def to_dict(parsed_result):
+#         operator, variables = parsed_result
+#         return {'type': operator, 'list': variables}
+
+#     # Parse the input string.
+#     input_string = 'a AND b'
+#     result = expression.parse(input_string)
+
+#     # Convert the parsed result to a dictionary.
+#     parsed_dict = to_dict(result)
+
+#     # Print the result.
+#     print(parsed_dict)

--- a/python/test_prereq_parse.py
+++ b/python/test_prereq_parse.py
@@ -1,4 +1,8 @@
-from prereq_parse import get_raw_prereqs_and_coreqs, get_prereqs_coreqs
+from prereq_parse import (
+    get_raw_prereqs_and_coreqs,
+    get_prereqs_coreqs,
+    parse_boolean_string,
+)
 import os
 import pytest
 
@@ -176,3 +180,174 @@ def test_prereqs_coreqs(index=None, shorten=False, verbose=False, hard=False):
             print(f"WRONG Answer: {answer} Got: {response}")
     print(f"{correct / total * 100}%")
     assert correct / total * 100 == 100
+
+
+def test_parse_boolean_string(verbose=False):
+    test_cases = [
+        ("", {}),
+        ("CS 4780", {"type": "ATOM", "exprs": "CS 4780"}),
+        (
+            "AEM 2100 OR AEM 2420 OR AEM 2010",
+            {
+                "type": "OR",
+                "exprs": [
+                    {"type": "ATOM", "exprs": "AEM 2100"},
+                    {"type": "ATOM", "exprs": "AEM 2420"},
+                    {"type": "ATOM", "exprs": "AEM 2010"},
+                ],
+            },
+        ),
+        (
+            "MATH 1110 AND MATH 1106",
+            {
+                "type": "AND",
+                "exprs": [
+                    {"type": "ATOM", "exprs": "MATH 1110"},
+                    {"type": "ATOM", "exprs": "MATH 1106"},
+                ],
+            },
+        ),
+        (
+            "BTRY 3010 AND CS 2110",
+            {
+                "type": "AND",
+                "exprs": [
+                    {"type": "ATOM", "exprs": "BTRY 3010"},
+                    {"type": "ATOM", "exprs": "CS 2110"},
+                ],
+            },
+        ),
+        (
+            "VIEN 2204 AND (VIEN 2205 OR FDSC 2205)",
+            {
+                "type": "AND",
+                "exprs": [
+                    {"type": "ATOM", "exprs": "VIEN 2204"},
+                    {
+                        "type": "OR",
+                        "exprs": [
+                            {"type": "ATOM", "exprs": "VIEN 2205"},
+                            {"type": "ATOM", "exprs": "FDSC 2205"},
+                        ],
+                    },
+                ],
+            },
+        ),
+        (
+            "STSCI 2110 OR PSYCH 2500 OR SOC 3010 OR ECON 3110",
+            {
+                "type": "OR",
+                "exprs": [
+                    {"type": "ATOM", "exprs": "STSCI 2110"},
+                    {"type": "ATOM", "exprs": "PSYCH 2500"},
+                    {"type": "ATOM", "exprs": "SOC 3010"},
+                    {"type": "ATOM", "exprs": "ECON 3110"},
+                ],
+            },
+        ),
+        (
+            "(CHEM 1560 OR CHEM 2070 OR CHEM 2080) AND (CHEM 1570 OR CHEM 3570 OR CHEM 3580) AND FDSC 4170",
+            {
+                "type": "AND",
+                "exprs": [
+                    {
+                        "type": "OR",
+                        "exprs": [
+                            {"type": "ATOM", "exprs": "CHEM 1560"},
+                            {"type": "ATOM", "exprs": "CHEM 2070"},
+                            {"type": "ATOM", "exprs": "CHEM 2080"},
+                        ],
+                    },
+                    {
+                        "type": "OR",
+                        "exprs": [
+                            {"type": "ATOM", "exprs": "CHEM 1570"},
+                            {"type": "ATOM", "exprs": "CHEM 3570"},
+                            {"type": "ATOM", "exprs": "CHEM 3580"},
+                        ],
+                    },
+                    {"type": "ATOM", "exprs": "FDSC 4170"},
+                ],
+            },
+        ),
+        (
+            "(MATH 2210 AND MATH 2220) OR (MATH 2230 AND MATH 2240) OR (MATH 1920 AND MATH 2940)",
+            {
+                "type": "OR",
+                "exprs": [
+                    {
+                        "type": "AND",
+                        "exprs": [
+                            {"type": "ATOM", "exprs": "MATH 2210"},
+                            {"type": "ATOM", "exprs": "MATH 2220"},
+                        ],
+                    },
+                    {
+                        "type": "AND",
+                        "exprs": [
+                            {"type": "ATOM", "exprs": "MATH 2230"},
+                            {"type": "ATOM", "exprs": "MATH 2240"},
+                        ],
+                    },
+                    {
+                        "type": "AND",
+                        "exprs": [
+                            {"type": "ATOM", "exprs": "MATH 1920"},
+                            {"type": "ATOM", "exprs": "MATH 2940"},
+                        ],
+                    },
+                ],
+            },
+        ),
+        (
+            "(PHYS 2208 AND (CHEM 2080 OR MATH 2090)) OR (MATH 2130 OR MATH 2310 OR MATH 2220)",
+            {
+                "type": "OR",
+                "exprs": [
+                    {
+                        "type": "AND",
+                        "exprs": [
+                            {"type": "ATOM", "exprs": "PHYS 2208"},
+                            {
+                                "type": "OR",
+                                "exprs": [
+                                    {"type": "ATOM", "exprs": "CHEM 2080"},
+                                    {"type": "ATOM", "exprs": "MATH 2090"},
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "type": "OR",
+                        "exprs": [
+                            {"type": "ATOM", "exprs": "MATH 2130"},
+                            {"type": "ATOM", "exprs": "MATH 2310"},
+                            {"type": "ATOM", "exprs": "MATH 2220"},
+                        ],
+                    },
+                ],
+            },
+        ),
+    ]
+
+    correct = 0
+    total = len(test_cases)
+    for test in test_cases:
+        (boolean_string, answer) = test
+        try:
+            response = parse_boolean_string(boolean_string)
+        except:
+            print("PARSING ERROR")
+            continue
+        if response == answer:
+            if verbose:
+                print("CORRECT")
+            correct += 1
+        elif verbose:
+            print(f"WRONG Answer: {answer} Got: {response}")
+    print(f"{correct / total * 100}%")
+    assert correct / total * 100 == 100
+
+
+if __name__ == "__main__":
+    test_parse_boolean_string()

--- a/python/test_prereq_parse.py
+++ b/python/test_prereq_parse.py
@@ -84,19 +84,10 @@ def test_raw_prereqs_coreqs(verbose=False):
             (["MATH 2930", "MSE 2610"], []),
         ),
     ]
-    correct = 0
-    total = len(test_cases)
     for test in test_cases:
         (course_desc, answer) = test
         response = get_raw_prereqs_and_coreqs(course_desc)
-        if response == answer:
-            if verbose:
-                print("CORRECT")
-            correct += 1
-        elif verbose:
-            print(f"WRONG Answer: {answer} Got: {response}")
-    print(f"{correct / total * 100}%")
-    assert correct / total * 100 == 100
+        assert response == answer
 
 
 @pytest.mark.skipif(os.environ.get("RUN_LANGCHAIN_TESTS") == "false", reason="skip")
@@ -161,25 +152,10 @@ def test_prereqs_coreqs(index=None, shorten=False, verbose=False, hard=False):
             ("MATH 2930 AND MSE 2610", ""),
         ),
     ]
-    if index is not None:
-        test_cases = [test_cases[index]]
-    if shorten:
-        test_cases = test_cases[:3]
-    if hard:
-        test_cases = test_cases[-6:]
-    correct = 0
-    total = len(test_cases)
     for test in test_cases:
         (course_desc, answer) = test
         response = get_prereqs_coreqs(course_desc)
-        if response == answer:
-            if verbose:
-                print("CORRECT")
-            correct += 1
-        elif verbose:
-            print(f"WRONG Answer: {answer} Got: {response}")
-    print(f"{correct / total * 100}%")
-    assert correct / total * 100 == 100
+        assert response == answer
 
 
 def test_parse_boolean_string(verbose=False):
@@ -330,23 +306,10 @@ def test_parse_boolean_string(verbose=False):
         ),
     ]
 
-    correct = 0
-    total = len(test_cases)
     for test in test_cases:
         (boolean_string, answer) = test
-        try:
-            response = parse_boolean_string(boolean_string)
-        except:
-            print("PARSING ERROR")
-            continue
-        if response == answer:
-            if verbose:
-                print("CORRECT")
-            correct += 1
-        elif verbose:
-            print(f"WRONG Answer: {answer} Got: {response}")
-    print(f"{correct / total * 100}%")
-    assert correct / total * 100 == 100
+        response = parse_boolean_string(boolean_string)
+        assert response == answer
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary <!-- Required -->
Parses the GPT Output into a usable dictionary to represent the boolean expression of prerequisites.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

- [x] implemented parser for parsing GPT output into dict

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [x] add test cases
- [x] make type change based on OR or AND clause

### Test Plan <!-- Required -->
Will add under python as new unit tests
