### PR TITLE
Requirement Migrations

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -24,7 +24,7 @@ import csRequirements, { csAdvisors } from './majors/cs';
 import deaRequirements, { deaAdvisors } from './majors/dea';
 import easRequirements, { easAdvisors } from './majors/eas';
 import economicsRequirements, { economicsAdvisors } from './majors/econ';
-import eceRequirements, { eceAdvisors } from './majors/ece';
+import eceRequirements, { eceAdvisors, eceMigrations } from './majors/ece';
 import essRequirements, { essAdvisors } from './majors/ess';
 import englishRequirements, { englishAdvisors } from './majors/engl';
 import envEngineeringRequirements, { envEngineeringAdvisors } from './majors/envE';
@@ -78,7 +78,6 @@ import earthAndAtmosphericSciencesMinorRequirements, {
 import mpaRequirements, { mpaAdvisors } from './grad/mpa';
 
 import { MATH2940, CHEM2080 } from './specializations/en';
-import { includesWithSubRequirements } from '@/requirements/checkers';
 
 const json: RequirementsJson = {
   university: {
@@ -257,25 +256,8 @@ const json: RequirementsJson = {
       schools: ['EN'],
       requirements: eceRequirements,
       advisors: eceAdvisors,
+      migrations: eceMigrations,
       abbrev: 'ECE',
-      // export migration from ece
-      migrations: [
-        {
-          entryYear: 2020,
-          type: 'modify',
-          field: 'Core Courses',
-          newValue: {
-            name: 'Core Courses',
-            description: 'ECE 2100, ECE 2200, & ECE 3400',
-            source:
-              'https://www.ece.cornell.edu/ece/programs/undergraduate-programs/majors/program-requirements',
-            checker: includesWithSubRequirements(['ECE 2100'], ['ECE 2200'], ['ECE 3400']),
-            fulfilledBy: 'courses',
-            perSlotMinCount: [1, 1, 1],
-            slotNames: ['ECE 2100', 'ECE 2200', 'ECE 3400'],
-          },
-        },
-      ],
     },
     ENGL: {
       name: 'English',

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -78,6 +78,7 @@ import earthAndAtmosphericSciencesMinorRequirements, {
 import mpaRequirements, { mpaAdvisors } from './grad/mpa';
 
 import { MATH2940, CHEM2080 } from './specializations/en';
+import { includesWithSubRequirements } from '@/requirements/checkers';
 
 const json: RequirementsJson = {
   university: {
@@ -257,6 +258,24 @@ const json: RequirementsJson = {
       requirements: eceRequirements,
       advisors: eceAdvisors,
       abbrev: 'ECE',
+      // export migration from ece 
+      migrations: [
+        { 
+          "entryYear": 2020,
+          "type": "modify",
+          "field": "Core Courses",
+          "newValue": {
+            name: 'Core Courses',
+            description: 'ECE 2100, ECE 2200, & ECE 3400',
+            source:
+              'https://www.ece.cornell.edu/ece/programs/undergraduate-programs/majors/program-requirements',
+            checker: includesWithSubRequirements(['ECE 2100'], ['ECE 2200'], ['ECE 3400']),
+            fulfilledBy: 'courses',
+            perSlotMinCount: [1, 1, 1],
+            slotNames: ['ECE 2100', 'ECE 2200', 'ECE 3400'],
+          },
+        }
+      ]
     },
     ENGL: {
       name: 'English',

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -258,13 +258,13 @@ const json: RequirementsJson = {
       requirements: eceRequirements,
       advisors: eceAdvisors,
       abbrev: 'ECE',
-      // export migration from ece 
+      // export migration from ece
       migrations: [
-        { 
-          "entryYear": 2020,
-          "type": "modify",
-          "field": "Core Courses",
-          "newValue": {
+        {
+          entryYear: 2020,
+          type: 'modify',
+          field: 'Core Courses',
+          newValue: {
             name: 'Core Courses',
             description: 'ECE 2100, ECE 2200, & ECE 3400',
             source:
@@ -274,8 +274,8 @@ const json: RequirementsJson = {
             perSlotMinCount: [1, 1, 1],
             slotNames: ['ECE 2100', 'ECE 2200', 'ECE 3400'],
           },
-        }
-      ]
+        },
+      ],
     },
     ENGL: {
       name: 'English',

--- a/src/data/majors/ece.ts
+++ b/src/data/majors/ece.ts
@@ -33,13 +33,13 @@ const eceRequirements: readonly CollegeOrMajorRequirement[] = [
   },
   {
     name: 'Core Courses',
-    description: 'ECE 2100, ECE 2200 ECE 3400',
+    description: 'ECE 2100, ECE 2720',
     source:
       'https://www.ece.cornell.edu/ece/programs/undergraduate-programs/majors/program-requirements',
-    checker: includesWithSubRequirements(['ECE 2100'], ['ECE 2200'], ['ECE 3400']),
+    checker: includesWithSubRequirements(['ECE 2100'], ['ECE 2720'],),
     fulfilledBy: 'courses',
-    perSlotMinCount: [1, 1, 1],
-    slotNames: ['ECE 2100', 'ECE 2200', 'ECE 3400'],
+    perSlotMinCount: [1, 1,],
+    slotNames: ['ECE 2100', 'ECE 2720'],
   },
   {
     name: 'Foundation Courses',

--- a/src/data/majors/ece.ts
+++ b/src/data/majors/ece.ts
@@ -1,4 +1,4 @@
-import { Course, CollegeOrMajorRequirement } from '../../requirements/types';
+import { Course, CollegeOrMajorRequirement, migration } from '../../requirements/types';
 import {
   ifCodeMatch,
   includesWithSubRequirements,
@@ -175,3 +175,21 @@ export default eceRequirements;
 export const eceAdvisors: AdvisorGroup = {
   advisors: [{ name: 'Sharif Ewais-Orozco', email: 'ugrad-coordinator@ece.cornell.edu' }],
 };
+
+export const eceMigrations: migration[] = [
+  {
+    entryYear: '2020', // For students with an entry year of 2020 or earlier, this requirement applies. For students with an entry year of 2021 or later, the above Core Courses requirement applies
+    type: 'Modify',
+    fieldName: 'Core Courses',
+    newValue: {
+      name: 'Core Courses',
+      description: 'ECE 2100, ECE 2200, & ECE 3400',
+      source:
+        'https://www.ece.cornell.edu/ece/programs/undergraduate-programs/majors/program-requirements',
+      checker: includesWithSubRequirements(['ECE 2100'], ['ECE 2200'], ['ECE 3400']),
+      fulfilledBy: 'courses',
+      perSlotMinCount: [1, 1, 1],
+      slotNames: ['ECE 2100', 'ECE 2200', 'ECE 3400'],
+    },
+  },
+];

--- a/src/data/majors/ece.ts
+++ b/src/data/majors/ece.ts
@@ -1,4 +1,4 @@
-import { Course, CollegeOrMajorRequirement, migration } from '../../requirements/types';
+import { Course, CollegeOrMajorRequirement, RequirementMigration } from '../../requirements/types';
 import {
   ifCodeMatch,
   includesWithSubRequirements,
@@ -176,9 +176,9 @@ export const eceAdvisors: AdvisorGroup = {
   advisors: [{ name: 'Sharif Ewais-Orozco', email: 'ugrad-coordinator@ece.cornell.edu' }],
 };
 
-export const eceMigrations: migration[] = [
+export const eceMigrations: RequirementMigration[] = [
   {
-    entryYear: '2020', // For students with an entry year of 2020 or earlier, this requirement applies. For students with an entry year of 2021 or later, the above Core Courses requirement applies
+    entryYear: 2020, // For students with an entry year of 2020 or earlier, this requirement applies. For students with an entry year of 2021 or later, the above Core Courses requirement applies
     type: 'Modify',
     fieldName: 'Core Courses',
     newValue: {

--- a/src/data/majors/ece.ts
+++ b/src/data/majors/ece.ts
@@ -36,9 +36,9 @@ const eceRequirements: readonly CollegeOrMajorRequirement[] = [
     description: 'ECE 2100, ECE 2720',
     source:
       'https://www.ece.cornell.edu/ece/programs/undergraduate-programs/majors/program-requirements',
-    checker: includesWithSubRequirements(['ECE 2100'], ['ECE 2720'],),
+    checker: includesWithSubRequirements(['ECE 2100'], ['ECE 2720']),
     fulfilledBy: 'courses',
-    perSlotMinCount: [1, 1,],
+    perSlotMinCount: [1, 1],
     slotNames: ['ECE 2100', 'ECE 2720'],
   },
   {

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -47,10 +47,10 @@ type ToggleableRequirementFulfillmentInformation<T = Record<string, unknown>> = 
       readonly minNumberOfSlots?: number;
       readonly description: string;
     } & T &
-    (
-      | { readonly counting: 'courses'; readonly slotNames: readonly string[] }
-      | { readonly counting: 'credits' }
-    );
+      (
+        | { readonly counting: 'courses'; readonly slotNames: readonly string[] }
+        | { readonly counting: 'credits' }
+      );
   };
 };
 
@@ -59,24 +59,24 @@ type ToggleableRequirementFulfillmentInformation<T = Record<string, unknown>> = 
  */
 type RequirementFulfillmentInformation<T = Record<string, unknown>> =
   | {
-    readonly fulfilledBy: 'self-check';
-    // Currently unused.
-    readonly minCount?: number;
-  }
+      readonly fulfilledBy: 'self-check';
+      // Currently unused.
+      readonly minCount?: number;
+    }
   | (RequirementFulfillmentInformationCourseBase<T> & {
-    /**
-     * Compound requirements only.
-     * It is a map from additional requirement name and corresponding courses/checkers.
-     */
-    readonly additionalRequirements?: {
-      readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
-    };
-  } & T)
+      /**
+       * Compound requirements only.
+       * It is a map from additional requirement name and corresponding courses/checkers.
+       */
+      readonly additionalRequirements?: {
+        readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
+      };
+    } & T)
   | (RequirementFulfillmentInformationCreditBase<T> & {
-    readonly additionalRequirements?: {
-      readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
-    };
-  } & T)
+      readonly additionalRequirements?: {
+        readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
+      };
+    } & T)
   | ToggleableRequirementFulfillmentInformation<T>;
 
 /** Requirements may have conditions associated with certain course ids, eg. for AP/IB exams. */

--- a/src/requirement-types.d.ts
+++ b/src/requirement-types.d.ts
@@ -47,10 +47,10 @@ type ToggleableRequirementFulfillmentInformation<T = Record<string, unknown>> = 
       readonly minNumberOfSlots?: number;
       readonly description: string;
     } & T &
-      (
-        | { readonly counting: 'courses'; readonly slotNames: readonly string[] }
-        | { readonly counting: 'credits' }
-      );
+    (
+      | { readonly counting: 'courses'; readonly slotNames: readonly string[] }
+      | { readonly counting: 'credits' }
+    );
   };
 };
 
@@ -59,24 +59,24 @@ type ToggleableRequirementFulfillmentInformation<T = Record<string, unknown>> = 
  */
 type RequirementFulfillmentInformation<T = Record<string, unknown>> =
   | {
-      readonly fulfilledBy: 'self-check';
-      // Currently unused.
-      readonly minCount?: number;
-    }
+    readonly fulfilledBy: 'self-check';
+    // Currently unused.
+    readonly minCount?: number;
+  }
   | (RequirementFulfillmentInformationCourseBase<T> & {
-      /**
-       * Compound requirements only.
-       * It is a map from additional requirement name and corresponding courses/checkers.
-       */
-      readonly additionalRequirements?: {
-        readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
-      };
-    } & T)
+    /**
+     * Compound requirements only.
+     * It is a map from additional requirement name and corresponding courses/checkers.
+     */
+    readonly additionalRequirements?: {
+      readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
+    };
+  } & T)
   | (RequirementFulfillmentInformationCreditBase<T> & {
-      readonly additionalRequirements?: {
-        readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
-      };
-    } & T)
+    readonly additionalRequirements?: {
+      readonly [name: string]: RequirementFulfillmentInformationCourseOrCreditBase<T>;
+    };
+  } & T)
   | ToggleableRequirementFulfillmentInformation<T>;
 
 /** Requirements may have conditions associated with certain course ids, eg. for AP/IB exams. */
@@ -95,6 +95,10 @@ type DecoratedCollegeOrMajorRequirement = RequirementCommon &
     readonly courses: readonly (readonly number[])[];
     readonly conditions?: Readonly<RequirementCourseConditions>;
   }>;
+
+type MigrationWithDecoratedRequirement = RequirementMigration & {
+  newValue?: DecoratedCollegeOrMajorRequirement;
+};
 
 /**
  * CourseTaken is the data type used in requirement computation.

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -125,6 +125,17 @@ export function allowCourseDoubleCountingBetweenRequirements(
   return false;
 }
 
+const reqWithSourceInfo = (
+  req: DecoratedCollegeOrMajorRequirement,
+  sourceType: 'Major' | 'Minor',
+  sourceSpecificName: string
+) => ({
+  ...req,
+  id: `${sourceType}-${sourceSpecificName}-${req.name}`,
+  sourceType,
+  sourceSpecificName,
+});
+
 /**
  * Get the requirements for a provided collection of majors/minors
  *
@@ -139,6 +150,7 @@ const fieldOfStudyReqs = (
 ) => {
   const jsonKey = sourceType.toLowerCase() as 'major' | 'minor';
   const fieldRequirements = requirementJson[jsonKey];
+
   return fields
     .map(field => {
       const fieldRequirement = fieldRequirements[field];
@@ -178,15 +190,7 @@ const fieldOfStudyReqs = (
           return it;
         })
         .concat(addMigrationNewValues.filter(Boolean) as DecoratedCollegeOrMajorRequirement[])
-        .map(
-          it =>
-            (({
-              ...it,
-              id: `${sourceType}-${field}-${it.name}`,
-              sourceType,
-              sourceSpecificName: field,
-            } as const) ?? [])
-        );
+        .map(it => reqWithSourceInfo(it, sourceType, field));
     })
     .flat();
 };

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -153,10 +153,6 @@ const fieldOfStudyReqs = (
         .filter(migration => migration.type === 'Add')
         .map(migration => migration.newValue);
 
-      const modifyMigrationNewValues = filteredMigrations
-        .filter(migration => migration.type === 'Modify')
-        .map(migration => migration.newValue);
-
       return fieldRequirement?.requirements
         .filter(it => {
           const matchingMigration = filteredMigrations.find(
@@ -164,14 +160,23 @@ const fieldOfStudyReqs = (
           );
 
           if (matchingMigration) {
-            if (matchingMigration.type === 'Delete' || matchingMigration.type === 'Modify') {
+            if (matchingMigration.type === 'Delete') {
               return false;
             }
           }
           return true;
         })
-
-        .concat(modifyMigrationNewValues.filter(Boolean) as DecoratedCollegeOrMajorRequirement[])
+        .map(it => {
+          const matchingMigration = filteredMigrations.find(
+            migration => migration.fieldName === it.name
+          );
+          if (matchingMigration) {
+            if (matchingMigration.type === 'Modify') {
+              return matchingMigration.newValue as DecoratedCollegeOrMajorRequirement;
+            }
+          }
+          return it;
+        })
         .concat(addMigrationNewValues.filter(Boolean) as DecoratedCollegeOrMajorRequirement[])
         .map(
           it =>

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -161,36 +161,44 @@ const fieldOfStudyReqs = (
         migration => parseInt(entryYear, 10) <= migration.entryYear
       );
 
+      // Collect all requirements corresponding to 'Add' migrations in one array
       const addMigrationNewValues = filteredMigrations
         .filter(migration => migration.type === 'Add')
         .map(migration => migration.newValue);
 
-      return fieldRequirement?.requirements
-        .filter(it => {
-          const matchingMigration = filteredMigrations.find(
-            migration => migration.fieldName === it.name
-          );
+      return (
+        fieldRequirement?.requirements
+          // Find migrations that match existing requirements - must be 'Delete' or 'Modify'
+          .filter(it => {
+            const matchingMigration = filteredMigrations.find(
+              migration => migration.fieldName === it.name
+            );
 
-          if (matchingMigration) {
-            if (matchingMigration.type === 'Delete') {
-              return false;
+            // If a reqiurement matches a 'Delete' migration, return false (filter it out of overall requirements)
+            if (matchingMigration) {
+              if (matchingMigration.type === 'Delete') {
+                return false;
+              }
             }
-          }
-          return true;
-        })
-        .map(it => {
-          const matchingMigration = filteredMigrations.find(
-            migration => migration.fieldName === it.name
-          );
-          if (matchingMigration) {
-            if (matchingMigration.type === 'Modify') {
-              return matchingMigration.newValue as DecoratedCollegeOrMajorRequirement;
+            return true;
+          })
+          .map(it => {
+            const matchingMigration = filteredMigrations.find(
+              migration => migration.fieldName === it.name
+            );
+
+            // If a requirement matches a 'Modify' migration, map it to it's new value
+            if (matchingMigration) {
+              if (matchingMigration.type === 'Modify') {
+                return matchingMigration.newValue as DecoratedCollegeOrMajorRequirement;
+              }
             }
-          }
-          return it;
-        })
-        .concat(addMigrationNewValues.filter(Boolean) as DecoratedCollegeOrMajorRequirement[])
-        .map(it => reqWithSourceInfo(it, sourceType, field));
+            return it;
+          })
+          .concat(addMigrationNewValues.filter(Boolean) as DecoratedCollegeOrMajorRequirement[])
+          // Use helper to map requirements to requirements with source info
+          .map(it => reqWithSourceInfo(it, sourceType, field))
+      );
     })
     .flat();
 };

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -175,12 +175,12 @@ const fieldOfStudyReqs = (
         .concat(addMigrationNewValues.filter(Boolean) as DecoratedCollegeOrMajorRequirement[])
         .map(
           it =>
-          (({
-            ...it,
-            id: `${sourceType}-${field}-${it.name}`,
-            sourceType,
-            sourceSpecificName: field,
-          } as const) ?? [])
+            (({
+              ...it,
+              id: `${sourceType}-${field}-${it.name}`,
+              sourceType,
+              sourceSpecificName: field,
+            } as const) ?? [])
         );
     })
     .flat();
@@ -210,12 +210,12 @@ const specializedForCollege = (collegeName: string, majorNames: readonly string[
   const spec = specialized(collegeReqs, majors);
   return spec.map(
     req =>
-    ({
-      ...req,
-      id: `College-${collegeName}-${req.name}`,
-      sourceType: 'College',
-      sourceSpecificName: collegeName,
-    } as const)
+      ({
+        ...req,
+        id: `College-${collegeName}-${req.name}`,
+        sourceType: 'College',
+        sourceSpecificName: collegeName,
+      } as const)
   );
 };
 
@@ -234,28 +234,28 @@ export function getUserRequirements({
   // University requirements only added if college is defined, i.e. if the user has selected an undergraduate program.
   const uniReqs = college
     ? rawUniReqs.requirements.map(
-      it =>
-      ({
-        ...it,
-        id: `College-UNI-${it.name}`,
-        sourceType: 'College',
-        sourceSpecificName: college,
-      } as const)
-    )
+        it =>
+          ({
+            ...it,
+            id: `College-UNI-${it.name}`,
+            sourceType: 'College',
+            sourceSpecificName: college,
+          } as const)
+      )
     : [];
   const collegeReqs = college ? specializedForCollege(college, majors) : [];
   const majorReqs = fieldOfStudyReqs('Major', majors, entranceYear);
   const minorReqs = fieldOfStudyReqs('Minor', minors, entranceYear);
   const gradReqs = grad
     ? requirementJson.grad[grad].requirements.map(
-      it =>
-      ({
-        ...it,
-        id: `Grad-${grad}-${it.name}`,
-        sourceType: 'Grad',
-        sourceSpecificName: grad,
-      } as const)
-    )
+        it =>
+          ({
+            ...it,
+            id: `Grad-${grad}-${it.name}`,
+            sourceType: 'Grad',
+            sourceSpecificName: grad,
+          } as const)
+      )
     : [];
   // flatten all requirements into single array
   return [uniReqs, collegeReqs, majorReqs, minorReqs, ...gradReqs]
@@ -285,10 +285,10 @@ type MatchedRequirementFulfillmentSpecificationBase = {
  */
 type MatchedRequirementFulfillmentSpecification =
   | (MatchedRequirementFulfillmentSpecificationBase & {
-    readonly additionalRequirements?: {
-      readonly [name: string]: MatchedRequirementFulfillmentSpecificationBase;
-    };
-  })
+      readonly additionalRequirements?: {
+        readonly [name: string]: MatchedRequirementFulfillmentSpecificationBase;
+      };
+    })
   | null;
 
 /**
@@ -339,25 +339,25 @@ export function getMatchedRequirementFulfillmentSpecification(
     additionalRequirements == null
       ? undefined
       : Object.fromEntries(
-        Object.entries(additionalRequirements).map(([name, subRequirement]) => {
-          const slotNames =
-            subRequirement.fulfilledBy === 'courses' ? subRequirement.slotNames : [];
-          return [
-            name,
-            {
-              fulfilledBy: subRequirement.fulfilledBy,
-              hasRequirementCheckerWarning: false,
-              eligibleCourses: filterEligibleCoursesByRequirementConditions(
-                subRequirement.courses,
-                subRequirement.conditions
-              ),
-              perSlotMinCount: subRequirement.perSlotMinCount,
-              slotNames,
-              minNumberOfSlots: subRequirement.minNumberOfSlots,
-            },
-          ];
-        })
-      );
+          Object.entries(additionalRequirements).map(([name, subRequirement]) => {
+            const slotNames =
+              subRequirement.fulfilledBy === 'courses' ? subRequirement.slotNames : [];
+            return [
+              name,
+              {
+                fulfilledBy: subRequirement.fulfilledBy,
+                hasRequirementCheckerWarning: false,
+                eligibleCourses: filterEligibleCoursesByRequirementConditions(
+                  subRequirement.courses,
+                  subRequirement.conditions
+                ),
+                perSlotMinCount: subRequirement.perSlotMinCount,
+                slotNames,
+                minNumberOfSlots: subRequirement.minNumberOfSlots,
+              },
+            ];
+          })
+        );
 
   const hasRequirementCheckerWarning = requirement.checkerWarning != null;
   switch (requirement.fulfilledBy) {
@@ -392,8 +392,8 @@ export function getMatchedRequirementFulfillmentSpecification(
     case 'toggleable': {
       const option =
         requirement.fulfillmentOptions[
-        toggleableRequirementChoices[requirement.id] ||
-        Object.keys(requirement.fulfillmentOptions)[0]
+          toggleableRequirementChoices[requirement.id] ||
+            Object.keys(requirement.fulfillmentOptions)[0]
         ];
       return {
         fulfilledBy: option.counting,

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -265,12 +265,12 @@ const sortRequirementCourses: RequirementDecorator = requirement => {
                 name,
                 { courses: additionalRequirementsCourses, ...additionalRequirementRest },
               ]) => [
-                  name,
-                  {
-                    ...additionalRequirementRest,
-                    courses: additionalRequirementsCourses.map(c => [...c].sort((a, b) => a - b)),
-                  },
-                ]
+                name,
+                {
+                  ...additionalRequirementRest,
+                  courses: additionalRequirementsCourses.map(c => [...c].sort((a, b) => a - b)),
+                },
+              ]
             )
           ),
       };

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -37,7 +37,9 @@ type InitialRequirementDecorator = (
 type RequirementDecorator = (
   requirement: DecoratedCollegeOrMajorRequirement
 ) => DecoratedCollegeOrMajorRequirement;
-type MigrationRequirementDecorator = (migration: RequirementMigration) => MigrationWithDecoratedRequirement;
+type MigrationRequirementDecorator = (
+  migration: RequirementMigration
+) => MigrationWithDecoratedRequirement;
 
 const getEligibleCoursesFromRequirementCheckers = (
   checkers: readonly RequirementChecker[]
@@ -103,8 +105,6 @@ const decorateRequirementWithCourses: InitialRequirementDecorator = requirement 
       throw new Error();
   }
 };
-
-
 
 const equivalentCourseIds = new Set(Object.keys(courseToExamMapping));
 const generateExamCourseIdsFromEquivalentCourses = (
@@ -301,16 +301,18 @@ const sortRequirementCourses: RequirementDecorator = requirement => {
 const decorateMigrationValue: MigrationRequirementDecorator = migration => {
   if (migration.newValue) {
     const decoratedValue = decorateRequirementWithCourses(migration.newValue);
-    return decorateRequirementWithExams(decoratedValue);
+    const fullyDecoratedMigration = {
+      ...migration,
+      newValue: decorateRequirementWithExams(decoratedValue),
+    };
+    return fullyDecoratedMigration;
   }
   return migration;
-}
+};
 
 const decorateMigrations = (
-  migrations: readonly RequirementMigration[],
-): readonly MigrationWithDecoratedRequirement[] =>
-  migrations.map(decorateMigrationValue);
-
+  migrations: readonly RequirementMigration[]
+): readonly MigrationWithDecoratedRequirement[] => migrations.map(decorateMigrationValue);
 
 const generateDecoratedRequirementsJson = (): DecoratedRequirementsJson => {
   const { university, college, major, minor, grad } = sourceRequirements;
@@ -373,11 +375,20 @@ const generateDecoratedRequirementsJson = (): DecoratedRequirementsJson => {
     };
   });
   Object.entries(major).forEach(([majorName, majorRequirement]) => {
-    const { requirements, migrations, advisors, specializations, abbrev: abbr, ...rest } = majorRequirement;
+    const {
+      requirements,
+      migrations,
+      advisors,
+      specializations,
+      abbrev: abbr,
+      ...rest
+    } = majorRequirement;
     decoratedJson.major[majorName] = {
       ...rest,
       requirements: decorateRequirements(requirements),
-      migrations: migrations ? (decorateMigrations(migrations) as RequirementMigration[]) : undefined,
+      migrations: migrations
+        ? (decorateMigrations(migrations) as RequirementMigration[])
+        : undefined,
       specializations: specializations && decorateRequirements(specializations),
     };
   });

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -21,11 +21,13 @@ export type CollegeRequirements<R> = {
   };
 };
 
-type migration = {
-  entryYear: number;
-  type: string;
-  field: string /** Modify or Deletion Migration? This field must already exist in requirements file */;
-  newValue?: CollegeOrMajorRequirement /** Required for modify migrations */;
+export type typeOfMigration = 'Modify' | 'Delete' | 'Add';
+
+export type migration = {
+  entryYear: number /** This migration applies to students with an entryYear equal to or EARLIER this entry year */;
+  type: typeOfMigration /** Modify or Delete Migration? This field must already exist in requirements file */;
+  fieldName: string;
+  newValue?: CollegeOrMajorRequirement /** Required for modify and add migrations */;
 };
 
 export type Major<R> = Readonly<{
@@ -35,8 +37,8 @@ export type Major<R> = Readonly<{
   /** College requirements that have been "specialized" for this major */
   specializations?: readonly R[];
   advisors?: AdvisorGroup;
-  readonly abbrev?: string;
   migrations?: migration[];
+  readonly abbrev?: string;
 }>;
 
 export type MutableMajorRequirements<R> = {

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -23,10 +23,10 @@ export type CollegeRequirements<R> = {
 
 type migration = {
   entryYear: number;
-  type: string; 
-  field: string; /** Modify or Deletion Migration? This field must already exist in requirements file */
-  newValue?: CollegeOrMajorRequirement /** Required for modify migrations */
-}
+  type: string;
+  field: string /** Modify or Deletion Migration? This field must already exist in requirements file */;
+  newValue?: CollegeOrMajorRequirement /** Required for modify migrations */;
+};
 
 export type Major<R> = Readonly<{
   name: string;

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -23,7 +23,7 @@ export type CollegeRequirements<R> = {
 
 export type typeOfMigration = 'Modify' | 'Delete' | 'Add';
 
-export type migration = {
+export type RequirementMigration = {
   entryYear: number /** This migration applies to students with an entryYear equal to or EARLIER this entry year */;
   type: typeOfMigration /** Modify or Delete Migration? This field must already exist in requirements file */;
   fieldName: string;
@@ -37,7 +37,7 @@ export type Major<R> = Readonly<{
   /** College requirements that have been "specialized" for this major */
   specializations?: readonly R[];
   advisors?: AdvisorGroup;
-  migrations?: migration[];
+  migrations?: RequirementMigration[];
   readonly abbrev?: string;
 }>;
 

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -21,6 +21,13 @@ export type CollegeRequirements<R> = {
   };
 };
 
+type migration = {
+  entryYear: number;
+  type: string; 
+  field: string; /** Modify or Deletion Migration? This field must already exist in requirements file */
+  newValue?: CollegeOrMajorRequirement /** Required for modify migrations */
+}
+
 export type Major<R> = Readonly<{
   name: string;
   schools: readonly string[];
@@ -29,6 +36,7 @@ export type Major<R> = Readonly<{
   specializations?: readonly R[];
   advisors?: AdvisorGroup;
   readonly abbrev?: string;
+  migrations?: migration[];
 }>;
 
 export type MutableMajorRequirements<R> = {


### PR DESCRIPTION
### Summary

- Implemented requirement migrations structure
- Adjusted types to accommodate migrations for majors
- Decorated migration requirements with courses with JSON generator
- Wrote documentation on how to add requirement migrations each year

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

### Test Plan

- Using the ECE Major, change entry year to post / pre 2021 and notice changes in Core Courses requirements
- Adding new migrations for other majors/minors and seeing changes in requirement bar
- Check that after adding new migrations, especially **Modify** migrations, that the order of requirements stays the same

### Notes 

Documentation in Notion describing how to add requirement migrations: https://www.notion.so/courseplan/Requirement-Migrations-126ffdc4c2274e15a9e40bb8432b791b?pvs=4