### PR TITLE
chore: normalize search

### DIFF
--- a/src/components/Modals/NewCourse/CourseSelector.vue
+++ b/src/components/Modals/NewCourse/CourseSelector.vue
@@ -44,11 +44,13 @@ const getMatchingCourses = (
   } else {
     filteredCourses = filter != null ? fullCoursesArray.filter(filter) : fullCoursesArray;
   }
+  const normalizedSearchText = searchText.toUpperCase().replace(/\s+/g, '');
   for (const course of filteredCourses) {
-    const courseCode = `${course.subject} ${course.catalogNbr}`;
-    if (courseCode.toUpperCase().includes(searchText)) {
+    const courseCode = `${course.subject}${course.catalogNbr}`.toUpperCase().replace(/\s+/g, '');
+    const courseTitle = course.titleLong.toUpperCase().replace(/\s+/g, '');
+    if (courseCode.includes(normalizedSearchText)) {
       code.push(course);
-    } else if (course.titleLong.toUpperCase().includes(searchText)) {
+    } else if (courseTitle.includes(normalizedSearchText)) {
       title.push(course);
     }
   }


### PR DESCRIPTION
We now ignore whitespace (in addition to case) when searching for a new course in the course selector. You can confirm this by, on this branch, typing in e.g. `cs1110` and noticing that `CS 1110: ...` gets matched.