### PR TITLE
feat: migration for new engineering liberal studies requirement

### DIFF
--- a/src/data/colleges/en.ts
+++ b/src/data/colleges/en.ts
@@ -323,7 +323,7 @@ export const engineeringAdvisors: AdvisorGroup = {
   source: 'https://www.engineering.cornell.edu/students/undergraduate-students/advising/meet-staff',
 };
 
-export const engMigrations: RequirementMigration[] = [
+export const engineeringMigrations: RequirementMigration[] = [
   {
     entryYear: 2023,
     type: 'Modify',

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -5,7 +5,7 @@ import aapRequirements, { aapAdvisors } from './colleges/ar';
 import casPreFA2020Requirements from './colleges/asPreFA2020';
 import casFA2020Requirements, { casAdvisors } from './colleges/asFA2020';
 import businessRequirements, { businessAdvisors } from './colleges/bu';
-import engineeringRequirements, { engineeringAdvisors } from './colleges/en';
+import engineeringRequirements, { engineeringAdvisors, engineeringMigrations } from './colleges/en';
 import humanEcologyRequirements, { humanEcologyAdvisors } from './colleges/he';
 import ilrRequirements, { ilrAdvisors } from './colleges/il';
 import aemRequirements, { aemAdvisors } from './majors/aem';
@@ -120,6 +120,7 @@ const json: RequirementsJson = {
       name: 'Engineering (ENG)',
       requirements: engineeringRequirements,
       advisors: engineeringAdvisors,
+      migrations: engineeringMigrations,
       abbrev: 'CoE',
     },
     HE: {

--- a/src/requirements/requirement-json-generator.ts
+++ b/src/requirements/requirement-json-generator.ts
@@ -327,6 +327,7 @@ const generateDecoratedRequirementsJson = (): DecoratedRequirementsJson => {
       [key: string]: {
         readonly name: string;
         readonly requirements: readonly DecoratedCollegeOrMajorRequirement[];
+        readonly migrations?: RequirementMigration[];
       };
     };
     major: MutableMajorRequirements<DecoratedCollegeOrMajorRequirement>;
@@ -368,10 +369,13 @@ const generateDecoratedRequirementsJson = (): DecoratedRequirementsJson => {
     };
   });
   Object.entries(college).forEach(([collegeName, collegeRequirement]) => {
-    const { requirements, advisors, abbrev: abbr, ...rest } = collegeRequirement;
+    const { requirements, migrations, advisors, abbrev: abbr, ...rest } = collegeRequirement;
     decoratedJson.college[collegeName] = {
       ...rest,
       requirements: decorateRequirements(requirements),
+      migrations: migrations
+        ? (decorateMigrations(migrations) as RequirementMigration[])
+        : undefined,
     };
   });
   Object.entries(major).forEach(([majorName, majorRequirement]) => {

--- a/src/requirements/types.ts
+++ b/src/requirements/types.ts
@@ -17,6 +17,7 @@ export type CollegeRequirements<R> = {
     readonly name: string;
     readonly requirements: readonly R[];
     readonly advisors?: AdvisorGroup;
+    readonly migrations?: RequirementMigration[];
     readonly abbrev?: string;
   };
 };


### PR DESCRIPTION
This pull request implements the revamped engineering liberal studies requirement for engineers entering Fall 2024 and later. To do this, I had to implement requirement migrations for college requirements (thanks @nidhi-mylavarapu!)

[engineering.cornell.edu/students/undergraduate-students/advising/liberal-studies/liberal-studies-requirements-students](https://www.engineering.cornell.edu/students/undergraduate-students/advising/liberal-studies/liberal-studies-requirements-students)

Supersedes #1004, #1005