### PR TITLE
Update CUReviews API Route

### DIFF
--- a/.github/workflows/cd-snapshot.yml
+++ b/.github/workflows/cd-snapshot.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
       - name: NPM Install
         run: npm install

--- a/src/components/BottomBar/BottomBarState.ts
+++ b/src/components/BottomBar/BottomBarState.ts
@@ -66,7 +66,7 @@ const getReviews = (
   classDifficulty: number;
   classWorkload: number;
 }> =>
-  fetch('https://www.cureviews.org/v2/getCourseByInfo', {
+  fetch('https://www.cureviews.org/api/getCourseByInfo', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ subject: subject.toLowerCase(), number }),


### PR DESCRIPTION
### Summary <!-- Required -->

Updates a reference to CUReviews' API; see [here](https://github.com/cornell-dti/course-reviews-react-2.0/pull/424/commits/c15a70f4a2152ea136a88becc10cf5b3892dcc4c). We should merge this and release ASAP, as the bottom bar is currently broken in prod. Closes #885

It also bumps the node version in our snapshot action so that the checks don't fail. Unfortunately, I have to make both of these changes in the same PR so we can merge. Gross, I know.

### Test Plan <!-- Required -->

CI
