### PR TITLE
Switch to an external cloud function to store requirements JSON

### DIFF
--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -114,15 +114,8 @@ import OnboardingBasic from '@/components/Modals/Onboarding/OnboardingBasic.vue'
 import OnboardingTransfer from '@/components/Modals/Onboarding/OnboardingTransfer.vue';
 import OnboardingReview from '@/components/Modals/Onboarding/OnboardingReview.vue';
 import { setAppOnboardingData, populateSemesters } from '@/global-firestore-data';
-import {
-  computeGradYears,
-  SeasonOrdinal,
-} from '@/utilities';
-import {
-  getMajorFullName,
-  getMinorFullName,
-  getGradFullName,
-} from "@/store-utilities";
+import { computeGradYears, SeasonOrdinal } from '@/utilities';
+import { getMajorFullName, getMinorFullName, getGradFullName } from '@/store-utilities';
 import timeline1Text from '@/assets/images/timeline1text.svg';
 import timeline2Text from '@/assets/images/timeline2text.svg';
 import timeline3Text from '@/assets/images/timeline3text.svg';

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -115,12 +115,14 @@ import OnboardingTransfer from '@/components/Modals/Onboarding/OnboardingTransfe
 import OnboardingReview from '@/components/Modals/Onboarding/OnboardingReview.vue';
 import { setAppOnboardingData, populateSemesters } from '@/global-firestore-data';
 import {
-  getMajorFullName,
-  getMinorFullName,
-  getGradFullName,
   computeGradYears,
   SeasonOrdinal,
 } from '@/utilities';
