### PR TITLE
Notes  giveaway modal

### DIFF
--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -180,7 +180,8 @@ export default defineComponent({
     'open-delete-note-modal': (uniqueID: number) => typeof uniqueID === 'number',
     'note-state-change': (uniqueID: number, isExpanded: boolean) =>
       typeof uniqueID === 'number' && typeof isExpanded === 'boolean',
-    'new-note-created': (uniqueID: number) => typeof uniqueID === 'number',
+    'new-note-created': (uniqueID: number, isNewNote: boolean) =>
+      typeof uniqueID === 'number' && typeof isNewNote === 'boolean',
   },
   data() {
     return {
@@ -302,10 +303,6 @@ export default defineComponent({
       if (now < deadline) {
         updateFA25GiveawayField({ step2: true });
       }
-      if (!this.isNoteVisible && !this.courseObj.note) {
-        // creation of a new note (regardless if it's saved or not)
-        this.$emit('new-note-created', this.courseObj.uniqueID);
-      }
       if (!this.isNoteVisible) {
         this.isNoteVisible = true;
         this.menuOpen = false;
@@ -315,6 +312,7 @@ export default defineComponent({
         this.$nextTick(() => {
           const noteComponent = this.$refs.note as MinimalNoteComponent | undefined;
           if (noteComponent) {
+            this.$emit('new-note-created', this.courseObj.uniqueID, true); // toggles new note to true
             noteComponent.expandNote();
           }
         });
@@ -350,6 +348,7 @@ export default defineComponent({
         return;
       }
       this.$emit('save-note', this.courseObj.uniqueID, note);
+      this.$emit('new-note-created', this.courseObj.uniqueID, false); // toggles new note back to undefined
     },
     handleClickOutsideNote(event: MouseEvent) {
       // Don't count a click on the open note (.courseMenu) or three dots (.course-dotRow)
@@ -369,10 +368,11 @@ export default defineComponent({
         // Warn if the user is trying to leave a note with unsaved changes.
         this.triggerCourseCardShake();
       } else if (noteComponent.note && this.isNoteVisible) {
+        this.$emit('new-note-created', this.courseObj.uniqueID, false); // toggles new note back to undefined
         noteComponent.collapseNote();
       } else {
         // this is a new note that hasn't been saved yet, and it gets cancelled
-        this.$emit('new-note-created', this.courseObj.uniqueID);
+        this.$emit('new-note-created', this.courseObj.uniqueID, false); // toggles new note back to undefined
         this.closeNote();
       }
     },
@@ -381,6 +381,9 @@ export default defineComponent({
     },
     handleNoteStateChange(isExpanded: boolean) {
       this.$emit('note-state-change', this.courseObj.uniqueID, isExpanded);
+    },
+    handleNewNote(isNewNote: boolean) {
+      this.$emit('new-note-created', this.courseObj.uniqueID, isNewNote);
     },
   },
   directives: {

--- a/src/components/Course/Course.vue
+++ b/src/components/Course/Course.vue
@@ -368,7 +368,6 @@ export default defineComponent({
         // Warn if the user is trying to leave a note with unsaved changes.
         this.triggerCourseCardShake();
       } else if (noteComponent.note && this.isNoteVisible) {
-        this.$emit('new-note-created', this.courseObj.uniqueID, false); // toggles new note back to undefined
         noteComponent.collapseNote();
       } else {
         // this is a new note that hasn't been saved yet, and it gets cancelled

--- a/src/components/Semester/Semester.vue
+++ b/src/components/Semester/Semester.vue
@@ -123,7 +123,7 @@
                 @edit-collection="editCollection"
                 @open-delete-note-modal="openDeleteNoteModal"
                 @note-state-change="handleNoteStateChange"
-                @new-note-update="handleNewNoteCreated"
+                @new-note-created="handleNewNoteCreated"
               />
               <placeholder
                 v-else
@@ -543,8 +543,8 @@ export default defineComponent({
       );
       this.closeDeleteNoteModal();
     },
-    handleNewNoteCreated(uniqueID: number) {
-      if (this.newNoteUniqueID === undefined) {
+    handleNewNoteCreated(uniqueID: number, isNewNote: boolean) {
+      if (isNewNote === true) {
         this.newNoteUniqueID = uniqueID;
       } else {
         this.newNoteUniqueID = undefined;


### PR DESCRIPTION
### Summary <!-- Required -->
Made a new PR bc i broke the other one 😅 
Fixed the bug where the semesterview box doesn't shift when one newly added a note without saving.
![image](https://github.com/user-attachments/assets/98f178fb-27b6-4bfd-9f79-680db075f927)


This pull request is notes frontend fix for giveaway modal.


<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] resolve bug 1
- [ ] implement Z

<!--- Note dependencies on other PRs if any. -->

Depends on #{number of PR}


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Blockers <!-- Optional -->

<!--- Note and itemize any blockers (especially for WIP PRs) here and on Notion -->

- A newly discovered dependency that hasn’t been addressed

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->

- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)
