### PR TITLE
[Schedule Generator] Read in Requirements

### DIFF
--- a/src/components/ScheduleGenerate/RequirementCourses.vue
+++ b/src/components/ScheduleGenerate/RequirementCourses.vue
@@ -92,11 +92,11 @@ export default defineComponent({
       typeof course === typeof 'CornellCourseRosterCourse' && typeof index === typeof 'number',
     'delete-course': (code: string, index: number) =>
       typeof code === typeof 'string' && typeof index === typeof 'number',
-    'delete-available-requirement': (reqId: string) => typeof reqId === typeof 'string',
     'select-requirement': (reqId: string, index: number) =>
       typeof reqId === typeof 'string' && typeof index === 'number',
-    'add-available-requirement': (requirement: ReqCourses) =>
-      typeof requirement === typeof 'ReqCourses',
+    // 'add-available-requirement': (requirement: ReqCourses) =>
+    //   typeof requirement === typeof 'ReqCourses',
+    // 'delete-available-requirement': (reqId: string) => typeof reqId === typeof 'string',
     'delete-requirement': () => true,
   },
   data() {
@@ -129,11 +129,11 @@ export default defineComponent({
       this.showDropdown = false;
     },
     selectRequirement(requirement: string) {
-      if (this.selectedRequirement.reqId !== '') {
-        this.$emit('add-available-requirement', this.selectedRequirement);
-      }
+      // if (this.selectedRequirement.reqId !== '') {
+      //   this.$emit('add-available-requirement', this.selectedRequirement);
+      // }
       this.$emit('select-requirement', requirement, this.index);
-      this.$emit('delete-available-requirement', requirement);
+      // this.$emit('delete-available-requirement', requirement);
     },
     deleteRequirement() {
       this.$emit('delete-requirement');

--- a/src/components/ScheduleGenerate/RequirementCourses.vue
+++ b/src/components/ScheduleGenerate/RequirementCourses.vue
@@ -91,7 +91,8 @@ export default defineComponent({
   emits: {
     'add-course': (course: CornellCourseRosterCourse, index: number) =>
       typeof course === typeof 'CornellCourseRosterCourse' && typeof index === typeof 'number',
-    'delete-course': (code: string) => typeof code === typeof 'string',
+    'delete-course': (code: string, index: number) =>
+      typeof code === typeof 'string' && typeof index === typeof 'number',
     'delete-available-requirement': (reqId: string) => typeof reqId === typeof 'string',
     'select-requirement': (reqId: string, index: number) =>
       typeof reqId === typeof 'string' && typeof index === 'number',
@@ -142,7 +143,7 @@ export default defineComponent({
       this.$emit('add-course', course, this.index);
     },
     deleteCourse(code: string) {
-      this.$emit('delete-course', code);
+      this.$emit('delete-course', code, this.index);
     },
   },
 });

--- a/src/components/ScheduleGenerate/RequirementCourses.vue
+++ b/src/components/ScheduleGenerate/RequirementCourses.vue
@@ -70,7 +70,6 @@ import { emGreen } from '@/assets/constants/scss-variables';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 import AllRequirementsDropdown from '@/components/ScheduleGenerate/AllRequirementsDropdown.vue';
 import Course from '@/components/Course/Course.vue';
-
 import { ReqCourses } from '@/components/ScheduleGenerate/ScheduleGenerateSideBar.vue';
 
 export default defineComponent({

--- a/src/components/ScheduleGenerate/RequirementCourses.vue
+++ b/src/components/ScheduleGenerate/RequirementCourses.vue
@@ -70,8 +70,7 @@ import { emGreen } from '@/assets/constants/scss-variables';
 import DropDownArrow from '@/components/DropDownArrow.vue';
 import AllRequirementsDropdown from '@/components/ScheduleGenerate/AllRequirementsDropdown.vue';
 import Course from '@/components/Course/Course.vue';
-import { cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor } from '@/user-data-converter';
-import store from '@/store';
+
 import { ReqCourses } from '@/components/ScheduleGenerate/ScheduleGenerateSideBar.vue';
 
 export default defineComponent({
@@ -90,6 +89,9 @@ export default defineComponent({
     },
   },
   emits: {
+    'add-course': (course: CornellCourseRosterCourse, index: number) =>
+      typeof course === typeof 'CornellCourseRosterCourse' && typeof index === typeof 'number',
+    'delete-course': (code: string) => typeof code === typeof 'string',
     'delete-available-requirement': (reqId: string) => typeof reqId === typeof 'string',
     'select-requirement': (reqId: string, index: number) =>
       typeof reqId === typeof 'string' && typeof index === 'number',
@@ -137,18 +139,10 @@ export default defineComponent({
       this.$emit('delete-requirement');
     },
     addCourse(course: CornellCourseRosterCourse) {
-      this.selectedRequirement.courses.push(
-        cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor(
-          course,
-          -1,
-          store.state.subjectColors[course.subject]
-        )
-      );
+      this.$emit('add-course', course, this.index);
     },
     deleteCourse(code: string) {
-      this.selectedRequirement.courses = this.selectedRequirement.courses.filter(
-        course => course.code !== code
-      );
+      this.$emit('delete-course', code);
     },
   },
 });

--- a/src/components/ScheduleGenerate/ScheduleGenerateSideBar.vue
+++ b/src/components/ScheduleGenerate/ScheduleGenerateSideBar.vue
@@ -62,6 +62,8 @@
         :available-requirements="availableRequirements"
         :selected-requirement="requirements[index]"
         :index="index"
+        @add-course="addCourse"
+        @delete-course="deleteCourse"
         @select-requirement="selectRequirement"
         @delete-available-requirement="deleteAvailableRequirement"
         @add-available-requirement="addAvailableRequirement"
@@ -154,7 +156,7 @@ export default defineComponent({
         )
       );
     },
-    deleteCourse(index: number, code: string) {
+    deleteCourse(code: string, index: number) {
       this.requirements[index].courses = this.requirements[index].courses.filter(
         course => course.code !== code
       );

--- a/src/components/ScheduleGenerate/ScheduleGenerateSideBar.vue
+++ b/src/components/ScheduleGenerate/ScheduleGenerateSideBar.vue
@@ -76,6 +76,7 @@ import { defineComponent } from 'vue';
 import RequirementCourses from '@/components/ScheduleGenerate/RequirementCourses.vue';
 import Confirmation from '@/components/Modals/Confirmation.vue';
 import store from '@/store';
+import { cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor } from '@/user-data-converter';
 
 export type ReqCourses = {
   reqId: string;
@@ -86,13 +87,11 @@ export type ReqCourses = {
 export default defineComponent({
   data(): {
     requirements: ReqCourses[];
-    numberOfRequirements: number;
     isConfirmationOpen: boolean;
     confirmationText: string;
   } {
     return {
       requirements: [],
-      numberOfRequirements: this.availableRequirements?.length,
       isConfirmationOpen: false,
       confirmationText: '',
     };
@@ -123,6 +122,15 @@ export default defineComponent({
       );
       return courseRecord;
     },
+    numberOfRequirements(): number {
+      let length = 0;
+      this.groupedRequirementFulfillmentReports.forEach(
+        (groupedReq: GroupedRequirementFulfillmentReport) => {
+          length += groupedReq.reqs.length;
+        }
+      );
+      return length;
+    },
   },
   methods: {
     openConfirmationModal(msg: string) {
@@ -137,7 +145,20 @@ export default defineComponent({
     closeConfirmationModal() {
       this.isConfirmationOpen = false;
     },
-
+    addCourse(course: CornellCourseRosterCourse, index: number) {
+      this.requirements[index].courses.push(
+        cornellCourseRosterCourseToFirebaseSemesterCourseWithCustomIDAndColor(
+          course,
+          -1,
+          store.state.subjectColors[course.subject]
+        )
+      );
+    },
+    deleteCourse(index: number, code: string) {
+      this.requirements[index].courses = this.requirements[index].courses.filter(
+        course => course.code !== code
+      );
+    },
     addRequirement() {
       this.requirements = [...this.requirements, { reqId: '', reqName: '', courses: [] }];
     },

--- a/src/components/ScheduleGenerate/ScheduleGenerateSideBar.vue
+++ b/src/components/ScheduleGenerate/ScheduleGenerateSideBar.vue
@@ -44,13 +44,7 @@
           -->
           <input type="number" placeholder='"18"' min="0" max="30" class="credit-limit-input" />
         </div>
-        <button
-          class="add-requirement-button"
-          @click="addRequirement"
-          :disabled="requirements.length === numberOfRequirements"
-        >
-          + Requirement
-        </button>
+        <button class="add-requirement-button" @click="addRequirement">+ Requirement</button>
       </div>
     </div>
     <p v-if="requirements.length === 0" class="no-requirements-added">No requirements added.</p>
@@ -62,8 +56,6 @@
         @add-course="addCourse"
         @delete-course="deleteCourse"
         @select-requirement="selectRequirement"
-        @delete-available-requirement="deleteAvailableRequirement"
-        @add-available-requirement="addAvailableRequirement"
         @delete-requirement="deleteRequirement(index)"
       />
     </div>
@@ -126,16 +118,17 @@ export default defineComponent({
       );
       return courseRecord;
     },
+    // TODO: use this once we check the total number of requirement groups they can add
     // total number of requirements, used to calculate when to gray out the +Requirement button
-    numberOfRequirements(): number {
-      let length = 0;
-      this.groupedRequirementFulfillmentReports.forEach(
-        (groupedReq: GroupedRequirementFulfillmentReport) => {
-          length += groupedReq.reqs.length;
-        }
-      );
-      return length;
-    },
+    // numberOfRequirements(): number {
+    //   let length = 0;
+    //   this.groupedRequirementFulfillmentReports.forEach(
+    //     (groupedReq: GroupedRequirementFulfillmentReport) => {
+    //       length += groupedReq.reqs.length;
+    //     }
+    //   );
+    //   return length;
+    // },
   },
   methods: {
     openConfirmationModal(msg: string) {
@@ -170,25 +163,29 @@ export default defineComponent({
     addRequirement() {
       this.requirements = [...this.requirements, { reqId: '', reqName: '', courses: [] }];
     },
+
+    // TODO: use availableRequirement once we start enforcing how many requirement groups we can add
+
+    // add back an available requirement
+    // addAvailableRequirement(requirement: ReqCourses) {
+    //   if (requirement.reqId !== '')
+    //     this.availableRequirements[requirement.reqId] = requirement.reqName;
+    // },
     // get rid of an available requirement
-    deleteAvailableRequirement(reqId: string) {
-      delete this.availableRequirements[reqId];
-    },
+    // deleteAvailableRequirement(reqId: string) {
+    //   delete this.availableRequirements[reqId];
+    // },
     // select a requirement on the dropdown
     selectRequirement(reqId: string, index: number) {
       const reqName = this.availableRequirements[reqId];
       this.requirements[index] = { reqId, reqName, courses: [] };
     },
-    // add back an available requirement
-    addAvailableRequirement(requirement: ReqCourses) {
-      if (requirement.reqId !== '')
-        this.availableRequirements[requirement.reqId] = requirement.reqName;
-    },
+
     // delete a requirement group and add back to the available requirements
     deleteRequirement(index: number) {
       const requirement = this.requirements[index];
       // add back to the availableRequirements record
-      this.addAvailableRequirement(requirement);
+      // this.addAvailableRequirement(requirement);
 
       // delete this requirement from list
       this.requirements.splice(index, 1);

--- a/src/components/ScheduleGenerate/ScheduleGenerateSideBar.vue
+++ b/src/components/ScheduleGenerate/ScheduleGenerateSideBar.vue
@@ -114,15 +114,11 @@ export default defineComponent({
     },
     availableRequirements(): Record<string, string> {
       const courseRecord: Record<string, string> = this.groupedRequirementFulfillmentReports.reduce(
-        (accumulator: Record<string, string>, groupedReq: GroupedRequirementFulfillmentReport) => {
-          return groupedReq.reqs.reduce(
-            (acc: Record<string, string>, req: RequirementFulfillment) => {
-              acc[req.requirement.id] = req.requirement.name;
-              return acc;
-            },
-            accumulator
-          );
-        },
+        (accumulator: Record<string, string>, groupedReq: GroupedRequirementFulfillmentReport) =>
+          groupedReq.reqs.reduce((acc: Record<string, string>, req: RequirementFulfillment) => {
+            acc[req.requirement.id] = req.requirement.name;
+            return acc;
+          }, accumulator),
         {} as Record<string, string>
       );
       return courseRecord;


### PR DESCRIPTION
### Summary <!-- Required -->
Reads in the requirements from the Vuex store
Question: should it be that the requirements disappear from dropdown once you select them?
Answer from Joanna: we should be allowed to add up to the number of required courses for that requirement
For instance: there are 6 courses needed for liberal studies, then we should be allowed to add requirement groups with the Liberal Studies label 6 times.

As of now, for V1, we're just going to allow users add as many of each requirement group as they want. We will add these checks in the future. However, the requirement groups will be enforcing that each course is only assigned to at most one requirement.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

<!--- Note dependencies on other PRs if any. -->

### Test Plan <!-- Required -->

https://github.com/cornell-dti/course-plan/assets/53061040/192ac4e6-6df1-4694-8a89-638be7e43366



<!-- Provide screenshots or point out the additional unit tests -->