+import {
+  getMajorFullName,
+  getMinorFullName,
+  getGradFullName,
+} from "@/store-utilities";
 import timeline1Text from '@/assets/images/timeline1text.svg';
 import timeline2Text from '@/assets/images/timeline2text.svg';
 import timeline3Text from '@/assets/images/timeline3text.svg';

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -170,7 +170,7 @@ export default defineComponent({
      *
      * @returns true if onboarding contains a major, minor, or program that is not in
      * requirementsJSON on this branch, false otherwise.
-     * 
+     *
      * FIXME: the requirement graph is not generated for the chosen major / minor / grad
      * etc. and so cannot tell if the user has chosen a valid major / minor / grad.
      */

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -247,7 +247,7 @@ export default defineComponent({
     submitOnboarding() {
       const revised = this.setASCollegeReqs();
       this.clearTransferCreditIfGraduate();
-      setAppOnboardingData(this.name, revised);
+      // setAppOnboardingData(this.name, revised); // now done when you navigate to the page
       // indicates first time user onboarding
       if (!this.isEditingProfile) populateSemesters(revised);
       this.$emit('onboard');
@@ -277,9 +277,16 @@ export default defineComponent({
       ) {
         // special case: if the user has a graduate program (and not an undergrad program), skip the transfer page
         if (this.onboarding.grad !== '' && !this.onboarding.college && this.currentPage === 1) {
+          const revised = this.setASCollegeReqs();
+          this.clearTransferCreditIfGraduate();
+          setAppOnboardingData(this.name, revised);
           this.currentPage += 2;
-        } else {
-          this.currentPage = this.currentPage === FINAL_PAGE ? FINAL_PAGE : this.currentPage + 1;
+        } else if (this.currentPage !== FINAL_PAGE) {
+          // Needs to be done ahead of time.
+          const revised = this.setASCollegeReqs();
+          this.clearTransferCreditIfGraduate();
+          setAppOnboardingData(this.name, revised);
+          this.currentPage += 1;
         }
       }
     },

--- a/src/components/Modals/Onboarding/Onboarding.vue
+++ b/src/components/Modals/Onboarding/Onboarding.vue
@@ -115,7 +115,6 @@ import OnboardingTransfer from '@/components/Modals/Onboarding/OnboardingTransfe
 import OnboardingReview from '@/components/Modals/Onboarding/OnboardingReview.vue';
 import { setAppOnboardingData, populateSemesters } from '@/global-firestore-data';
 import { computeGradYears, SeasonOrdinal } from '@/utilities';
-import { getMajorFullName, getMinorFullName, getGradFullName } from '@/store-utilities';
 import timeline1Text from '@/assets/images/timeline1text.svg';
 import timeline2Text from '@/assets/images/timeline2text.svg';
 import timeline3Text from '@/assets/images/timeline3text.svg';
@@ -171,17 +170,21 @@ export default defineComponent({
      *
      * @returns true if onboarding contains a major, minor, or program that is not in
      * requirementsJSON on this branch, false otherwise.
+     * 
+     * FIXME: the requirement graph is not generated for the chosen major / minor / grad
+     * etc. and so cannot tell if the user has chosen a valid major / minor / grad.
      */
     isInvalidMajorMinorGradError(): boolean {
-      return (
-        this.onboarding.major
-          .map(getMajorFullName)
-          .some((majorFullName: string) => majorFullName === '') ||
-        this.onboarding.minor
-          .map(getMinorFullName)
-          .some((minorFullName: string) => minorFullName === '') ||
-        (this.onboarding.grad ? getGradFullName(this.onboarding.grad) === '' : false)
-      );
+      return false;
+      // return (
+      //   this.onboarding.major
+      //     .map(getMajorFullName)
+      //     .some((majorFullName: string) => majorFullName === '') ||
+      //   this.onboarding.minor
+      //     .map(getMinorFullName)
+      //     .some((minorFullName: string) => minorFullName === '') ||
+      //   (this.onboarding.grad ? getGradFullName(this.onboarding.grad) === '' : false)
+      // );
     },
     /**
      * Display error if the entrance and graduation year are not blank and the graduation semester comes before entrance semester, comparing the season if not blank

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -177,14 +177,9 @@
 
 <script lang="ts">
 import { PropType, defineComponent } from 'vue';
-import reqsData from '@/requirements/typed-requirement-json';
-import {
-  clickOutside,
-  getCurrentYear,
-  getCollegeFullName,
-  computeGradYears,
-  computeEntranceYears,
-} from '@/utilities';
+import store from '@/store';
+import { clickOutside, getCurrentYear, computeGradYears, computeEntranceYears } from '@/utilities';
+import { getCollegeFullName } from '@/store-utilities';
 import OnboardingBasicMultiDropdown from './OnboardingBasicMultiDropdown.vue';
 import OnboardingBasicSingleDropdown from './OnboardingBasicSingleDropdown.vue';
 
@@ -274,7 +269,7 @@ export default defineComponent({
       return computeGradYears(this.entranceYear);
     },
     colleges(): Readonly<Record<string, string>> {
-      const base = Object.entries(reqsData.college)
+      const base = Object.entries(store.state.storedRequirementsJSON.college)
         .filter(college => !college[0].startsWith('AS'))
         .map(([key, { name }]) => [key, name]);
       base.push(['AS', getCollegeFullName('AS')]);
@@ -283,7 +278,7 @@ export default defineComponent({
     },
     majors(): Readonly<Record<string, string>> {
       const majors: Record<string, string> = {};
-      const majorJSON = reqsData.major;
+      const majorJSON = store.state.storedRequirementsJSON.major;
       const acr = this.collegeAcronym !== 'AS' ? this.collegeAcronym : 'AS2';
       Object.keys(majorJSON).forEach(key => {
         // only show majors for schools the user is in
@@ -295,7 +290,7 @@ export default defineComponent({
     },
     minors(): Readonly<Record<string, string>> {
       const minors: Record<string, string> = {};
-      const minorJSON = reqsData.minor;
+      const minorJSON = store.state.storedRequirementsJSON.minor;
       Object.keys(minorJSON).forEach(key => {
         // show no minors if the user is not in a college
         if (this.collegeAcronym) {
@@ -306,7 +301,7 @@ export default defineComponent({
     },
     gradPrograms(): Readonly<Record<string, string>> {
       return Object.fromEntries(
-        Object.entries(reqsData.grad).map(([key, { name }]) => [key, name])
+        Object.entries(store.state.storedRequirementsJSON.grad).map(([key, { name }]) => [key, name])
       );
     },
     suggestedEntranceSem(): Readonly<number> {
@@ -359,7 +354,7 @@ export default defineComponent({
     },
     // Clear a major if a new college is selected and the major is not in it
     clearMajorIfNotInCollege() {
-      const majorJSON = reqsData.major;
+      const majorJSON = store.state.storedRequirementsJSON.major;
       for (let x = 0; x < this.majorAcronyms.length; x += 1) {
         const majorAcronym = this.majorAcronyms[x];
         let foundCollege = false;

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -179,7 +179,6 @@
 import { PropType, defineComponent } from 'vue';
 import store from '@/store';
 import { clickOutside, getCurrentYear, computeGradYears, computeEntranceYears } from '@/utilities';
-import { getCollegeFullName } from '@/store-utilities';
 import OnboardingBasicMultiDropdown from './OnboardingBasicMultiDropdown.vue';
 import OnboardingBasicSingleDropdown from './OnboardingBasicSingleDropdown.vue';
 
@@ -187,6 +186,11 @@ import fall from '@/assets/images/fallEmoji.svg';
 import spring from '@/assets/images/springEmoji.svg';
 import winter from '@/assets/images/winterEmoji.svg';
 import summer from '@/assets/images/summerEmoji.svg';
+
+import majors from '@/requirements/majors.json';
+import minors from '@/requirements/minors.json';
+import colleges from '@/requirements/colleges.json';
+import grad from '@/requirements/grad.json';
 
 const placeholderText = 'Select one';
 
@@ -269,43 +273,22 @@ export default defineComponent({
       return computeGradYears(this.entranceYear);
     },
     colleges(): Readonly<Record<string, string>> {
-      const base = Object.entries(store.state.storedRequirementsJSON.college)
-        .filter(college => !college[0].startsWith('AS'))
-        .map(([key, { name }]) => [key, name]);
-      base.push(['AS', getCollegeFullName('AS')]);
-      base.sort((c1, c2) => c1[1].localeCompare(c2[1]));
-      return Object.fromEntries(base);
+      return Object.fromEntries(colleges);
     },
     majors(): Readonly<Record<string, string>> {
-      const majors: Record<string, string> = {};
-      const majorJSON = store.state.storedRequirementsJSON.major;
+      // only majors in the user's college
       const acr = this.collegeAcronym !== 'AS' ? this.collegeAcronym : 'AS2';
-      Object.keys(majorJSON).forEach(key => {
-        // only show majors for schools the user is in
-        if (majorJSON[key].schools.includes(acr)) {
-          majors[key] = majorJSON[key].name;
-        }
-      });
-      return majors;
+      return Object.fromEntries(majors.filter(it => it[2].includes(acr)));
     },
     minors(): Readonly<Record<string, string>> {
-      const minors: Record<string, string> = {};
-      const minorJSON = store.state.storedRequirementsJSON.minor;
-      Object.keys(minorJSON).forEach(key => {
-        // show no minors if the user is not in a college
-        if (this.collegeAcronym) {
-          minors[key] = minorJSON[key].name;
-        }
-      });
-      return minors;
+      // show no minors if the user is not in a college
+      if (!this.collegeAcronym) {
+        return {};
+      }
+      return Object.fromEntries(minors);
     },
     gradPrograms(): Readonly<Record<string, string>> {
-      return Object.fromEntries(
-        Object.entries(store.state.storedRequirementsJSON.grad).map(([key, { name }]) => [
-          key,
-          name,
-        ])
-      );
+      return Object.fromEntries(grad);
     },
     suggestedEntranceSem(): Readonly<number> {
       return getCurrentYear();

--- a/src/components/Modals/Onboarding/OnboardingBasic.vue
+++ b/src/components/Modals/Onboarding/OnboardingBasic.vue
@@ -301,7 +301,10 @@ export default defineComponent({
     },
     gradPrograms(): Readonly<Record<string, string>> {
       return Object.fromEntries(
-        Object.entries(store.state.storedRequirementsJSON.grad).map(([key, { name }]) => [key, name])
+        Object.entries(store.state.storedRequirementsJSON.grad).map(([key, { name }]) => [
+          key,
+          name,
+        ])
       );
     },
     suggestedEntranceSem(): Readonly<number> {

--- a/src/components/Modals/Onboarding/OnboardingReview.vue
+++ b/src/components/Modals/Onboarding/OnboardingReview.vue
@@ -192,7 +192,7 @@ import {
   getMajorFullName,
   getMinorFullName,
   getGradFullName,
-} from '@/utilities';
+} from '@/store-utilities';
 import { GTagEvent } from '@/gtag';
 
 const placeholderText = 'Select one';

--- a/src/components/Requirements/RequirementHeader.vue
+++ b/src/components/Requirements/RequirementHeader.vue
@@ -196,13 +196,13 @@
 import { PropType, defineComponent } from 'vue';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 import ProgressBarCaution from '@/components/Requirements/ProgressBarCaution.vue';
+import { getReqColor } from '@/utilities';
 import {
   getCollegeFullName,
   getMajorFullName,
   getMinorFullName,
   getGradFullName,
-  getReqColor,
-} from '@/utilities';
+} from '@/store-utilities';
 import featureFlagCheckers from '@/feature-flags';
 import {
   groupedRequirementDangerouslyFulfilled,

--- a/src/components/Tools/AdvisorCard.vue
+++ b/src/components/Tools/AdvisorCard.vue
@@ -30,7 +30,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import store from '@/store';
-import { getCollegeFullName, getMajorFullName } from '@/utilities';
+import { getCollegeFullName, getMajorFullName } from '@/store-utilities';
 import { AdvisorPackage } from '@/tools/advisors/types';
 import getAdvisor from '@/tools/advisors/utilities';
 

--- a/src/containers/Profile.vue
+++ b/src/containers/Profile.vue
@@ -70,7 +70,6 @@ import OnboardingTransfer from '@/components/Modals/Onboarding/OnboardingTransfe
 import { setAppOnboardingData } from '@/global-firestore-data';
 import ProfileConfirmation from '@/components/Modals/ProfileConfirmation.vue';
 import { computeGradYears, SeasonOrdinal } from '@/utilities';
-import { getMajorFullName, getMinorFullName, getGradFullName } from '@/store-utilities';
 import store from '@/store';
 
 const placeholderText = 'Select one';
@@ -114,16 +113,19 @@ export default defineComponent({
       }
       return false;
     },
+    // FIXME: the requirement graph is not generated for the chosen major / minor / grad
+    // etc. and so cannot tell if the user has chosen a valid major / minor / grad.
     isInvalidMajorMinorGradError(): boolean {
-      return (
-        this.onboarding.major
-          .map(getMajorFullName)
-          .some((majorFullName: string) => majorFullName === '') ||
-        this.onboarding.minor
-          .map(getMinorFullName)
-          .some((minorFullName: string) => minorFullName === '') ||
-        (this.onboarding.grad ? getGradFullName(this.onboarding.grad) === '' : false)
-      );
+      return false;
+      // return (
+      //   this.onboarding.major
+      //     .map(getMajorFullName)
+      //     .some((majorFullName: string) => majorFullName === '') ||
+      //   this.onboarding.minor
+      //     .map(getMinorFullName)
+      //     .some((minorFullName: string) => minorFullName === '') ||
+      //   (this.onboarding.grad ? getGradFullName(this.onboarding.grad) === '' : false)
+      // );
     },
     isError(): boolean {
       if (!this.changed || this.isInvalidGraduationSemester || this.isInvalidMajorMinorGradError) {

--- a/src/containers/Profile.vue
+++ b/src/containers/Profile.vue
@@ -69,13 +69,8 @@ import OnboardingBasic from '@/components/Modals/Onboarding/OnboardingBasic.vue'
 import OnboardingTransfer from '@/components/Modals/Onboarding/OnboardingTransfer.vue';
 import { setAppOnboardingData } from '@/global-firestore-data';
 import ProfileConfirmation from '@/components/Modals/ProfileConfirmation.vue';
-import {
-  getMajorFullName,
-  getMinorFullName,
-  getGradFullName,
-  computeGradYears,
-  SeasonOrdinal,
-} from '@/utilities';
+import { computeGradYears, SeasonOrdinal } from '@/utilities';
+import { getMajorFullName, getMinorFullName, getGradFullName } from '@/store-utilities';
 import store from '@/store';
 
 const placeholderText = 'Select one';

--- a/src/requirements/colleges.json
+++ b/src/requirements/colleges.json
@@ -1,0 +1,30 @@
+[
+  [
+    "AG",
+    "Agriculture and Life Sciences"
+  ],
+  [
+    "AR",
+    "Architecture, Art and Planning"
+  ],
+  [
+    "AS",
+    "Arts and Sciences"
+  ],
+  [
+    "EN",
+    "Engineering"
+  ],
+  [
+    "HE",
+    "Human Ecology"
+  ],
+  [
+    "IL",
+    "Industrial Labor Relations"
+  ],
+  [
+    "BU",
+    "SC Johnson College of Business"
+  ]
+]

--- a/src/requirements/filter-from-api.ts
+++ b/src/requirements/filter-from-api.ts
@@ -1,5 +1,8 @@
 import { DecoratedRequirementsJson } from './types';
 
+// TODO: update to real firebase function URL
+const BASE_URL = 'http://127.0.0.1:5001/advanced-todos-73680/us-central1/api/requirements';
+
 export default async function getDecoratedRequirementsJson(
   major?: readonly string[],
   minor?: readonly string[],
@@ -22,7 +25,7 @@ export default async function getDecoratedRequirementsJson(
       formattedGrad = 'skip-this';
     }
 
-    const route = `http://localhost:3000/requirements/?major=${formattedMajors}&minor=${formattedMinors}&college=${college}&grad=${formattedGrad}`;
+    const route = `${BASE_URL}?major=${formattedMajors}&minor=${formattedMinors}&college=${college}&grad=${formattedGrad}`;
     const response = await fetch(route);
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/requirements/filter-from-api.ts
+++ b/src/requirements/filter-from-api.ts
@@ -7,9 +7,22 @@ export default async function getDecoratedRequirementsJson(
   grad?: string
 ): Promise<DecoratedRequirementsJson> {
   try {
-    const route = `http://localhost:3000/requirements/?major=${(major ?? []).join(',')}&minor=${(
-      minor ?? []
-    ).join(',')}&college=${college}&grad=${grad}`;
+    let formattedMajors = (major ?? []).join(',');
+    if (formattedMajors.length === 0) {
+      formattedMajors = 'skip-this';
+    }
+
+    let formattedMinors = (minor ?? []).join(',');
+    if (formattedMinors.length === 0) {
+      formattedMinors = 'skip-this';
+    }
+
+    let formattedGrad = grad;
+    if (!grad) {
+      formattedGrad = 'skip-this';
+    }
+
+    const route = `http://localhost:3000/requirements/?major=${formattedMajors}&minor=${formattedMinors}&college=${college}&grad=${formattedGrad}`;
     const response = await fetch(route);
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/requirements/filter-from-api.ts
+++ b/src/requirements/filter-from-api.ts
@@ -1,0 +1,24 @@
+import { DecoratedRequirementsJson } from './types';
+
+export default async function getDecoratedRequirementsJson(
+  major?: readonly string[],
+  minor?: readonly string[],
+  college?: string,
+  grad?: string
+): Promise<DecoratedRequirementsJson> {
+  try {
+    const route = `http://localhost:3000/requirements/?major=${(major ?? []).join(',')}&minor=${(
+      minor ?? []
+    ).join(',')}&college=${college}&grad=${grad}`;
+    const response = await fetch(route);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = (await response.json()) as DecoratedRequirementsJson;
+    return data;
+  } catch (e) {
+    // FIXME: the alternative is to return a default json, but that
+    // defeats the whole purpose. Maybe throw an error here?
+    return {} as DecoratedRequirementsJson;
+  }
+}

--- a/src/requirements/grad.json
+++ b/src/requirements/grad.json
@@ -1,0 +1,6 @@
+[
+  [
+    "MPA",
+    "Master of Public Administration (MPA) Program"
+  ]
+]

--- a/src/requirements/majors.json
+++ b/src/requirements/majors.json
@@ -1,0 +1,316 @@
+[
+  [
+    "AEM",
+    "Applied Economics and Management",
+    [
+      "AG",
+      "BU"
+    ]
+  ],
+  [
+    "ANTHR",
+    "Anthropology",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "AS",
+    "Atmospheric Science",
+    [
+      "AG"
+    ]
+  ],
+  [
+    "ASTRO",
+    "Astronomy",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "BIO",
+    "Biological Sciences",
+    [
+      "AG",
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "BSOC",
+    "Biology and Society",
+    [
+      "AG",
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "BME",
+    "Biomedical Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "BE",
+    "Biological Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "CE",
+    "Civil Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "CHEM",
+    "Chemistry",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "CHEME",
+    "Chemical and Biomolecular Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "COMM",
+    "Communication",
+    [
+      "AG"
+    ]
+  ],
+  [
+    "CRP",
+    "City and Regional Planning",
+    [
+      "AR"
+    ]
+  ],
+  [
+    "CS",
+    "Computer Science",
+    [
+      "EN",
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "DEA",
+    "Design and Environmental Analysis",
+    [
+      "HE"
+    ]
+  ],
+  [
+    "EAS",
+    "Earth and Atmospheric Sciences",
+    [
+      "AG",
+      "AS1",
+      "AS2",
+      "EN"
+    ]
+  ],
+  [
+    "ECON",
+    "Economics",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "ECE",
+    "Electrical and Computer Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "ENGL",
+    "English",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "ENV",
+    "Environmental Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "ESS",
+    "Environment and Sustainability",
+    [
+      "AG",
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "EP",
+    "Engineering Physics",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "FSAD",
+    "Fashion Design",
+    [
+      "HE"
+    ]
+  ],
+  [
+    "FDSC",
+    "Food Science",
+    [
+      "AG"
+    ]
+  ],
+  [
+    "GOVT",
+    "Government",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "HADM",
+    "Hotel Administration",
+    [
+      "BU"
+    ]
+  ],
+  [
+    "HD",
+    "Human Development",
+    [
+      "HE"
+    ]
+  ],
+  [
+    "HIST",
+    "History",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "INFO",
+    "Information Science",
+    [
+      "AS1",
+      "AG",
+      "AS2"
+    ]
+  ],
+  [
+    "ISST1",
+    "Information Science, Systems, and Technology [before Fall 2020]",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "ISST2",
+    "Information Science, Systems, and Technology [Fall 2020 and after]",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "LING",
+    "Linguistics",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "MATH",
+    "Math",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "ME",
+    "Mechanical Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "MSE",
+    "Materials Science & Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "ORIE",
+    "Operations Research and Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "PAM",
+    "Policy Analysis and Management",
+    [
+      "HE"
+    ]
+  ],
+  [
+    "PHYS",
+    "Physics",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "PSYCH",
+    "Psychology",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "SPAN",
+    "Spanish",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "STS",
+    "Science & Technology Studies",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ]
+]

--- a/src/requirements/minors.json
+++ b/src/requirements/minors.json
@@ -1,0 +1,185 @@
+[
+  [
+    "AEROSPACE",
+    "Aerospace Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "ANIMALSCIENCE",
+    "Animal Science",
+    [
+      "AG"
+    ]
+  ],
+  [
+    "APPLIEDECON",
+    "Applied Economics",
+    [
+      "AG",
+      "BU"
+    ]
+  ],
+  [
+    "APPLIEDMATH",
+    "Applied Mathematics",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "BU",
+    "Business",
+    [
+      "BU"
+    ]
+  ],
+  [
+    "COGSCI",
+    "Cognitive Science",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "CS",
+    "Computer Science",
+    [
+      "EN",
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "DS",
+    "Data Science",
+    [
+      "EN",
+      "AG",
+      "AS2"
+    ]
+  ],
+  [
+    "DBME",
+    "Dyson Business Minor for Engineers",
+    [
+      "BU"
+    ]
+  ],
+  [
+    "DEA",
+    "Design and Environmental Analysis",
+    [
+      "HE"
+    ]
+  ],
+  [
+    "EAS",
+    "Earth and Atmospheric Sciences",
+    [
+      "EN",
+      "AG"
+    ]
+  ],
+  [
+    "ECE",
+    "Electrical and Computer Engineering",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "GAMEDESIGN",
+    "Game Design",
+    [
+      "EN",
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "HP",
+    "Health Policy",
+    [
+      "HE"
+    ]
+  ],
+  [
+    "HD",
+    "Human Development",
+    [
+      "HE"
+    ]
+  ],
+  [
+    "INEQ",
+    "Inequality Studies",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "ISST",
+    "Information Science [Engineering]",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "LING",
+    "Linguistics",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "MATH",
+    "Mathematics",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "ORMS",
+    "Operations Research and Management Science",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "POLICY",
+    "Public Policy",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "PSYCH",
+    "Psychology",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ],
+  [
+    "ROBOTICS",
+    "Robotics",
+    [
+      "EN"
+    ]
+  ],
+  [
+    "SPAN",
+    "Spanish",
+    [
+      "AS1",
+      "AS2"
+    ]
+  ]
+]

--- a/src/requirements/requirement-frontend-computation.ts
+++ b/src/requirements/requirement-frontend-computation.ts
@@ -9,6 +9,7 @@ import {
 import RequirementFulfillmentGraph from './requirement-graph';
 import buildRequirementFulfillmentGraphFromUserData from './requirement-graph-builder-from-user-data';
 import featureFlagCheckers from '../feature-flags';
+import { DecoratedRequirementsJson } from './types';
 
 /**
  * Used for total academic credit requirements for all colleges except EN and AR
@@ -200,6 +201,7 @@ function mergeRequirementFulfillmentStatisticsWithAdditionalRequirements(
 export default function computeGroupedRequirementFulfillmentReports(
   semesters: readonly FirestoreSemester[],
   onboardingData: AppOnboardingData,
+  requirementJson: DecoratedRequirementsJson,
   toggleableRequirementChoices: AppToggleableRequirementChoices,
   overriddenFulfillmentChoices: FirestoreOverriddenFulfillmentChoices
 ): {
@@ -223,6 +225,7 @@ export default function computeGroupedRequirementFulfillmentReports(
   } = buildRequirementFulfillmentGraphFromUserData(
     coursesTaken,
     onboardingData,
+    requirementJson,
     toggleableRequirementChoices,
     overriddenFulfillmentChoices
   );

--- a/src/requirements/requirement-frontend-utils.ts
+++ b/src/requirements/requirement-frontend-utils.ts
@@ -86,6 +86,7 @@ export function allowCourseDoubleCountingBetweenRequirements(
   requirementA: RequirementWithIDSourceType,
   requirementB: RequirementWithIDSourceType
 ): boolean {
+  if (!requirementA || !requirementB) return false;
   const allowCourseDoubleCounting =
     requirementA.allowCourseDoubleCounting || requirementB.allowCourseDoubleCounting || false;
 

--- a/src/requirements/requirement-graph-builder-from-user-data.ts
+++ b/src/requirements/requirement-graph-builder-from-user-data.ts
@@ -9,10 +9,12 @@ import {
   buildRequirementFulfillmentGraph,
   removeIllegalEdgesFromRequirementFulfillmentGraph,
 } from './requirement-graph-builder';
+import { DecoratedRequirementsJson } from './types';
 
 export default function buildRequirementFulfillmentGraphFromUserData(
   coursesTaken: readonly CourseTaken[],
   onboardingData: AppOnboardingData,
+  requirementJson: DecoratedRequirementsJson,
   toggleableRequirementChoices: AppToggleableRequirementChoices,
   overriddenFulfillmentChoices: FirestoreOverriddenFulfillmentChoices
 ): {
@@ -23,7 +25,7 @@ export default function buildRequirementFulfillmentGraphFromUserData(
   readonly doubleCountedCourseUniqueIDSet: ReadonlySet<string | number>;
   readonly courseToRequirementsInConstraintViolations: Map<string | number, Set<string[]>>;
 } {
-  const userRequirements = getUserRequirements(onboardingData);
+  const userRequirements = getUserRequirements(onboardingData, requirementJson);
   const userRequirementsMap = Object.fromEntries(userRequirements.map(it => [it.id, it]));
 
   const requirementGraphBuilderParameters: BuildRequirementFulfillmentGraphParameters<

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -406,3 +406,39 @@ const decoratedRequirements = generateDecoratedRequirementsJson();
 const decoratedRequirementsString = JSON.stringify(decoratedRequirements, undefined, 2);
 
 writeFileSync('src/requirements/decorated-requirements.json', decoratedRequirementsString);
+
+const majors = Object.keys(decoratedRequirements.major).map(major => [
+  major,
+  decoratedRequirements.major[major].name,
+  decoratedRequirements.major[major].schools,
+]);
+
+writeFileSync('src/requirements/majors.json', JSON.stringify(majors, undefined, 2));
+
+const minors = Object.keys(decoratedRequirements.minor).map(minor => [
+  minor,
+  decoratedRequirements.minor[minor].name,
+  decoratedRequirements.minor[minor].schools,
+]);
+
+writeFileSync('src/requirements/minors.json', JSON.stringify(minors, undefined, 2));
+
+const collegesOut = Object.keys(decoratedRequirements.college)
+  .map(college => [college, decoratedRequirements.college[college].name])
+  .filter(([college]) => college !== 'AS1')
+  .map(([college, name]) => {
+    if (college === 'AS2') {
+      return ['AS', 'Arts and Sciences'];
+    }
+
+    return [college, name];
+  });
+
+writeFileSync('src/requirements/colleges.json', JSON.stringify(collegesOut, undefined, 2));
+
+const grad = Object.keys(decoratedRequirements.grad).map(gr => [
+  gr,
+  decoratedRequirements.grad[gr].name,
+]);
+
+writeFileSync('src/requirements/grad.json', JSON.stringify(grad, undefined, 2));

--- a/src/requirements/typed-requirement-json.ts
+++ b/src/requirements/typed-requirement-json.ts
@@ -12,6 +12,7 @@ import decoratedRequirementJson from './decorated-requirements.json';
 //    - Requirement generation runs on node, requirement checking runs in browser.
 //      They have different import mechanisms. It's better to separate them.
 //    - To help webpack to avoid bundling the giant `filtered-all-courses.json`.
+// 3. This file is only used for a frontend test. Not used in the actual app.
 
 /** The generated requirement json that contains all pre-computed courses that satisfy each requirement. */
 export default (decoratedRequirementJson as unknown) as DecoratedRequirementsJson;

--- a/src/store-utilities.ts
+++ b/src/store-utilities.ts
@@ -1,0 +1,42 @@
+import store from '@/store';
+
+export function getCollegeFullName(acronym: string | undefined): string {
+  // return Arts and Sciences for AS, AS1, or AS2
+  if (acronym && acronym.startsWith('AS')) {
+    return 'Arts and Sciences';
+  }
+  if (!store.state.storedRequirementsJSON.college) {
+    return '';
+  }
+  const college = acronym ? store.state.storedRequirementsJSON.college[acronym] : null;
+
+  // Return empty string if college is not in requirementJSON
+  return college ? college.name : '';
+}
+
+export function getMajorFullName(acronym: string): string {
+  // Return empty string if major is not in requirementJSON
+  if (!store.state.storedRequirementsJSON.major) {
+    return '';
+  }
+  const major = store.state.storedRequirementsJSON.major[acronym];
+  return major ? major.name : '';
+}
+
+export function getMinorFullName(acronym: string): string {
+  // Return empty string if minor is not in requirementJSON
+  if (!store.state.storedRequirementsJSON.minor) {
+    return '';
+  }
+  const minor = store.state.storedRequirementsJSON.minor[acronym];
+  return minor ? minor.name : '';
+}
+
+export function getGradFullName(acronym: string | undefined): string {
+  // Return empty string if grad is not in requirementJSON
+  if (!store.state.storedRequirementsJSON.grad) {
+    return '';
+  }
+  const grad = acronym ? store.state.storedRequirementsJSON.grad[acronym] : null;
+  return grad ? grad.name : '';
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,6 +17,8 @@ import {
 } from './utilities';
 import featureFlagCheckers from './feature-flags';
 import { setUserProperties } from './gtag';
+import { DecoratedRequirementsJson } from './requirements/types';
+import getDecoratedRequirementsJson from './requirements/filter-from-api';
 
 type SimplifiedFirebaseUser = { readonly displayName: string; readonly email: string };
 
@@ -35,6 +37,7 @@ type DerivedCoursesData = {
 export type VuexStoreState = {
   currentFirebaseUser: SimplifiedFirebaseUser;
   userName: FirestoreUserName;
+  storedRequirementsJSON: DecoratedRequirementsJson;
   onboardingData: AppOnboardingData;
   semesters: readonly FirestoreSemester[];
   orderByNewest: boolean;
@@ -63,6 +66,7 @@ const store: TypedVuexStore = new TypedVuexStore({
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     currentFirebaseUser: null!,
     userName: { firstName: '', middleName: '', lastName: '' },
+    storedRequirementsJSON: {} as DecoratedRequirementsJson,
     onboardingData: {
       gradYear: '',
       gradSem: '',
@@ -104,6 +108,12 @@ const store: TypedVuexStore = new TypedVuexStore({
     },
     setUserName(state: VuexStoreState, userName: FirestoreUserName) {
       state.userName = userName;
+    },
+    async setStoredRequirementsJSON(
+      state: VuexStoreState,
+      storedRequirementsJSON: DecoratedRequirementsJson
+    ) {
+      state.storedRequirementsJSON = storedRequirementsJSON;
     },
     setOnboardingData(state: VuexStoreState, onboardingData: AppOnboardingData) {
       state.onboardingData = onboardingData;
@@ -162,7 +172,7 @@ const store: TypedVuexStore = new TypedVuexStore({
 });
 
 const autoRecomputeDerivedData = (): (() => void) =>
-  store.subscribe((mutation, state) => {
+  store.subscribe(async (mutation, state) => {
     switch (mutation.type) {
       case 'setOnboardingData': {
         setUserProperties(mutation.payload);
@@ -210,12 +220,24 @@ const autoRecomputeDerivedData = (): (() => void) =>
       mutation.type === 'setToggleableRequirementChoices' ||
       mutation.type === 'setOverriddenFulfillmentChoices'
     ) {
+      if (mutation.type === 'setOnboardingData') {
+        store.commit(
+          'setStoredRequirementsJSON',
+          await getDecoratedRequirementsJson(
+            state.onboardingData.major,
+            state.onboardingData.minor,
+            state.onboardingData.college,
+            state.onboardingData.grad
+          )
+        );
+      }
       if (state.onboardingData.college !== '') {
         store.commit(
           'setRequirementData',
           computeGroupedRequirementFulfillmentReports(
             state.semesters,
             state.onboardingData,
+            state.storedRequirementsJSON,
             state.toggleableRequirementChoices,
             state.overriddenFulfillmentChoices
           )

--- a/src/tools/export-plan/pdf-generator.ts
+++ b/src/tools/export-plan/pdf-generator.ts
@@ -12,13 +12,13 @@ import userDataToExamCourses from '../../requirements/requirement-exam-utils';
 import { trimEmptySems, bubbleColorMap, getCourseRows, loadImage } from './utilities';
 import { SemesterRows } from './types';
 
+import { sortedSemesters } from '../../utilities';
 import {
   getCollegeFullName,
   getMajorFullName,
   getMinorFullName,
   getGradFullName,
-  sortedSemesters,
-} from '../../utilities';
+} from '../../store-utilities';
 import store from '../../store';
 import { addFonts } from './add-fonts';
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,4 @@
 import { fullCoursesArray } from './assets/courses/typed-full-courses';
-import requirementJSON from './requirements/typed-requirement-json';
 import { coursesColorSet } from './assets/constants/colors';
 
 /** Enumerated type to define seasons as integers in season order
@@ -85,35 +84,6 @@ export function computeEntranceYears(): Readonly<Record<string, string>> {
     semsDict[yr] = yr;
   }
   return semsDict;
-}
-
-export function getCollegeFullName(acronym: string | undefined): string {
-  // return Arts and Sciences for AS, AS1, or AS2
-  if (acronym && acronym.startsWith('AS')) {
-    return 'Arts and Sciences';
-  }
-  const college = acronym ? requirementJSON.college[acronym] : null;
-
-  // Return empty string if college is not in requirementJSON
-  return college ? college.name : '';
-}
-
-export function getMajorFullName(acronym: string): string {
-  // Return empty string if major is not in requirementJSON
-  const major = requirementJSON.major[acronym];
-  return major ? major.name : '';
-}
-
-export function getMinorFullName(acronym: string): string {
-  // Return empty string if minor is not in requirementJSON
-  const minor = requirementJSON.minor[acronym];
-  return minor ? minor.name : '';
-}
-
-export function getGradFullName(acronym: string | undefined): string {
-  // Return empty string if grad is not in requirementJSON
-  const grad = acronym ? requirementJSON.grad[acronym] : null;
-  return grad ? grad.name : '';
 }
 
 function getAllSubjects(): ReadonlySet<string> {


### PR DESCRIPTION
### Summary <!-- Required -->

In #705 we talked about using a firebase cloud function to send relevant sub-parts of the decorate requirements json file so that initial page speed is quicker. This PR takes steps towards implementing this:

- [x] instead of reading from `decorated-requirements.json` we instead have a store that contains the requirements data that is relevant to a specific user
- [x] data / the store is updated when a user changes majors etc. on their profile
- [x] working functionality when a new user is onboarded as well

Remaining TODOs:

- [ ] create the actual cloud function in firebase (I don't have perms for this, have been running locally)
- [ ] somehow (GitHub Action?) make it so that the JSON file which the cloud function it itself references is updated whenever `npm run req-gen` is done (aka when we have a new major or whatnot then we need to update the base requirements JSON file)
- [ ] update URL in `src/requirements/filter-from-api.ts` to match TODO 1

### Test Plan <!-- Required -->

Buckle up this is going to be long.

First up you need to make a local server that you can call, since we don't have a firebase cloud function setup yet. (Once we have it setup then this will be quite easier to test.)

1. Make a new express app somewhere and add the following in `index.js`

```js
const express = require("express");
const fs = require("fs").promises; // Use fs promises API for simpler async handling
const path = require("path");

const app = express();
const port = 3000;

// Enable CORS for all routes
app.use((req, res, next) => {
    res.header("Access-Control-Allow-Origin", "*");
    next();
});

// Function to read and optionally filter the JSON data
async function readAndFilterData(filterParams) {
    const filePath = path.join(__dirname, "decorated-requirements.json");
    const jsonData = await fs.readFile(filePath, "utf8");
    const data = JSON.parse(jsonData);

    // Always include "university": "UNI"
    const filteredData = { university: data.university };

    // Filter based on provided query parameters
    ["grad", "minor", "major", "college"].forEach((param) => {
        if (filterParams[param]) {
            // If the parameter exists in the query string, and is found in data, add it to filteredData
            const paramValues = filterParams[param].split(",");
            filteredData[param] = {};
            paramValues.forEach((value) => {
                if (data[param] && data[param].hasOwnProperty(value.trim())) {
                    filteredData[param][value.trim()] =
                        data[param][value.trim()];
                }
            });
        } else {
            // If the parameter doesn't exist, or not found, include everything under it
            // *unless* the parameter is "skip-this", in which case we don't include it at all.
            if (param !== "skip-this") {
                filteredData[param] = data[param];
            }
        }
    });

    return filteredData;
}

// Express route to handle the GET requests
app.get("/requirements", async (req, res) => {
    try {
        const filteredData = await readAndFilterData(req.query);
        res.json(filteredData);
    } catch (error) {
        res.status(500).json({ error: "Failed to read or filter data" });
    }
});

app.listen(port, () => console.log(`Server running on port ${port}`));

```

2. At the same level as the above file, copy over the `decorated-requirements.json` file.
3. `node index.js`
4. Go to `src/requirements/filter-from-api.ts` and update `BASE_URL` to `http://localhost:3000/requirements`.
5. Now you can test things properly.

Note that if you want to test against a locally run firebase cloud function, you'll have to message me — took a lot of configuring and would be overwhelming to put things here.

### Notes <!-- Optional -->

*I really don't like this PR for a number of reasons.*

- Because we always only see a subset of the requirements, when you are onboarding / editing your major or minor or college we have to constantly ping the server
- This is supposed to make things go faster by returning a smaller requirements json file (true), but isn't there inherent lag in fetching?
- Since we have to wait until the store + site is loaded before we can call the server (since we need to know what major the user is for example), there is a short flicker (probably even bigger once we are not having a local server) as the requirements sidebar panel is filled with data (i.e. it goes from having 0/0 requirements satisfied for your college to everything else)
- It will be a pain to update the cloud function whenever the base requirements graph is generated
- We are passing around the requirements json file a bit within functions (this is necessary, I minimized it as much as I could but it still happened a few places) which might be inefficient

Note that the tests are failing because currently the virtual machine runner can't access the cloud function server since it's localhost.

### Blockers <!-- Optional -->

### Breaking Changes  <!-- Optional -->

Lots of internal reworking to prevent there from being cyclical dependencies. Means that some of the internal util "APIs" have changed.
