### PR TITLE
style: make course search modal scrollable

### DIFF
--- a/src/components/Modals/NewCourse/CourseSelector.vue
+++ b/src/components/Modals/NewCourse/CourseSelector.vue
@@ -51,8 +51,9 @@ const getMatchingCourses = (
   title.sort((first, second) => first.titleLong.localeCompare(second.titleLong));
 
   /* prioritize code matches over title matches */
+  return code.concat(title);
   // limit the number of results to 10
-  return code.concat(title).slice(0, 10);
+  // return code.concat(title).slice(0, 10);
 };
 
 export default defineComponent({
@@ -140,6 +141,8 @@ export default defineComponent({
   right: 0;
   box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.25);
   border-radius: 7px;
+  max-height: 50vh;
+  overflow-y: auto;
 
   .search-result {
     padding: 10px;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Long overdue: make it so that you can scroll when searching for courses when you are searching for them to add to a semester.

Algorithm: sort first by matching course codes, then by title.

### Test Plan <!-- Required -->

Use eyes.

<img width="523" alt="Screenshot 2024-03-20 at 6 33 06 PM" src="https://github.com/cornell-dti/course-plan/assets/61620873/210b7ea0-fa58-4171-8c9e-04b86f20c1f6">

### Notes <!-- Optional -->

Right now I just came up with my own styles — scroll spans `max-height: 50vh;`. Works on both mobile and desktop but maybe there is something else that is better? Though right now Joanna gave this the ok since it is pretty much the same height as if you had 10 courses (the default).

Also there is "dead code" (I just commented stuff out). Sarah and Sophia would undoubtedly be disappointed given what we went over in Dev Sesh 2. However I reckon it's best to leave this up there just in case any bugs come up (I don't think we are going to be bug bashing this).
