### PR TITLE
potential save course fix

### DIFF
--- a/src/components/Modals/SaveCourseModal.vue
+++ b/src/components/Modals/SaveCourseModal.vue
@@ -162,6 +162,11 @@ export default defineComponent({
         collection => !this.checkedCollections.includes(collection)
       );
 
+      // If no specific collections were selected, and no prevoius selections were removed, add to 'All'
+      if (addedToCollections.length === 0 && deletedFromCollections.length === 0) {
+        console.log('added to All');
+        addedToCollections.push('All');
+      }
       this.$emit('save-course', addedToCollections, deletedFromCollections);
 
       this.closeCurrentModal();

--- a/src/global-firestore-data/user-semesters.ts
+++ b/src/global-firestore-data/user-semesters.ts
@@ -52,21 +52,23 @@ export const setOrderByNewest = (orderByNewest: boolean): void => {
 };
 
 /**
- * Updates the 'All'/Default Collection with all unique courses from all collections.
- *
+ * Updates the 'All'/Default Collection with courses based on the following logic:
+ * - Add unique courses from specific collections to the default collection.
+ * - If a course is removed from the default collection, it is removed from all specific collections.
+ * Note: Does not remove a course form the default collection if that course is removed in all specfic collections.
  */
 export const editDefaultCollection = (): void => {
   const allCollections = store.state.savedCourses;
   const defaultCollectionName = 'All';
 
-  const uniqueCourses = new Set<FirestoreSemesterCourse>();
+  const uniqueCoursesMap = new Map<string, FirestoreSemesterCourse>();
   allCollections.forEach(collection => {
-    if (collection.name !== defaultCollectionName) {
-      collection.courses.forEach(course => {
-        uniqueCourses.add(course);
-      });
-    }
+    collection.courses.forEach(course => {
+      uniqueCoursesMap.set(course.name, course);
+    });
   });
+
+  const uniqueCourses = new Set<FirestoreSemesterCourse>(uniqueCoursesMap.values());
 
   editCollection(defaultCollectionName, oldCollection => ({
     ...oldCollection,

--- a/src/store.ts
+++ b/src/store.ts
@@ -346,7 +346,7 @@ export const initializeFirestoreListeners = (onLoad: () => void): (() => void) =
       const plan = getFirstPlan(data);
       store.commit('setPlans', data.plans);
       store.commit('setCurrentPlan', plan);
-      store.commit('setSavedCourses', data.savedCourses); // Note: toggle this on and off to save collections progress after refresh
+      store.commit('setSavedCourses', data.savedCourses); 
       const { orderByNewest } = data;
       store.commit('setSemesters', plan.semesters);
       updateDoc(doc(fb.semestersCollection, simplifiedUser.email), {
@@ -357,7 +357,7 @@ export const initializeFirestoreListeners = (onLoad: () => void): (() => void) =
       store.commit('setOrderByNewest', orderByNewest === undefined ? true : orderByNewest);
     } else {
       const plans = [{ name: 'Plan 1', semesters: [] }];
-      const savedCourses = [{ name: 'All', courses: [] }]; // Warning: Every retruning user needs this Collection too
+      const savedCourses = [{ name: 'All', courses: [] }]; 
       store.commit('setPlans', plans);
       store.commit('setCurrentPlan', plans[0]);
       store.commit('setSavedCourses', savedCourses);


### PR DESCRIPTION


### Summary <!-- Required -->
- default collection functionality changed
- courses in default collection can only be removed by specifically removing that course from the default collection

This pull request is the first step potentially fixing save Courses default collection functionality 

### Test Plan <!-- Required -->
- If no specific collection is chosen, then a course is only saved to the 'All/default collection'
- If a course is deleted from 'All/default collection', then every instance of that course is deleted from the specific collections
- *Note:* if a course is removed from any instance from the specific collections, that course will still remain in the 'All/default collection`
- There should never be any duplicate courses in a particular collection.

### Notes <!-- Optional -->
May not change the functionality based on future user reviews
### Blockers <!-- Optional -->

<!--- Note and itemize any blockers (especially for WIP PRs) here and on Notion -->

- A newly discovered dependency that hasn’t been addressed

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->

- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)
