### PR TITLE
In schedule generator, only allow courses matching requirement to be added

### DIFF
--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -53,19 +53,26 @@ import store from '@/store';
 import {
   getRelatedRequirementIdsForCourseOptOut,
   getRelatedUnfulfilledRequirements,
+  getFilterForRequirementFulfillment,
 } from '@/requirements/requirement-frontend-utils';
 import { specificRosterCoursesArray } from '@/assets/courses/typed-full-courses';
 import { seasonAndYearToRosterIdentifier } from '../../../user-data-converter';
 
 export default defineComponent({
   props: {
-    // TODO: filter by selectedRequirement for schedule generator
-    // selectedRequirement: { type: String, required: false, default: '' },
     year: { type: Number, required: false, default: undefined },
     season: {
       type: String as PropType<FirestoreSemesterSeason>,
       required: false,
       default: undefined,
+    },
+    // An optional filter for the course selector; if set, only
+    // allows for viewing (and so selecting) courses that fulfill
+    // the given requirement.
+    filterForRequirementID: {
+      type: String as PropType<string>,
+      required: false,
+      default: '',
     },
   },
   components: { CourseSelector, TeleportModal, SelectedRequirementEditor },
@@ -100,6 +107,15 @@ export default defineComponent({
       if (this.season !== undefined && this.year !== undefined) {
         const currRoster = seasonAndYearToRosterIdentifier(this.season, this.year);
         const courses = specificRosterCoursesArray(currRoster);
+        if (this.filterForRequirementID) {
+          return courses.filter(
+            getFilterForRequirementFulfillment(
+              store.state.userRequirementsMap,
+              store.state.toggleableRequirementChoices,
+              this.filterForRequirementID
+            )
+          );
+        }
         return courses;
       }
       return undefined;

--- a/src/components/Modals/NewCourse/NewCourseModal.vue
+++ b/src/components/Modals/NewCourse/NewCourseModal.vue
@@ -66,7 +66,7 @@ export default defineComponent({
       required: false,
       default: undefined,
     },
-    // An optional filter for the course selector; if set, only
+    // An optional filter for the course selector. If set, only
     // allows for viewing (and so selecting) courses that fulfill
     // the given requirement.
     filterForRequirementID: {

--- a/src/components/ScheduleGenerate/RequirementCourses.vue
+++ b/src/components/ScheduleGenerate/RequirementCourses.vue
@@ -26,19 +26,19 @@
       </button>
     </div>
     <div v-if="showDropdown">
-      <p class="requirement-header-subtext">Please select a major requirement.</p>
+      <p class="requirement-header-subtext">Please select a major/minor requirement.</p>
       <all-requirements-dropdown
         :available-choices="availableRequirements"
         :choice="selectedRequirement.reqName"
         @on-select="selectRequirement"
       />
-      <!-- TODO: filter course showing to ones that fulfill req -->
       <new-course-modal
         @close-course-modal="closeCourseModal"
         v-if="isCourseModalOpen"
         @add-course="addCourse"
         :year="year"
         :season="season"
+        :filterForRequirementID="selectedRequirement.reqId"
       />
       <div class="requirement-courses">
         <div v-for="c in uniqueify(selectedRequirement.courses)" :key="c.crseId">


### PR DESCRIPTION
### Summary <!-- Required -->

Currently, in the schedule generator, if you select e.g. the "Mathematics" requirement you can still click add *any* school course to the "requirement block", even if it would not fulfill the Mathematics requirement. With the introduction of this PR, that issue is resolved — you can now only add courses to a requirement that actually fulfill that requirement.

### Test Plan <!-- Required -->

Go to the builder page and pick a requirement.

<img width="561" alt="image" src="https://github.com/user-attachments/assets/3eff804e-f714-4771-9d75-222435c52350">

Verify that only courses which would fulfill that requirement show up in the modal.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/7286e3c6-0def-4b76-93e2-87a0876a6bb5">

Note that this behavior does not apply for the "No Requirement" requirement block, as would be expected.

### Notes

We still have the UI oddity where you can select which requirement to match a course to if there are multiple options.

<img width="964" alt="image" src="https://github.com/user-attachments/assets/f8b9d0e2-0cea-4ea6-a68e-8747c31c24fc">

Or it could say 'not automatically fulfilling any requirement'. I think we should just get rid of this stuff in the modal as it is not relevant to schedule generator (though very relevant to the base dashboard).

Also, **please note** that the FWS example in the test plan will not show you any FWSes if you type in 'FWS'. This is because the migration script for this semester hasn't seemed to have actually found / counted FWS courses. If you look at [the Fall 24 brochure](https://fws.arts.cornell.edu/brochures/2024FA_Brochure.pdf), you'll notice that the FA24 specific courses (ones that don't happen in other semesters) do not show up in any new course modals. This is not an issue with this PR but rather with our typed course JSON consistency.
