### PR TITLE
docs: update readme based on algorithm updates

### DIFF
--- a/src/schedule-generator/README.md
+++ b/src/schedule-generator/README.md
@@ -1,6 +1,6 @@
 # schedule-generator
 
-This folder contains everything necessary to the functionality of the schedule-generation _algorithm_, for the new semesterly schedule-generation feature launching SP24.
+This folder contains everything necessary to the functionality of the schedule-generation _algorithm_, for the new semesterly schedule-generation feature launching SP24. This is for use by the components in the `src/components/ScheduleGenerate` folder.
 
 Below is a detailed file-by-file breakdown:
 
@@ -8,22 +8,42 @@ Below is a detailed file-by-file breakdown:
 
 This is essentially what is imported and used by the frontend. It takes in a request (type `GeneratorRequest`, see `generator-request.ts`) and outputs a meaningful value of type `GeneratedScheduleOutput` which can be used to see what courses fulfill what requirements and are at what times.
 
-Currently the algorithm functions by randomly shuffling potential courses the user inputted, and then generating the first valid schedule that can be constructed through iteration through this randomly shuffled list.
+Currently the algorithm functions by randomly shuffling potential courses the user inputted, and then generating the first valid schedule that can be constructed by iterating through this randomly shuffled list.
+
+Please note that the frontend generates five schedules at once, for paging through. This is done by calling the algorithm five times, but with a different random seed, as JavaScript's `Random` library uses system time. However, especially for smaller problems, this means that some generated schedules might be the same — a potential avenue for improvement down the line would be to have a somewhat more sophisticated algorithm that allows for the generation of `n` unique solutions, though `<n` might occur if `n` are not found (after some `>n` number of iterations).
+
+There are a couple of specificities that one should be aware of in relation to the algorithm's functionality:
+
+- a `Set` is used to guarantee that no course is duplicated
+  - if a user wants to take a course twice (e.g. CS 4999), they should make two separate requirement groups and add the course to each group
+- another `Set` is used to guarantee that no _requirement_ is fulfilled multiple times
+  - previously there was no cap on this, but now we guarantee that an outputted schedule has <= 1 fulfillment of each requirement
+  - if a user wants to fulfill the same requirement multiple times (e.g. take multiple liberal studies, potentially), then they should follow the procedure above of duplicating requirement groups
+
+Please note that GitHub Actions may complain about some `console.log` functions inside of `algorithm.ts`. This can be safely ignored — these `console.log`s are necessary and only called in the context of the `prettyPrintSchedule` function in a backend test.
 
 ## `course-unit.ts`
 
-A `CourseUnit` is a class that represents a single course _in a single semester and "meta-timeslot"_. Example:
+A `CourseUnit` is a class that represents a single course.
 
-Say we have one lecture L and two discussions D1 and D2. Then there would be generated:
+As shown in `testing.ts`, constructing a `CourseUnit` is somewhat involved due to all the associated frontend parameters, especially for the PDF generator. These include color, time, offered semesters, etc.
 
 ```typescript
-Course(name=L, timeslots=[LectureTimeslot, D1Timeslot], ...)
-Course(name=L, timeslots=[LectureTimeslot, D2Timeslot], ...)
+new Course(
+  L,
+  '#FFFFF',
+  3,
+  [
+    {
+      daysOfTheWeek: ['Monday', 'Wednesday'],
+      start: '10:00 AM',
+      end: '11:30 AM'
+    }
+  ],
+  ['Fall', 'Spring'],
+  [coreClass, techElective]
+);
 ```
-
-This is done to aid in the random-shuffling algorithm as well as overlap-checking mechanism (in `algorithm.ts`).
-
-A `Course` has associated with it 1-7 days of the week (hence why we need multiple `Course`s for a single class representation, as some may meet on different days — this is the easiest way to represent this).
 
 ## `generator-request.ts`
 
@@ -31,7 +51,12 @@ Just a narrow wrapper around the information you send to `algorithm.ts` for sche
 
 ## `requirement.ts`
 
-A super-simple class that just stores the "`name`" of a class, as well as the type of the requirement (e.g. "College") and its typeValue (e.g. "CS").
+A simple class that just stores the "`name`" of a class, as well as the `type` of the requirement (e.g. `"College"`) and its `typeValue` (e.g. `"CS"`).
+
+These parameters are required to:
+
+- track which requirements are being fulfilled
+- pass to the PDF downloader enough information to generate tables with requirement fulfillment information — see `src/tools/export-plan/pdf-schedule-generator.ts`
 
 ## `testing.ts`
 

--- a/src/schedule-generator/algorithm.ts
+++ b/src/schedule-generator/algorithm.ts
@@ -16,6 +16,7 @@ export default class ScheduleGenerator {
     let { creditLimit } = request;
 
     const schedule: Map<Course, Timeslot[]> = new Map();
+    // Bad naming — should update to fulfilledRequirementsByCourse, for example (due to legacy variable convention).
     const fulfilledRequirements: Map<string, Requirement[]> = new Map(); // used for checking no course duplicates
     const actualFulfilledRequirements: Set<string> = new Set(); // used for checking no requirement duplicates
 

--- a/src/schedule-generator/course-unit.ts
+++ b/src/schedule-generator/course-unit.ts
@@ -36,15 +36,6 @@ export default class Course {
   /*
   *all* of these have to be available for the course to be scheduled.
   will usually just be one, but if there is e.g. a lab or a discussion then it could be two
-  for now, just going to have multiple copies of the course.
-  
-  say we have one lecture L and two discussions D1 and D2.
-  then there would be generated:
-
-  Course(code=L, timeslots=[LectureTimeslot, D1Timeslot])
-  Course(code=L, timeslots=[LectureTimeslot, D2Timeslot])
-
-  then the algorithm will just choose one of these to schedule
   */
   timeslots: Timeslot[];
 


### PR DESCRIPTION
### Summary <!-- Required -->

Updated the documentation for the schedule generator algorithm, as it has seen some rework in the following areas:

- way that some class instances are constructed due to updates I wrote when resolving merge conflicts related to the PDF generator
- new requirement that at most one course be selected per requirement
- conceptual updates to the way in which you would overcome the point above or redo the same course multiple times — currently without the docs it is unclear how that might be accomplished

### Test Plan <!-- Required -->

No code changes — just ensure that documentation updates are clear!