### PR TITLE
chore: added engrc 3027 as valid engrc

### DIFF
--- a/src/data/colleges/en.ts
+++ b/src/data/colleges/en.ts
@@ -211,6 +211,7 @@ const engineeringRequirements: readonly CollegeOrMajorRequirement[] = [
       'COMM 3030',
       'COMM 3020',
       'ENGRC 3023',
+      'ENGRC 3027',
       'ENGRC 2640',
       'ENGRC 3152',
       'ENGRC 3160',


### PR DESCRIPTION
### Summary <!-- Required -->

We are missing a class that can potentially fulfill an Engineering Communications requirement. Fixed this.

### Test Plan <!-- Required -->

Drag in ENGRC 3027 with an Engineering College student and note that it counts.