### PR TITLE
feat: migration for new cs major requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Access CoursePlan at [courseplan.io](https://courseplan.io)!
 
-CoursePlan is a four-year academic planner for Cornell undergraduates developed by the Digital Tech & Innovation. CoursePlan helps undergraduates track their courses and their requirements automatically depending on their college, major, and minor. It aims to allow students view the big picture of their time at Cornell.
+CoursePlan is a four-year academic planner for Cornell undergraduates developed by the Digital Tech & Innovation project team. CoursePlan helps undergraduates track their courses and their requirements automatically depending on their college, major, and minor. It aims to allow students view the big picture of their time at Cornell.
 
 View documentation in our [wiki](https://github.com/cornell-dti/course-plan/wiki).
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -21,7 +21,7 @@ import chemERequirements, { chemEAdvisors } from './majors/chemE';
 import civilRequirements, { civilAdvisors } from './majors/ce';
 import commRequirements, { commAdvisors } from './majors/comm';
 import crpRequirements, { crpAdvisors } from './majors/crp';
-import csRequirements, { csAdvisors } from './majors/cs';
+import csRequirements, { csAdvisors, csMigrations } from './majors/cs';
 import deaRequirements, { deaAdvisors } from './majors/dea';
 import easRequirements, { easAdvisors } from './majors/eas';
 import economicsRequirements, { economicsAdvisors } from './majors/econ';
@@ -239,6 +239,7 @@ const json: RequirementsJson = {
       requirements: csRequirements,
       specializations: [MATH2940, CHEM2080],
       advisors: csAdvisors,
+      migrations: csMigrations,
       abbrev: 'CS',
     },
     DEA: {

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -25,7 +25,7 @@ export type typeOfMigration = 'Modify' | 'Delete' | 'Add';
 
 export type RequirementMigration = {
   entryYear: number /** This migration applies to students with an entryYear equal to or EARLIER this entry year */;
-  type: typeOfMigration /** Modify or Delete Migration? This field must already exist in requirements file */;
+  type: typeOfMigration /** Modify, Delete, or Add Migration? This field must already exist in requirements file */;
   fieldName: string;
   newValue?: CollegeOrMajorRequirement /** Required for modify and add migrations */;
 };


### PR DESCRIPTION
### Summary <!-- Required -->

Computer Science majors who enter Cornell in Fall 2024 have different requirements compared to those who entered Cornell before that: CS 3700 or CS 3780 is now a required course, there are only two required CS electives, and there is no Probability requirement.

This PR implements migrations in the CS major file to reflect these differences for future CS majors who entered Cornell in Fall 2024.

Supersedes #939 because of weird fork prevention check