### PR TITLE
Artificial Intelligence Minor

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -52,6 +52,7 @@ import stsRequirements, { stsAdvisors } from './majors/sts';
 import vienRequirements, { vienAdvisors } from './majors/vien';
 import aerospaceMinorRequirements, { aerospaceMinorAdvisors } from './minors/aerospace';
 import animalSciRequirements, { animalSciAdvisors } from './minors/animal-sci';
+import aiMinorRequirements, { aiMinorAdvisors } from './minors/artificial-intelligence';
 import appliedMathMinorRequirements, { appliedMathMinorAdvisors } from './minors/applied-math';
 import buMinorRequirements, { buMinorAdvisors } from './minors/bu';
 import cogsciMinorRequirements, { cogsciMinorAdvisors } from './minors/cogsci';
@@ -462,6 +463,13 @@ const json: RequirementsJson = {
       requirements: animalSciRequirements,
       advisors: animalSciAdvisors,
       abbrev: 'AnimalSci',
+    },
+    AI: {
+      name: 'Artificial Intelligence',
+      schools: ['AS1', 'AS2'],
+      requirements: aiMinorRequirements,
+      advisors: aiMinorAdvisors,
+      abbrev: 'AI',
     },
     APPLIEDECON: {
       name: 'Applied Economics',

--- a/src/data/minors/artificial-intelligence.ts
+++ b/src/data/minors/artificial-intelligence.ts
@@ -1,0 +1,72 @@
+import { CollegeOrMajorRequirement, Course } from '../../requirements/types';
+import {
+  includesWithSingleRequirement,
+  includesWithSubRequirements,
+  courseMatchesCodeOptions,
+  courseMatchesCode,
+  ifCodeMatch,
+} from '../../requirements/checkers';
+import { AdvisorGroup } from '../../tools/advisors/types';
+
+const aiMinorRequirements: readonly CollegeOrMajorRequirement[] = [
+  {
+    name: 'Foundations of AI Core Courses',
+    description:
+      'Four required core courses covering computational AI methods, human-AI systems, and AI ethics',
+    source: 'https://www.cs.cornell.edu/undergrad/aiminor',
+    checker: includesWithSubRequirements(
+      ['CS 4780', 'CS 4786', 'CS 4740'],
+      ['CS 4700', 'CS 4701', 'CS 4720'],
+      ['INFO 3450', 'INFO 4450', 'CS 4450'],
+      ['GOVT 2049', 'INFO 2040', 'STS 2040']
+    ),
+    fulfilledBy: 'courses',
+    perSlotMinCount: [1, 1, 1, 1],
+    slotNames: [
+      'Machine Learning Course',
+      'AI/Reasoning Course',
+      'Human-AI Systems Course',
+      'AI Ethics Course',
+    ],
+    allowCourseDoubleCounting: true,
+  },
+  {
+    name: 'AI Elective Courses',
+    description: 'Two AI elective courses from approved list',
+    source: 'https://www.cs.cornell.edu/undergrad/aiminor',
+    checker: [
+      (course: Course): boolean =>
+        courseMatchesCodeOptions(course, [
+          'CS 4750',
+          'CS 4670',
+          'CS 4780',
+          'CS 4786',
+          'CS 4700',
+          'CS 4701',
+          'CS 4720',
+          'CS 4740',
+          'CS 4758',
+          'CS 4820',
+          'CS 4850',
+          'INFO 3450',
+          'INFO 4450',
+          'INFO 2040',
+          'GOVT 2049',
+          'STS 2040',
+          'ORIE 4740',
+          'MATH 4710',
+          'MATH 4740',
+        ]),
+    ],
+    fulfilledBy: 'courses',
+    perSlotMinCount: [2],
+    slotNames: ['AI Elective Course'],
+    allowCourseDoubleCounting: true,
+  },
+];
+
+export default aiMinorRequirements;
+
+export const aiMinorAdvisors: AdvisorGroup = {
+  advisors: [{ name: 'Computer Science Department', email: 'cs-undergrad@cornell.edu' }],
+};


### PR DESCRIPTION
- Add AI minor requirements with core courses and electives
- Include machine learning, AI reasoning, human-AI systems, and ethics courses
- Available to AS1 and AS2 colleges (Arts & Sciences)
- Regenerate decorated-requirements.json to include new minor